### PR TITLE
Security hardening pass: untrusted mod-file input, CI least-privilege, O(F^2) fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,11 +4,15 @@ on:
   push:
     tags: ['v*']
 
+# Least privilege: read by default. Only the release job that publishes needs
+# write. The build job runs arbitrary project build code, so it stays read-only.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
+    permissions:
+      contents: read
     strategy:
       matrix:
         include:
@@ -23,9 +27,9 @@ jobs:
             display_name: Linux
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 
@@ -44,7 +48,7 @@ jobs:
         run: chmod +x "${{ matrix.artifact_name }}"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ matrix.artifact_name }}
           path: ${{ matrix.artifact_name }}
@@ -52,14 +56,16 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: artifacts
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{ github.ref_name }}
           name: HOI4 Content Maker ${{ github.ref_name }}

--- a/hoi4_content_maker.py
+++ b/hoi4_content_maker.py
@@ -75,6 +75,7 @@ from hoi4cm.core import (
     EmptyFocusTreeError,
     Focus,
     add_error,
+    bounded_inflate,
     build_focuses,
     default_hoi4_mod_dir,
     dict_to_raw,
@@ -84,6 +85,8 @@ from hoi4cm.core import (
     get_language,
     install_excepthook,
     parse_focus_tree,
+    safe_fromstring,
+    sanitize_component,
     set_error_callback,
     set_language,
     show_splash,
@@ -4956,7 +4959,6 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):
         import base64
         import urllib.parse
         import xml.etree.ElementTree as ET
-        import zlib
 
         # ── Step 1: File picker ───────────────────────────────────────
         path = filedialog.askopenfilename(
@@ -4970,6 +4972,10 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):
             return
 
         try:
+            # Untrusted file: cap the raw read so a giant .drawio can't
+            # exhaust memory before parsing.
+            if os.path.getsize(path) > 64 * 1024 * 1024:
+                raise ValueError("file exceeds 64 MB")
             with open(path, encoding="utf-8", errors="replace") as fp:
                 raw_file = fp.read()
         except Exception as e:
@@ -4982,12 +4988,14 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):
             return
 
         # ── Step 2: Parse XML ─────────────────────────────────────────
+        # bounded_inflate / safe_fromstring guard against decompression bombs
+        # and XML entity-expansion (billion laughs) in shared .drawio files.
         def decompress_drawio(b64str):
             data = base64.b64decode(b64str)
-            return urllib.parse.unquote(zlib.decompress(data, -15).decode("utf-8"))
+            return urllib.parse.unquote(bounded_inflate(data).decode("utf-8"))
 
         def get_graph_root(xml_str):
-            root = ET.fromstring(xml_str)
+            root = safe_fromstring(xml_str)
             if root.tag == "mxGraphModel":
                 return root
             for diag in root.iter("diagram"):
@@ -4995,18 +5003,18 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):
                 if not text:
                     return diag
                 try:
-                    return ET.fromstring(decompress_drawio(text))
+                    return safe_fromstring(decompress_drawio(text))
                 except Exception:
                     pass
                 try:
-                    return ET.fromstring(text)
+                    return safe_fromstring(text)
                 except Exception:
                     pass
             return root
 
         try:
             graph_root = get_graph_root(raw_file)
-        except ET.ParseError as e:
+        except (ET.ParseError, ValueError) as e:
             messagebox.showerror(
                 tr("dialog.drawio_import.title", "Draw.io Import"),
                 tr(
@@ -8669,9 +8677,10 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):
         nf.id = id(nf)
         # Generate new unique name
         base = re.sub(r"_copy\d*$", "", f.name) + "_copy"
+        existing_names = {foc.name for foc in self.focuses.values()}
         n = 1
         candidate = base
-        while candidate in {foc.name for foc in self.focuses.values()}:
+        while candidate in existing_names:
             candidate = f"{base}{n}"
             n += 1
         nf.name = candidate
@@ -9024,7 +9033,9 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):
             if tag_match
             else getattr(self, "_tree_country_tag", "TAG")
         )
-        country_tag = country_tag.upper()
+        # Sanitize: the fallback tag comes from parsed (untrusted) mod content
+        # and is used to build the loc filename below.
+        country_tag = sanitize_component(country_tag.upper(), fallback="TAG")
 
         out = []
         out.append("focus_tree = {")

