### PR TITLE
Cache undo id_set per structural revision

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ A standalone Python/Tkinter desktop app for authoring Hearts of Iron IV mod cont
 
 **New code goes in `src/hoi4cm/`. Do not grow the monolith.**
 
-`hoi4_content_maker.py` is down to ~6k lines from its original ~21k. What's left is essentially `class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk)` plus the importers and exporters that haven't been extracted yet (see `docs/dev/monolith-migration.md` for the full status table). When adding or refactoring, extract into a `src/hoi4cm/` module and pair it with a test — don't add features to the monolith. Edits to the monolith should be confined to bug fixes and the wiring needed to call into newly-extracted modules.
+`hoi4_content_maker.py` is down to ~5.7k lines from its original ~21k. What's left is essentially `class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk)` holding the Tk shells: dialogs, wiring, event bindings, and the one-line delegates into extracted modules. The sidebar form is the last big chunk still in the monolith and is deliberately deferred (see `docs/dev/monolith-migration.md` for the full status table and why). When adding or refactoring, extract into a `src/hoi4cm/` module and pair it with a test — don't add features to the monolith. Edits to the monolith should be confined to bug fixes and the wiring needed to call into newly-extracted modules.
 
 ## Commands
 
@@ -30,12 +30,12 @@ CI runs ruff + black and pytest, all on 3.14 (the project's floor).
 
 ## Layout
 
-- **`hoi4_content_maker.py`** — the launch point and (still) most of the app: `App(tk.Tk)` and its remaining importers/exporters/settings. Entry point at the bottom calls `show_splash(_launch)`.
-- **`src/hoi4cm/core/`** — the extracted package: `logger.py`, `config.py`, `paths.py`, re-exported flat from `hoi4cm.core`. This is where new modules land.
+- **`hoi4_content_maker.py`** — the launch point and (still) most of the app: `App(tk.Tk)`, its Tk-shell methods and one-line delegates into extracted modules, and the deferred sidebar form. Entry point at the bottom calls `show_splash(_launch)`.
+- **`src/hoi4cm/`** — the extracted package, organized by domain: `core/` (logger, config, paths, undo, i18n, concurrency, safe file/xml helpers), `models/` (`Focus`, `FocusDocument`, `EditorWorkspace`), `focus_tree/` (parse/build/export, codec, operations, drawio, loc), `ui/` (canvas, splash, menubar, toolbar, settings dialog, gfx browser, image pipeline), `wizards/` (the five authoring wizards + shared helpers), `mod/` (mod context, GFX catalog, scan/workspace caches), `script/` (effects + syntax), `editor/` (project save/load), `data/` (effect/modifier tables). New modules land in the owning subpackage, not a catch-all.
 - **`hoi4_logger.py`** — back-compat shim re-exporting from `hoi4cm.core.logger`. No logic here.
-- **`docs/dev/`**: developer docs, architecture, migration status, performance, testing, wizards. Start at `docs/dev/README.md`.
+- **`docs/dev/`**: developer docs, architecture, migration status, performance, testing, wizards. Start at `docs/dev/README.md`. They carry a maintenance rule: any PR that changes architecture, hot paths, or migration status updates the matching doc in the same PR.
 
-The monolith inserts `src/` onto `sys.path` at startup and imports canonical names straight from the `hoi4cm.core` facade (`from hoi4cm.core import (...)`). There's no more underscore-aliasing layer; the one survivor is `_default_hoi4_mod_dir = default_hoi4_mod_dir`, kept because a couple of call sites still use the old name. When you extract a new module, add the public name to the owning subpackage's `__all__`, and to `core/__init__.py`'s import and `__all__` if the monolith needs it from there. Details in `docs/dev/architecture.md`.
+The monolith inserts `src/` onto `sys.path` at startup and imports canonical names straight from the `hoi4cm.core` facade (`from hoi4cm.core import (...)`), which re-exports the public names of every subpackage (data, focus_tree, models, ui, ...). There's no underscore-aliasing layer left. When you extract a new module, add the public name to the owning subpackage's `__all__`, and to `core/__init__.py`'s import list and `__all__` if the monolith or a wizard needs it via the facade. Details in `docs/dev/architecture.md`.
 
 ## Conventions
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,9 @@ requires-python = ">=3.14"
 dependencies = []
 
 [project.optional-dependencies]
-image = ["Pillow>=9.0"]                              # GFX icon previews (.png/.tga)
-dev = ["pytest>=7.0", "ruff>=0.16", "black>=26.5"]   # tests + linting
-build = ["pyinstaller>=6.0", "Pillow>=9.0"]          # compile standalone executables
+image = ["Pillow>=9.0"]                            # GFX icon previews (.png/.tga)
+dev = ["pytest>=7.0", "ruff>=0.16", "black>=26.5"] # tests + linting
+build = ["pyinstaller>=6.0", "Pillow>=9.0"]        # compile standalone executables
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/hoi4cm"]

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,3 @@
+{
+  "extraPaths": ["src"]
+}

--- a/src/hoi4cm/core/undo.py
+++ b/src/hoi4cm/core/undo.py
@@ -37,6 +37,15 @@ def _snapshot_focus(focus):
     return snapshot
 
 
+def _decode_full(payload: bytes) -> dict[int, dict] | None:
+    """Decompress a full-snapshot blob; None if the payload is corrupt."""
+    try:
+        snapshot = json.loads(zlib.decompress(payload).decode("utf-8"))
+        return {int(k): v for k, v in snapshot.items()}
+    except zlib.error, UnicodeDecodeError, ValueError:
+        return None
+
+
 class UndoStack:
     """A bounded stack of undo entries, each either sparse or a full snapshot.
 
@@ -70,8 +79,15 @@ class UndoStack:
         instead). Pass ``touched_ids=None`` when the touched set isn't known
         or would be "most of the tree anyway" (bulk import/clear): this takes
         a full compressed snapshot instead.
+
+        ``focuses`` may be a plain dict or a ``FocusDocument``; the latter
+        hands out a cached frozenset of its keys so consecutive pushes
+        without structural changes share one object instead of reallocating
+        a set of every id per action.
         """
-        id_set = frozenset(focuses.keys())
+        id_set = getattr(focuses, "id_set", None)
+        if id_set is None:
+            id_set = frozenset(focuses.keys())
         if touched_ids is None:
             blob = zlib.compress(
                 json.dumps(
@@ -100,21 +116,24 @@ class UndoStack:
             return None
         label, kind, payload, id_set = self._stack.pop()
 
-        created_ids = [fid for fid in focuses if fid not in id_set]
-        delete_many = getattr(focuses, "delete_many", None)
-        if callable(delete_many):
-            delete_many(created_ids, clean_references=False)
-        else:
-            for fid in created_ids:
-                del focuses[fid]
-
         if kind == _FULL:
+            # Decode before mutating anything: a corrupt blob (self-written
+            # data, so effectively impossible) drops the entry without
+            # damaging the document.
+            snapshot = _decode_full(payload)
+            if snapshot is None:
+                return None
             # id_set was captured from the same `focuses` dict the snapshot
             # came from, so it's exactly the snapshot's keys: created_ids
             # (current ids missing from id_set) already covers everything
             # that needs removing, there's nothing else to diff.
-            snapshot = json.loads(zlib.decompress(payload).decode("utf-8"))
-            snapshot = {int(k): v for k, v in snapshot.items()}
+            created_ids = [fid for fid in focuses if fid not in id_set]
+            delete_many = getattr(focuses, "delete_many", None)
+            if callable(delete_many):
+                delete_many(created_ids, clean_references=False)
+            else:
+                for fid in created_ids:
+                    del focuses[fid]
             changed_ids = set(snapshot)
             restored = [focus_factory(fd) for fd in snapshot.values()]
             load = getattr(focuses, "load", None)
@@ -124,6 +143,14 @@ class UndoStack:
                 for focus in restored:
                     focuses[focus.id] = focus
             return label, changed_ids, set(created_ids)
+
+        created_ids = [fid for fid in focuses if fid not in id_set]
+        delete_many = getattr(focuses, "delete_many", None)
+        if callable(delete_many):
+            delete_many(created_ids, clean_references=False)
+        else:
+            for fid in created_ids:
+                del focuses[fid]
 
         changed_ids = set()
         restored = [focus_factory(fd) for fd in payload.values()]

--- a/src/hoi4cm/models/document.py
+++ b/src/hoi4cm/models/document.py
@@ -37,6 +37,7 @@ class FocusDocument(MutableMapping[int, Focus]):
 
     def __init__(self, focuses: Iterable[Focus] = ()) -> None:
         self._focuses: dict[int, Focus] = {}
+        self._id_set_cache: frozenset[int] | None = None
         self.geometry_revision = 0
         self.names: dict[str, tuple[int, ...]] = {}
         self.first_by_name: dict[str, int] = {}
@@ -54,6 +55,18 @@ class FocusDocument(MutableMapping[int, Focus]):
     @property
     def by_id(self) -> MutableMapping[int, Focus]:
         return self._focuses
+
+    @property
+    def id_set(self) -> frozenset[int]:
+        """All focus ids as a frozenset, cached until ids change.
+
+        Undo entries reference this instead of allocating a fresh set per
+        push, so a long edit sequence on a large tree retains one shared
+        frozenset instead of rebuilding a 20k+ element set per action.
+        """
+        if self._id_set_cache is None:
+            self._id_set_cache = frozenset(self._focuses)
+        return self._id_set_cache
 
     def __getitem__(self, focus_id: int) -> Focus:
         return self._focuses[focus_id]
@@ -77,6 +90,7 @@ class FocusDocument(MutableMapping[int, Focus]):
     def clear(self) -> None:
         if self._focuses:
             self._focuses.clear()
+            self._id_set_cache = None
             self._changed()
         self.rebuild_indexes()
 
@@ -84,6 +98,7 @@ class FocusDocument(MutableMapping[int, Focus]):
         if focus.id in self._focuses and not replace:
             raise KeyError(f"focus id already exists: {focus.id}")
         self._focuses[focus.id] = focus
+        self._id_set_cache = None
         self._changed()
         self.rebuild_indexes()
         return focus
@@ -100,6 +115,7 @@ class FocusDocument(MutableMapping[int, Focus]):
         if not additions:
             return
         self._focuses.update((focus.id, focus) for focus in additions)
+        self._id_set_cache = None
         self._changed()
         self.rebuild_indexes()
 
@@ -201,6 +217,7 @@ class FocusDocument(MutableMapping[int, Focus]):
                 focus.mutex = [other for other in focus.mutex if other not in deleted]
         for focus_id in deleted:
             del self._focuses[focus_id]
+        self._id_set_cache = None
         self._changed()
         self.rebuild_indexes()
         return deleted
@@ -215,6 +232,7 @@ class FocusDocument(MutableMapping[int, Focus]):
         changed = loaded != self._focuses
         self._focuses = loaded
         if changed:
+            self._id_set_cache = None
             self._changed()
         self.rebuild_indexes()
 

--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -102,6 +102,47 @@ def test_focus_document_undo_batches_index_rebuilds():
     assert focuses.validate_indexes()
 
 
+def test_pushes_without_structural_change_share_one_id_set():
+    """Pure edits must not allocate a fresh per-action set of every id."""
+    focuses = FocusDocument(_mk_focus(i, f"focus_{i}") for i in range(1000))
+    stack = UndoStack()
+    stack.push("edit 1", focuses, touched_ids=(1,))
+    stack.push("edit 2", focuses, touched_ids=(2,))
+    first_id_set = focuses.id_set
+
+    stack.push("edit 3", focuses, touched_ids=(3,))
+
+    assert focuses.id_set is first_id_set
+    assert stack._stack[0][3] is first_id_set
+    assert stack._stack[1][3] is first_id_set
+    assert stack._stack[2][3] is first_id_set
+
+
+def test_structural_change_rebuilds_id_set():
+    focuses = FocusDocument(_mk_focus(i, f"focus_{i}") for i in range(3))
+    before = focuses.id_set
+
+    focuses.add(_mk_focus(9, "focus_9"))
+
+    assert focuses.id_set is not before
+    assert focuses.id_set == frozenset({0, 1, 2, 9})
+
+    before = focuses.id_set
+    focuses.delete_many((1,))
+    assert focuses.id_set is not before
+    assert focuses.id_set == frozenset({0, 2, 9})
+
+    before = focuses.id_set
+    focuses.load([_mk_focus(7, "focus_7")])
+    assert focuses.id_set is not before
+    assert focuses.id_set == frozenset({7})
+
+    before = focuses.id_set
+    focuses.clear()
+    assert focuses.id_set is not before
+    assert focuses.id_set == frozenset()
+
+
 def test_single_edit_undo_restores_fields():
     f = _mk_focus(1, "focus_1", cost=10, desc="old")
     focuses = {1: f}

--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -143,6 +143,44 @@ def test_structural_change_rebuilds_id_set():
     assert focuses.id_set == frozenset()
 
 
+def test_pure_edits_between_pushes_keep_sharing_id_set():
+    """Geometry-only changes and field edits must not invalidate the cache;
+    invalidating on every mutation would rebuild the set per action again."""
+    focuses = FocusDocument(_mk_focus(i, f"focus_{i}") for i in range(5))
+    stack = UndoStack()
+    stack.push("edit 1", focuses, touched_ids=(1,))
+    first_id_set = focuses.id_set
+
+    focuses.move(1, 3, 4)
+    focuses.touch()
+    focuses.link_prerequisite(2, [1])
+    focuses.rename_prefix("focus", "f_")
+    stack.push("edit 2", focuses, touched_ids=(2,))
+
+    assert focuses.id_set is first_id_set
+    assert stack._stack[0][3] is first_id_set
+    assert stack._stack[1][3] is first_id_set
+
+
+def test_undo_refreshes_id_set_cache():
+    """Undo deletes created ids through the document; the next id_set read
+    must reflect the restored keys, not the stale pre-undo set."""
+    focuses = FocusDocument([_mk_focus(1, "focus_1")])
+    stack = UndoStack()
+
+    stack.push("add focus", focuses, touched_ids=())
+    focuses.add(_mk_focus(2, "focus_2"))
+    stack.undo(focuses, Focus.from_dict)
+    assert focuses.id_set == frozenset({1})
+
+    stack.push("full import", focuses)
+    focuses.clear()
+    focuses.load([_mk_focus(9, "focus_9")])
+    stack.undo(focuses, Focus.from_dict)
+    assert focuses.id_set == frozenset({1})
+    assert focuses.id_set == frozenset(focuses.keys())
+
+
 def test_single_edit_undo_restores_fields():
     f = _mk_focus(1, "focus_1", cost=10, desc="old")
     focuses = {1: f}


### PR DESCRIPTION
Fixes #33.

`UndoStack.push` rebuilt `frozenset(focuses.keys())` on every push: at 23k+ focuses that is a per-action allocation of every id, with up to 60 entries retained in the deque. The id set only changes when a focus is created or deleted, so pure edits were rebuilding it for nothing.

- `FocusDocument.id_set`: cached frozenset, invalidated only by the key-changing methods (`add`/`extend`/`delete_many`/`load`/`clear`). Moves and edits don't invalidate it, so an edit sequence shares one object.
- `UndoStack.push` uses `focuses.id_set` when present; plain dicts fall back to the old behavior.
- Full-snapshot payloads now decode before any document mutation: a corrupt blob drops the entry instead of leaving the document half-restored.
- Tests: entries share one frozenset across pure-edit pushes; structural ops rebuild it.

Also updates AGENTS.md to match the current package layout (subpackage map, facade wiring, docs maintenance rule) and adds `pyrightconfig.json` so pyright/pylance resolve `hoi4cm.*` imports in the src-layout.

410 tests pass; ruff and black are clean.