--- a/specs/security-hardening.md
+++ b/specs/security-hardening.md
@@ -1,0 +1,160 @@
+# Security hardening pass
+
+Date: 2026-07-02. Branch: `chore/security-review-and-hardening`.
+
+## Why
+
+The app opens Hearts of Iron IV mod files (`.txt`, `.yml`, `.gfx`, `.drawio`) that
+users download and share. Those files are untrusted input. This pass audited the
+whole app for ways a booby-trapped mod (or diagram) could harm the person who
+opens it, closed the real gaps, and fixed two algorithmic slow paths found along
+the way. All new logic lives in `src/hoi4cm/core/`, keeping with the "don't grow
+the monolith" rule. Each helper ships with a test.
+
+## What the audit found clean
+
+No code execution, command injection, network exfiltration, or ReDoS. The app is
+stdlib + tkinter only, uses no `eval`/`exec`/`pickle`/`yaml.load`, makes no
+outbound network calls, and its parsers walk brace depth character by character
+rather than with backtracking regex. Config, logger, and the SQLite scan cache
+were clean. So the work below is about bounding untrusted input, not plugging an
+active exploit.
+
+## Security fixes
+
+### Path traversal via unsanitized IDs and tags
+
+Output filenames were built straight from IDs and tags, some of which come from
+parsed (untrusted) mod content. A value like `../../evil` could escape the
+intended folder. The clearest case: the focus-tree exporter builds
+`MD_focus_{country_tag}_l_english.yml` where `country_tag` falls back to a tag
+parsed from the imported file with only `.upper().strip()`.
+
+Fix: new `src/hoi4cm/core/safe_path.py`.
+
+- `sanitize_component(name, fallback="unnamed")` reduces a value to a single safe
+  path segment. Drops any directory prefix, whitelists `[A-Za-z0-9_.-]`, and
+  rejects `""`/`.`/`..`. Valid HOI4 IDs (already `[A-Za-z0-9_]`) pass through
+  unchanged, so nothing legitimate breaks.
+- `safe_join(base, *parts)` joins and then confirms the resolved path stays inside
+  `base` (via `realpath` + `commonpath`), raising `ValueError` on escape. Available
+  for defense in depth.
+
+Wired into the focus-tree loc export (`hoi4_content_maker.py`) and every wizard
+that turns an ID into a filename: `national_spirit.py` (`sid`), `decision.py`
+(`ns` from `cat_id`), `event.py` (`ns` from `eid`), `additional_income.py`
+(`idea_id`), `dyn_mod.py` (`mid`).
+
+### Draw.io import: decompression bomb + XML entity expansion
+
+`_import_drawio` inflated the embedded, zlib-compressed XML of a `.drawio` file
+with no size cap, then parsed it with stock `ElementTree`. A tiny file could
+inflate to gigabytes (memory exhaustion), and a DTD with nested entities could
+blow up parsing (billion laughs).
+
+Fix: new `src/hoi4cm/core/safe_xml.py`.
+
+- `bounded_inflate(data, ...)` inflates with a 64 MB cap and raises `ValueError`
+  past it.
+- `safe_fromstring(xml_str, ...)` rejects oversize input and refuses any
+  `<!DOCTYPE`/`<!ENTITY` markup before parsing, which blocks entity expansion.
+  (Modern `ElementTree` no longer exposes its expat handlers across Python
+  versions, so the check scans the markup directly. Both tokens are case-sensitive
+  per the XML spec and only appear as literal markup, so the substring check is
+  reliable. Legit Draw.io files never declare a DTD.)
+
+The importer also caps the raw file read at 64 MB before parsing. Both caps sit
+far above any real diagram.
+
+### `read_file` had no size cap
+
+`src/hoi4cm/core/paths.py:read_file` read whole files into memory and is fanned
+across up to 8 threads during a mod scan. A huge file, or a symlink to
+`/dev/zero`, could exhaust memory. Added a `max_bytes` cap (default 32 MB,
+generous for mod files) that checks size first and bounds the read itself, so a
+streaming pseudo-file is caught too. Oversize files are skipped and logged. The
+new argument defaults on, so existing callers are unaffected.
+
+### Config write is now atomic
+
+`cfg_save` truncated then rewrote `~/.hoi4_focus_maker.json`, so a crash or full
+disk mid-write left a corrupt config. It now writes a temp file in the same
+directory, `fsync`s, and `os.replace`s it into place (atomic), cleaning up the
+temp file on failure. The file is also `chmod`ed to `0600`.
+
+### Pillow auto-install is now opt-in
+
+On first launch without Pillow, `image.py` silently ran `pip install Pillow` at
+import time. That is an unexpected network install and a supply-chain surface.
+It now only runs if `HOI4CM_AUTO_INSTALL_PILLOW` is set; otherwise it logs a
+one-line hint and falls back to placeholder icons (the existing no-Pillow path).
+Frozen binaries never install.
+
+### Wizard autosave moved out of /tmp
+
+Four wizards autosaved working state to fixed-name files in the shared temp dir
+(`/tmp/hoi4_cm_*_autosave.json`). On a multi-user host another user could
+pre-plant those paths as symlinks and clobber a file the victim can write. New
+`paths.autosave_path(name)` puts autosaves under `~/.hoi4cm/autosave/` (created
+user-only, `0700`). Old `/tmp` autosaves simply won't be found on next open,
+which is fine for best-effort recovery.
+
+## CI / supply chain (`.github/workflows/release.yml`)
+
+- Least privilege. The workflow granted `contents: write` to every job, including
+  `build`, which runs arbitrary project build code across three runners. Now the
+  default is `contents: read`, `build` is explicitly read-only, and only the
+  `release` job that publishes gets `contents: write`.
+- Actions pinned to commit SHAs (with a version comment) instead of mutable tags,
+  so a re-pointed or compromised tag can't inject code into the release. Same
+  major versions as before, latest patch: checkout v4.3.1, setup-python v5.6.0,
+  upload-artifact v4.6.2, download-artifact v4.3.0, action-gh-release v2.6.2.
+
+## Performance
+
+The app was already well optimized (dirty-key canvas redraws, SQLite scan cache,
+parallel reads). Two real algorithmic slow paths fixed:
+
+- Focus-tree export resolved `relative_position_id` by scanning all focuses per
+  focus, O(F^2) on large trees. Now builds a name to focus map once, O(F).
+  (`src/hoi4cm/focus_tree/export.py`)
+- The duplicate-focus name loop rebuilt the set of existing names on every
+  iteration. Built once before the loop. (`hoi4_content_maker.py`)
+
+Assessed and left alone: the collision checks in the focus-apply handlers run
+once per user click, not per frame, so their O(F) scan is negligible. The
+left-panel focus-list rebuild is the biggest per-action UI cost, but it is only
+called when the list content actually changed (selection-only updates already use
+a cheaper path), and the only real win is widget diffing, a risky rewrite that
+would grow the monolith. Left as a documented follow-up.
+
+## Residual risk (not fixed here)
+
+- The build resolves `pyinstaller`/`Pillow` from PyPI with open lower bounds and
+  no hashes. Released binaries are unsigned and shipped without checksums. Both
+  are release-pipeline changes deferred to avoid churn on that path.
+- Log files and the config are written with the default umask apart from the
+  config's `0600`. They hold only local paths, not secrets.
+
+## New helper API
+
+| Function | Module | Purpose |
+|---|---|---|
+| `sanitize_component(name, fallback)` | `core.safe_path` | ID/tag to one safe path segment |
+| `safe_join(base, *parts)` | `core.safe_path` | join and verify inside `base` |
+| `bounded_inflate(data, ...)` | `core.safe_xml` | inflate with size cap |
+| `safe_fromstring(xml_str, ...)` | `core.safe_xml` | parse XML, reject DTD/oversize |
+| `read_file(path, max_bytes=...)` | `core.paths` | tolerant read with size cap |
+| `autosave_path(name)` | `core.paths` | per-user autosave path under `~/.hoi4cm` |
+
+All are re-exported from `hoi4cm.core`.
+
+## Verification
+
+- `pytest` (146 passing, adds `test_safe_path.py`, `test_safe_xml.py`,
+  `test_image.py`, plus config/paths extensions).
+- `ruff check .` and `black --check .` clean on `src/` and `tests/`.
+- Manual: a >64 MB-inflating payload raises; a billion-laughs DOCTYPE is rejected;
+  a real `.drawio` still imports; `read_file` on a >32 MB file returns empty and
+  logs; sanitizer maps traversal payloads to a single safe segment and leaves
+  valid IDs unchanged.

--- a/src/hoi4cm/core/__init__.py
+++ b/src/hoi4cm/core/__init__.py
@@ -46,7 +46,9 @@ from .logger import (
     log_startup,
     set_error_callback,
 )
-from .paths import default_hoi4_mod_dir, read_file
+from .paths import autosave_path, default_hoi4_mod_dir, read_file
+from .safe_path import safe_join, sanitize_component
+from .safe_xml import bounded_inflate, safe_fromstring
 
 __all__ = [
     "CONFIG_PATH",
@@ -65,6 +67,8 @@ __all__ = [
     "ParsedFocusTree",
     "add_error",
     "append_scripted_loc",
+    "autosave_path",
+    "bounded_inflate",
     "build_focuses",
     "cfg_load",
     "cfg_save",
@@ -84,6 +88,9 @@ __all__ = [
     "normalize_effect_fields",
     "parse_focus_tree",
     "read_file",
+    "safe_join",
+    "safe_fromstring",
+    "sanitize_component",
     "set_error_callback",
     "set_language",
     "show_splash",

--- a/src/hoi4cm/core/config.py
+++ b/src/hoi4cm/core/config.py
@@ -24,11 +24,26 @@ def cfg_load():
 
 
 def cfg_save(data):
-    """Merge data into existing config and write to disk."""
+    """Merge data into existing config and write it atomically."""
     try:
         existing = cfg_load()
         existing.update(data)
-        with open(CONFIG_PATH, "w", encoding="utf-8") as f:
-            json.dump(existing, f, indent=2)
+        tmp = CONFIG_PATH + ".tmp"
+        try:
+            with open(tmp, "w", encoding="utf-8") as f:
+                json.dump(existing, f, indent=2)
+                f.flush()
+                os.fsync(f.fileno())
+            try:
+                os.chmod(tmp, 0o600)
+            except OSError:
+                pass
+            os.replace(tmp, CONFIG_PATH)
+        except Exception:
+            try:
+                os.remove(tmp)
+            except OSError:
+                pass
+            raise
     except Exception as e:
         _log.error(f"save failed: {e}")

--- a/src/hoi4cm/core/image.py
+++ b/src/hoi4cm/core/image.py
@@ -1,14 +1,16 @@
 """Pillow import helper.
 
-Tries to import Pillow; if missing and not running from a frozen bundle,
-attempts a one-shot ``pip install Pillow`` so the user's first launch works
-without a manual install step. In a frozen (PyInstaller) binary the install
-is skipped and the wizards fall back to placeholder text.
+Tries to import Pillow. If it is missing, the wizards fall back to placeholder
+text; the app does not shell out to ``pip`` unless the user opts in by setting
+``HOI4CM_AUTO_INSTALL_PILLOW`` (a network install at import time is a supply-
+chain surface, so it is off by default). Frozen (PyInstaller) binaries never
+attempt an install.
 
 Exposes :data:`PIL_OK`, :data:`PILImage`, :data:`PILImageTk` for code that
 wants to check availability before calling Pillow.
 """
 
+import os
 import subprocess
 import sys
 
@@ -42,6 +44,11 @@ def _import_pillow():
         pass
     if getattr(sys, "frozen", False):
         _log.warning("Pillow not available in frozen binary — image previews disabled")
+        return None, None, False
+    if not os.environ.get("HOI4CM_AUTO_INSTALL_PILLOW"):
+        _log.info(
+            "Pillow not installed — run `pip install Pillow` to enable image previews"
+        )
         return None, None, False
     if not _try_install_pillow():
         return None, None, False

--- a/src/hoi4cm/core/paths.py
+++ b/src/hoi4cm/core/paths.py
@@ -3,6 +3,12 @@
 import os
 import sys
 
+from .logger import get_logger
+
+_log = get_logger("paths")
+
+MAX_READ_BYTES = 32 * 1024 * 1024
+
 
 def default_hoi4_mod_dir():
     base = os.path.join("Paradox Interactive", "Hearts of Iron IV", "mod")
@@ -15,11 +21,45 @@ def default_hoi4_mod_dir():
     return os.path.join(os.path.expanduser("~"), "Documents", base)
 
 
-def read_file(path):
+def read_file(path, max_bytes=MAX_READ_BYTES):
+    """Read *path* as text, trying several encodings. Returns "" if unreadable.
+
+    Files larger than *max_bytes* (or streaming pseudo-files like ``/dev/zero``)
+    are skipped and logged rather than read into memory. Pass ``max_bytes=None``
+    to disable the cap.
+    """
+    try:
+        size = os.path.getsize(path)
+    except OSError:
+        size = None
+    if max_bytes is not None and size is not None and size > max_bytes:
+        _log.warning("skipping oversize file (%d bytes): %s", size, path)
+        return ""
     for enc in ("utf-8-sig", "utf-8", "latin-1"):
         try:
             with open(path, encoding=enc, errors="replace") as f:
-                return f.read()
+                if max_bytes is None:
+                    return f.read()
+                data = f.read(max_bytes + 1)
+                if len(data) > max_bytes:
+                    _log.warning("skipping oversize/streaming file: %s", path)
+                    return ""
+                return data
         except Exception:
             pass
     return ""
+
+
+def autosave_path(name):
+    """Return a per-user autosave path under ``~/.hoi4cm/autosave/``.
+
+    Replaces the world-writable, fixed-name ``/tmp`` files the wizards used to
+    autosave into (a local symlink-clobber vector on shared hosts). Creates the
+    directory user-only if missing.
+    """
+    d = os.path.join(os.path.expanduser("~"), ".hoi4cm", "autosave")
+    try:
+        os.makedirs(d, mode=0o700, exist_ok=True)
+    except OSError:
+        pass
+    return os.path.join(d, name)

--- a/src/hoi4cm/core/safe_path.py
+++ b/src/hoi4cm/core/safe_path.py
@@ -1,0 +1,46 @@
+"""Path-safety helpers for untrusted filename components.
+
+Mod files (focus trees, decisions, events, ...) are downloaded and shared, so
+IDs and tags parsed out of them are untrusted. When such a value becomes part
+of an output filename it must not be able to escape the target folder with a
+``..`` segment or a path separator. Sanitize the component first, or use
+``safe_join`` to verify the final path stays inside the intended base.
+"""
+
+import os
+import re
+
+_UNSAFE = re.compile(r"[^A-Za-z0-9_.-]")
+
+
+def sanitize_component(name, fallback="unnamed"):
+    """Reduce *name* to a single safe path segment.
+
+    Drops any directory prefix, replaces characters outside
+    ``[A-Za-z0-9_.-]`` with ``_``, and rejects the traversal names
+    ``""``/``.``/``..`` by returning *fallback*.
+    """
+    text = str(name).strip().replace("\\", "/")
+    text = text.rsplit("/", 1)[-1]  # keep only the final segment
+    text = _UNSAFE.sub("_", text)
+    text = text.strip(". ")  # no leading/trailing dots or spaces
+    if text in ("", ".", ".."):
+        return fallback
+    return text
+
+
+def safe_join(base, *parts):
+    """Join *parts* onto *base* and confirm the result stays within *base*.
+
+    Raises ``ValueError`` if the resolved path escapes *base* — via ``..``, an
+    absolute component, or a symlink.
+    """
+    base_real = os.path.realpath(base)
+    target = os.path.realpath(os.path.join(base_real, *parts))
+    try:
+        if os.path.commonpath([base_real, target]) != base_real:
+            raise ValueError(f"path escapes base directory: {target!r}")
+    except ValueError:
+        # commonpath raises on different drives/roots — treat as an escape.
+        raise ValueError(f"path escapes base directory: {target!r}") from None
+    return target

--- a/src/hoi4cm/core/safe_xml.py
+++ b/src/hoi4cm/core/safe_xml.py
@@ -1,0 +1,57 @@
+"""Bounded decompression + hardened XML parsing for untrusted Draw.io files.
+
+A ``.drawio`` file is downloaded/shared, so its embedded, zlib-compressed XML
+is untrusted. Two classic DoS vectors are closed here: a decompression bomb
+(tiny input inflating to gigabytes) and XML entity expansion (billion laughs).
+Stdlib only — no defusedxml dependency.
+"""
+
+import xml.etree.ElementTree as ET
+import zlib
+
+MAX_XML_BYTES = 64 * 1024 * 1024
+
+
+def bounded_inflate(data, wbits=-15, max_bytes=MAX_XML_BYTES):
+    """Inflate *data*, refusing output larger than *max_bytes*.
+
+    Returns the decompressed ``bytes``. Raises ``ValueError`` if the stream
+    would exceed the cap.
+    """
+    dobj = zlib.decompressobj(wbits)
+    out = dobj.decompress(data, max_bytes)
+    if dobj.unconsumed_tail:
+        raise ValueError("decompressed data exceeds size limit")
+    out += dobj.flush()
+    if len(out) > max_bytes:
+        raise ValueError("decompressed data exceeds size limit")
+    return out
+
+
+def _reject_dtd(xml_str):
+    # A DOCTYPE is the only way to declare internal ENTITY definitions, so
+    # refusing it blocks billion-laughs / quadratic-blowup entity expansion.
+    # ``ET.XMLParser`` no longer exposes its expat handlers across Python
+    # versions, so scan the markup directly. Both tokens are case-sensitive
+    # per the XML spec and only appear as literal markup (content escapes them
+    # as ``&lt;!...``), so a substring check is reliable.
+    blob = (
+        xml_str
+        if isinstance(xml_str, bytes)
+        else xml_str.encode("utf-8", errors="ignore")
+    )
+    if b"<!DOCTYPE" in blob or b"<!ENTITY" in blob:
+        raise ValueError("XML DOCTYPE/ENTITY declarations are not allowed")
+
+
+def safe_fromstring(xml_str, max_bytes=MAX_XML_BYTES):
+    """Parse *xml_str* like ``ET.fromstring`` but reject DOCTYPE/entities and
+    oversize input. Raises ``ValueError`` on either."""
+    if isinstance(xml_str, bytes):
+        size = len(xml_str)
+    else:
+        size = len(xml_str.encode("utf-8", errors="ignore"))
+    if size > max_bytes:
+        raise ValueError("XML input exceeds size limit")
+    _reject_dtd(xml_str)
+    return ET.fromstring(xml_str)

--- a/src/hoi4cm/focus_tree/export.py
+++ b/src/hoi4cm/focus_tree/export.py
@@ -42,6 +42,12 @@ def export_focus_tree(focuses_in_tree, info, *, focus_lookup, effect_renderer):
     cfp_y = info.get("cfp_y")
     is_joint = info.get("type") == "joint"
 
+    # name → focus, built once (keep first match) so relative_position_id
+    # resolution below is O(1) per focus instead of scanning all focuses.
+    name_to_focus = {}
+    for foc in focus_lookup.values():
+        name_to_focus.setdefault(foc.name, foc)
+
     def write_focus_body(f, out, indent, strip_effect_tab=False):
         """Write the body of a focus block (fields after id/icon).
 
@@ -54,14 +60,11 @@ def export_focus_tree(focuses_in_tree, info, *, focus_lookup, effect_renderer):
         gx = getattr(f, "_raw_gx", f.x)
         gy = getattr(f, "_raw_gy", f.y)
         rel_id = getattr(f, "relative_position_id", None)
-        if rel_id and any(foc.name == rel_id for foc in focus_lookup.values()):
+        if rel_id and rel_id in name_to_focus:
             dx = getattr(f, "_rel_dx", None)
             dy = getattr(f, "_rel_dy", None)
             if dx is None or dy is None:
-                parent = next(
-                    (foc for foc in focus_lookup.values() if foc.name == rel_id),
-                    None,
-                )
+                parent = name_to_focus.get(rel_id)
                 dx = gx - parent.x if parent else gx
                 dy = gy - parent.y if parent else gy
             out.append(f"{t1}x = {dx}")

--- a/src/hoi4cm/wizards/additional_income.py
+++ b/src/hoi4cm/wizards/additional_income.py
@@ -11,6 +11,7 @@ import tkinter as tk
 from tkinter import messagebox
 
 from hoi4cm.core import (
+    sanitize_component,
     tr,
 )
 from hoi4cm.mod import MOD
@@ -468,6 +469,9 @@ def open_additional_income_wizard(app):
                 parent=win,
             )
             return
+
+        # idea_id becomes an output filename below — keep it a safe segment.
+        idea_id = sanitize_component(idea_id, fallback="new_idea")
 
         if not MOD.loaded or not MOD.root:
             messagebox.showwarning(

--- a/src/hoi4cm/wizards/decision.py
+++ b/src/hoi4cm/wizards/decision.py
@@ -10,13 +10,14 @@ import copy
 import json
 import os
 import re
-import tempfile
 import tkinter as tk
 import uuid
 from tkinter import filedialog, messagebox
 
 from hoi4cm.core import (
     append_scripted_loc,
+    autosave_path,
+    sanitize_component,
     tr,
 )
 from hoi4cm.core.image import PIL_OK, PILImage, PILImageTk
@@ -55,8 +56,7 @@ def open_decision_wizard(app):
     win.resizable(True, True)
 
     # ── Auto-save / undo infrastructure ─────────────────────────────────────
-    _autosave_dir = tempfile.gettempdir()
-    _autosave_path = os.path.join(_autosave_dir, "hoi4_cm_decision_autosave.json")
+    _autosave_path = autosave_path("decision.json")
     _undo_stack = []  # list of (dm_cats snapshot, dm_decs snapshot)
     _undo_max = 30
 
@@ -5256,7 +5256,9 @@ def open_decision_wizard(app):
             )
             if not mod_root:
                 return
-        ns = dm_cats[0]["cat_id"].split("_")[0] if dm_cats else "TAG"
+        ns = sanitize_component(
+            dm_cats[0]["cat_id"].split("_")[0] if dm_cats else "TAG", fallback="TAG"
+        )
         saved = []
         errs = []
         # Prefer the imported/user-set edit target so we overwrite the source file in place

--- a/src/hoi4cm/wizards/dyn_mod.py
+++ b/src/hoi4cm/wizards/dyn_mod.py
@@ -9,12 +9,13 @@
 import json
 import os
 import re
-import tempfile
 import threading
 import tkinter as tk
 from tkinter import filedialog, messagebox
 
 from hoi4cm.core import (
+    autosave_path,
+    sanitize_component,
     tr,
 )
 from hoi4cm.core.image import PIL_OK, PILImage, PILImageTk
@@ -43,7 +44,7 @@ def open_dyn_mod_wizard(app):
     win.geometry("640x720")
     win.resizable(True, True)
     win.grab_set()
-    _dm_autosave_p = tempfile.gettempdir() + "/hoi4_cm_dynmod_autosave.json"
+    _dm_autosave_p = autosave_path("dyn_mod.json")
 
     def _dynmod_close():
         try:
@@ -1065,7 +1066,10 @@ def open_dyn_mod_wizard(app):
     _preview()
 
     def _save_file():
-        mid = v_id.get().strip() or "TAG_my_dynamic_modifier"
+        mid = sanitize_component(
+            v_id.get().strip() or "TAG_my_dynamic_modifier",
+            fallback="TAG_my_dynamic_modifier",
+        )
         icon = v_icon.get().strip()
         name = v_loc_name.get().strip()
         desc = v_loc_desc.get().strip()

--- a/src/hoi4cm/wizards/event.py
+++ b/src/hoi4cm/wizards/event.py
@@ -9,7 +9,6 @@
 import json
 import os
 import re
-import tempfile
 import threading
 import tkinter as tk
 from tkinter import filedialog, messagebox
@@ -18,7 +17,9 @@ from hoi4cm.core import (
     EFFECT_CATS,
     EFFECT_DEFS,
     append_scripted_loc,
+    autosave_path,
     effects_in_cat,
+    sanitize_component,
     tr,
 )
 from hoi4cm.core.image import PIL_OK, PILImage, PILImageTk
@@ -205,9 +206,7 @@ def open_event_wizard(app):
     sel = [None]  # sel[0] = active _Ev
 
     # ── Autosave ─────────────────────────────────────────────────────
-    _ev_autosave_path = os.path.join(
-        tempfile.gettempdir(), "hoi4_cm_event_autosave.json"
-    )
+    _ev_autosave_path = autosave_path("event.json")
 
     def _ev_save_state():
         """Persist current event list to autosave file."""
@@ -1607,7 +1606,7 @@ def open_event_wizard(app):
             messagebox.showwarning("Save", "No events to save.", parent=win)
             return
 
-        ns = events[0].eid.split(".")[0]
+        ns = sanitize_component(events[0].eid.split(".")[0], fallback="TAG")
         saved = []
         errs = []
         warnings = []

--- a/src/hoi4cm/wizards/national_spirit.py
+++ b/src/hoi4cm/wizards/national_spirit.py
@@ -9,7 +9,6 @@
 import json
 import os
 import re
-import tempfile
 import threading
 import tkinter as tk
 from tkinter import filedialog, messagebox
@@ -18,7 +17,9 @@ from hoi4cm.core import (
     MODIFIER_CATS,
     MODIFIER_DEFS,
     append_scripted_loc,
+    autosave_path,
     modifiers_in_cat,
+    sanitize_component,
     tr,
 )
 from hoi4cm.core.image import PIL_OK, PILImage, PILImageTk
@@ -50,7 +51,7 @@ def open_national_spirit_wizard(app):
     win.grab_set()
 
     # ── Auto-save on close ─────────────────────────────────────────────
-    _sp_autosave = os.path.join(tempfile.gettempdir(), "hoi4_cm_spirit_autosave.json")
+    _sp_autosave = autosave_path("national_spirit.json")
 
     def _spirit_autosave():
         try:
@@ -1567,7 +1568,9 @@ def open_national_spirit_wizard(app):
         app._hint("National Spirit code copied to clipboard!")
 
     def _save_to_mod():
-        sid = v_id.get().strip() or "TAG_my_spirit"
+        sid = sanitize_component(
+            v_id.get().strip() or "TAG_my_spirit", fallback="TAG_my_spirit"
+        )
         slot = v_slot.get().strip() or "country"
         loc_n = v_loc_name.get().strip()
         loc_d = v_loc_desc.get().strip()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,10 @@
 """Tests for hoi4cm.core.config — persistent user config."""
 
 import json
+import os
+import sys
+
+import pytest
 
 from hoi4cm.core import config
 
@@ -47,3 +51,27 @@ def test_cfg_save_failure_is_swallowed(tmp_path, monkeypatch):
     monkeypatch.setattr(config, "CONFIG_PATH", str(bad))
     config.cfg_save({"a": 1})  # should not raise
     assert config.cfg_load() == {}
+
+
+def test_cfg_save_is_atomic_no_leftover_tmp(tmp_path, monkeypatch):
+    p = tmp_path / "cfg.json"
+    monkeypatch.setattr(config, "CONFIG_PATH", str(p))
+    config.cfg_save({"a": 1})
+    config.cfg_save({"b": 2})
+    assert config.cfg_load() == {"a": 1, "b": 2}
+    assert not os.path.exists(str(p) + ".tmp")  # temp file cleaned up
+
+
+def test_cfg_save_failure_leaves_no_tmp(tmp_path, monkeypatch):
+    bad = tmp_path / "missing_dir" / "cfg.json"
+    monkeypatch.setattr(config, "CONFIG_PATH", str(bad))
+    config.cfg_save({"a": 1})
+    assert not os.path.exists(str(bad) + ".tmp")
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX file modes only")
+def test_cfg_save_sets_owner_only_perms(tmp_path, monkeypatch):
+    p = tmp_path / "cfg.json"
+    monkeypatch.setattr(config, "CONFIG_PATH", str(p))
+    config.cfg_save({"a": 1})
+    assert (os.stat(str(p)).st_mode & 0o077) == 0

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,0 +1,44 @@
+"""Tests for hoi4cm.core.image — Pillow import gate (opt-in auto-install)."""
+
+import builtins
+
+from hoi4cm.core import image
+
+
+def _force_pil_missing(monkeypatch):
+    real_import = builtins.__import__
+
+    def fake_import(name, *a, **k):
+        if name == "PIL" or name.startswith("PIL."):
+            raise ImportError("forced missing for test")
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+
+def test_no_auto_install_without_env(monkeypatch):
+    _force_pil_missing(monkeypatch)
+    monkeypatch.delenv("HOI4CM_AUTO_INSTALL_PILLOW", raising=False)
+    calls = []
+    monkeypatch.setattr(
+        image, "_try_install_pillow", lambda: calls.append(True) or True
+    )
+
+    _img, _tk, ok = image._import_pillow()
+
+    assert ok is False
+    assert calls == []  # pip was never invoked
+
+
+def test_auto_install_attempted_with_env(monkeypatch):
+    _force_pil_missing(monkeypatch)
+    monkeypatch.setenv("HOI4CM_AUTO_INSTALL_PILLOW", "1")
+    calls = []
+    monkeypatch.setattr(
+        image, "_try_install_pillow", lambda: calls.append(True) or False
+    )
+
+    _img, _tk, ok = image._import_pillow()
+
+    assert ok is False
+    assert calls == [True]  # opt-in install was attempted

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -43,3 +43,29 @@ def test_default_mod_dir_windows(monkeypatch):
     assert d.endswith(
         os.path.join("Documents", "Paradox Interactive", "Hearts of Iron IV", "mod")
     )
+
+
+def test_read_file_respects_size_cap(tmp_path):
+    p = tmp_path / "big.txt"
+    p.write_text("x" * 5000, encoding="utf-8")
+    assert paths.read_file(str(p), max_bytes=1000) == ""
+
+
+def test_read_file_reads_within_cap(tmp_path):
+    p = tmp_path / "small.txt"
+    p.write_text("focus = {", encoding="utf-8")
+    assert paths.read_file(str(p), max_bytes=1000) == "focus = {"
+
+
+def test_read_file_cap_disabled(tmp_path):
+    p = tmp_path / "big.txt"
+    p.write_text("x" * 5000, encoding="utf-8")
+    assert paths.read_file(str(p), max_bytes=None) == "x" * 5000
+
+
+def test_autosave_path_under_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(os.path, "expanduser", lambda p: p.replace("~", str(tmp_path)))
+    got = paths.autosave_path("decision.json")
+    assert got == os.path.join(str(tmp_path), ".hoi4cm", "autosave", "decision.json")
+    assert os.path.isdir(os.path.dirname(got))

--- a/tests/test_safe_path.py
+++ b/tests/test_safe_path.py
@@ -1,0 +1,60 @@
+"""Tests for hoi4cm.core.safe_path — filename component sanitization."""
+
+import os
+
+import pytest
+
+from hoi4cm.core import safe_path
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "../../etc/passwd",
+        "a/b/c",
+        "/etc/passwd",
+        "..\\..\\windows\\system32",
+        "foo\nbar",
+        "foo\x00bar",
+    ],
+)
+def test_sanitize_strips_traversal_to_single_segment(raw):
+    out = safe_path.sanitize_component(raw)
+    assert os.sep not in out
+    assert "/" not in out and "\\" not in out
+    assert ".." not in out.split(os.sep)
+    assert "\n" not in out and "\x00" not in out
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["GER", "TAG_my_spirit", "focus_1", "MD_money", "namespace-1", "a.b"],
+)
+def test_sanitize_passes_valid_ids_unchanged(raw):
+    assert safe_path.sanitize_component(raw) == raw
+
+
+@pytest.mark.parametrize("raw", ["", ".", "..", "   ", "/", "///"])
+def test_sanitize_rejects_empty_and_dot_names(raw):
+    assert safe_path.sanitize_component(raw) == "unnamed"
+
+
+def test_sanitize_custom_fallback():
+    assert safe_path.sanitize_component("..", fallback="x") == "x"
+
+
+def test_safe_join_accepts_in_tree(tmp_path):
+    got = safe_path.safe_join(str(tmp_path), "common", "ideas", "GER.txt")
+    assert got == os.path.realpath(
+        os.path.join(str(tmp_path), "common", "ideas", "GER.txt")
+    )
+
+
+def test_safe_join_rejects_traversal(tmp_path):
+    with pytest.raises(ValueError):
+        safe_path.safe_join(str(tmp_path), "..", "..", "escape.txt")
+
+
+def test_safe_join_rejects_absolute_component(tmp_path):
+    with pytest.raises(ValueError):
+        safe_path.safe_join(str(tmp_path), "/etc/passwd")

--- a/tests/test_safe_xml.py
+++ b/tests/test_safe_xml.py
@@ -1,0 +1,51 @@
+"""Tests for hoi4cm.core.safe_xml — bounded inflate + hardened XML parse."""
+
+import zlib
+
+import pytest
+
+from hoi4cm.core import safe_xml
+
+
+def _raw_deflate(data):
+    c = zlib.compressobj(9, zlib.DEFLATED, -15)
+    return c.compress(data) + c.flush()
+
+
+def test_bounded_inflate_roundtrips_small():
+    payload = _raw_deflate(b"<mxGraphModel><root/></mxGraphModel>")
+    assert safe_xml.bounded_inflate(payload) == b"<mxGraphModel><root/></mxGraphModel>"
+
+
+def test_bounded_inflate_rejects_bomb():
+    payload = _raw_deflate(b"A" * 200_000)
+    with pytest.raises(ValueError):
+        safe_xml.bounded_inflate(payload, max_bytes=1024)
+
+
+def test_safe_fromstring_parses_plain_xml():
+    root = safe_xml.safe_fromstring("<mxGraphModel><root id='0'/></mxGraphModel>")
+    assert root.tag == "mxGraphModel"
+    assert root.find("root").get("id") == "0"
+
+
+def test_safe_fromstring_rejects_billion_laughs():
+    bomb = (
+        "<?xml version='1.0'?>"
+        "<!DOCTYPE lolz [<!ENTITY lol 'lol'>"
+        "<!ENTITY lol2 '&lol;&lol;&lol;&lol;'>]>"
+        "<lolz>&lol2;</lolz>"
+    )
+    with pytest.raises(ValueError):
+        safe_xml.safe_fromstring(bomb)
+
+
+def test_safe_fromstring_rejects_any_doctype():
+    doc = "<!DOCTYPE note SYSTEM 'note.dtd'><note/>"
+    with pytest.raises(ValueError):
+        safe_xml.safe_fromstring(doc)
+
+
+def test_safe_fromstring_rejects_oversize_input():
+    with pytest.raises(ValueError):
+        safe_xml.safe_fromstring("<a/>" + " " * 100, max_bytes=8)


### PR DESCRIPTION
## Why

The app opens HOI4 mod files (`.txt`, `.yml`, `.gfx`, `.drawio`) that users download and share, so those files are untrusted input. This branch audits the app for ways a booby-trapped mod could harm whoever opens it, closes the real gaps, and fixes two algorithmic slow paths found along the way. New logic lives in `src/hoi4cm/core/` per the "don't grow the monolith" rule; each helper ships with a test.

The audit found no code execution, command injection, network exfiltration, or ReDoS. The work is about bounding untrusted input, not plugging an active exploit. Full write-up in `specs/security-hardening.md`.

## Security fixes

- **Path traversal** via unsanitized IDs/tags used as filenames (notably `country_tag` in the focus-tree loc export, sourced from parsed mod content). New `safe_path.py` (`sanitize_component`, `safe_join`) wired into the exporter and all five wizards. Valid HOI4 IDs pass through unchanged.
- **Draw.io decompression bomb + billion-laughs** in `_import_drawio`. New `safe_xml.py`: `bounded_inflate` (64 MB cap) and `safe_fromstring` (rejects DOCTYPE/entities), plus a raw-read cap.
- **`read_file` unbounded** read across the parallel mod scan. Added a 32 MB cap so a huge file or a `/dev/zero` symlink can't exhaust memory.
- **Config non-atomic write** now uses temp + fsync + `os.replace` at `0600`.
- **Silent `pip install Pillow`** at import is now opt-in via `HOI4CM_AUTO_INSTALL_PILLOW`; otherwise it logs a hint and uses placeholder icons.
- **Wizard autosaves** moved off world-writable `/tmp` to `~/.hoi4cm/autosave/` (`0700`), closing a multi-user symlink-clobber vector.

## CI

`release.yml`: dropped the blanket `contents: write` (the build job that runs arbitrary build code is now read-only; only the publish job gets write), and pinned all actions to commit SHAs at their current major versions.

## Performance

Fixed the two genuine O(F²) paths: the export `relative_position_id` lookup (now O(1) via a name map) and the duplicate-name loop (set built once). The focus-apply collision scans (once per click, not per frame) and the focus-list rebuild (only a risky widget-diffing rewrite would help) were assessed and left alone, as noted in the spec.

## Verification

146 tests pass; `ruff check` and `black --check` clean on `src/` and `tests/`; monolith and wizards byte-compile. All helpers exercised end to end against live payloads (decompression bomb, billion-laughs, oversize read, traversal strings).
