### PR TITLE
Add pre-commit, mypy and pylint to the dev toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches: [main]
-    tags: ['v*']
+    tags: ["v*"]
 
 # Least privilege: read by default. Only `release`, the one job gated on a v*
 # tag, gets write. Everything before it, including the build that runs arbitrary
@@ -17,29 +17,35 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        # v5.6.0
         with:
-          python-version: '3.14'
+          python-version: "3.14"
       - name: Install dev dependencies
         run: pip install ".[dev]"
       - name: Ruff
         run: ruff check .
       - name: Black
         run: black --check .
+      - name: Mypy
+        run: mypy
+      - name: Pylint
+        run: pylint src/hoi4cm tests
 
   test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.14']
+        python-version: ["3.14"]
     env:
       # Turns "no display" from a silent skip into a failure, so a broken
       # Xvfb can't quietly drop every widget test (tests/conftest.py).
-      HOI4CM_REQUIRE_TK: '1'
+      HOI4CM_REQUIRE_TK: "1"
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dev dependencies
@@ -82,9 +88,10 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        # v5.6.0
         with:
-          python-version: '3.14'
+          python-version: "3.14"
 
       - name: Install tkinter (Linux)
         if: runner.os == 'Linux'
@@ -104,7 +111,8 @@ jobs:
         run: chmod +x "${{ matrix.artifact_name }}"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        # v4.6.2
         with:
           name: ${{ matrix.artifact_name }}
           path: ${{ matrix.artifact_name }}
@@ -117,17 +125,21 @@ jobs:
       contents: write
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        # v4.3.0
         with:
           path: artifacts
           merge-multiple: true
 
       - name: Checksum the binaries
         working-directory: artifacts
-        run: sha256sum HOI4ContentMaker.exe HOI4ContentMaker-mac HOI4ContentMaker-linux > SHA256SUMS.txt
+        run: >
+          sha256sum HOI4ContentMaker.exe HOI4ContentMaker-mac
+          HOI4ContentMaker-linux > SHA256SUMS.txt
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
+        # v2.6.2
         with:
           tag_name: ${{ github.ref_name }}
           name: HOI4 Content Maker ${{ github.ref_name }}
@@ -143,8 +155,10 @@ jobs:
 
             ### Running
             - **Windows**: Double-click `HOI4ContentMaker.exe`
-            - **macOS**: `chmod +x HOI4ContentMaker-mac && ./HOI4ContentMaker-mac`
-            - **Linux**: `chmod +x HOI4ContentMaker-linux && ./HOI4ContentMaker-linux`
+            - **macOS**: `chmod +x HOI4ContentMaker-mac &&
+              ./HOI4ContentMaker-mac`
+            - **Linux**: `chmod +x HOI4ContentMaker-linux &&
+              ./HOI4ContentMaker-linux`
 
             No Python installation required.
 
@@ -153,10 +167,10 @@ jobs:
             download and check it:
 
             - **Linux**: `sha256sum --ignore-missing -c SHA256SUMS.txt`
-            - **macOS**: `shasum -a 256 -c SHA256SUMS.txt` (it will complain about
-              the two files you didn't download)
-            - **Windows**: `certutil -hashfile HOI4ContentMaker.exe SHA256`, then
-              compare against the matching line.
+            - **macOS**: `shasum -a 256 -c SHA256SUMS.txt` (it will
+              complain about the two files you didn't download)
+            - **Windows**: `certutil -hashfile HOI4ContentMaker.exe SHA256`,
+              then compare against the matching line.
           files: |
             artifacts/HOI4ContentMaker.exe
             artifacts/HOI4ContentMaker-mac

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,39 @@
+# Pre-commit hooks. Install with `pre-commit install`; run all with
+# `pre-commit run --all-files`. Config lives in pyproject.toml (ruff, black,
+# mypy, pylint all read it), so the hooks here are thin wrappers.
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-merge-conflict
+      - id: check-ast
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.16.0
+    hooks:
+      - id: ruff
+        args: [--fix]
+
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 26.5.1
+    hooks:
+      - id: black
+        # Files are passed explicitly by pre-commit, which bypasses black's
+        # --extend-exclude; --force-exclude makes it honor the monolith/build
+        # exclusions (matched against the relative paths pre-commit passes).
+        args: [--force-exclude, 'hoi4_content_maker\.py|build/']
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v2.3.0
+    hooks:
+      - id: mypy
+        args: [--config-file=pyproject.toml]
+
+  - repo: https://github.com/PyCQA/pylint
+    rev: v4.0.6
+    hooks:
+      - id: pylint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,11 +22,15 @@ pytest                          # full suite (src/ is on the path via pyproject)
 pytest tests/test_config.py::test_cfg_save_merges_existing_keys   # single test
 ruff check .                    # lint
 black --check .                 # formatting
+mypy                            # type check (src/hoi4cm + tests)
+pylint src/hoi4cm tests         # lint (light gate on top of ruff/black)
+pre-commit run --all-files      # run all hooks once
+pre-commit install              # run hooks on every commit
 
 python build/build.py           # standalone exe (after pip install ".[build]")
 ```
 
-CI runs ruff + black and pytest, all on 3.14 (the project's floor).
+CI runs ruff, black, mypy, pylint and pytest, all on 3.14 (the project's floor).
 
 ## Layout
 
@@ -39,7 +43,7 @@ The monolith inserts `src/` onto `sys.path` at startup and imports canonical nam
 
 ## Conventions
 
-- **Lint scope:** ruff (`E,F,W,I,UP,B`) and black (line-length 88) cover `src/hoi4cm/` and `tests/` only — the monolith and `build/` are excluded. Packaged code must pass both; in the monolith, match the existing style by hand.
+- **Lint scope:** ruff (`E,F,W,I,UP,B`), black (line-length 88), mypy and pylint cover `src/hoi4cm/` and `tests/` only — the monolith and `build/` are excluded. Packaged code must pass all four; in the monolith, match the existing style by hand. Config lives in `pyproject.toml` (`[tool.ruff]`, `[tool.black]`, `[tool.mypy]`, `[tool.pylint]`); `.pre-commit-config.yaml` wires them into pre-commit. Pylint's `disable` list is deliberate: it drops checks ruff/black already cover and false positives on Tk/dataclass/mixin patterns, so it stays a light gate.
 - **Logging, not print.** `get_logger("name")` for a `HOI4CM.<name>` child. User-facing errors go through `add_error()` so they reach the in-app error log.
 - **Tolerant file reads.** Mod files have mixed encodings — read them via `read_file`, never bare `open(...).read()`.
 - **Preserve user data on round-trips.** Parse→export of an existing file must not drop fields. Test round-trips when touching the parser or exporters.

--- a/build/build.py
+++ b/build/build.py
@@ -9,9 +9,9 @@ Works on Windows, macOS, and Linux.
 """
 
 import os
+import shutil
 import subprocess
 import sys
-import shutil
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 ROOT_DIR = os.path.dirname(SCRIPT_DIR)
@@ -65,7 +65,7 @@ def write_spec():
     elif sys.platform == "darwin":
         png = os.path.join(SCRIPT_DIR, "icon.png")
         if os.path.exists(png):
-            icon_line = f"    icon=os.path.join(SCRIPT_DIR, 'icon.png'),"
+            icon_line = "    icon=os.path.join(SCRIPT_DIR, 'icon.png'),"
     # Linux ELF executables don't support embedded icons — skip
 
     source_path = SOURCE.replace("\\", "/")
@@ -225,7 +225,7 @@ def main():
         size_mb = os.path.getsize(final_out) / (1024 * 1024)
         print()
         print("=" * 55)
-        print(f"  Build SUCCESSFUL")
+        print("  Build SUCCESSFUL")
         print(f"  Output: {output_name}  ({size_mb:.1f} MB)")
         print("=" * 55)
         print()

--- a/build/build.py
+++ b/build/build.py
@@ -50,8 +50,7 @@ def generate_icon():
     ensure_package("Pillow", "PIL")
 
     gen_script = os.path.join(SCRIPT_DIR, "generate_icon.py")
-    run([sys.executable, gen_script, "--all-formats"],
-        cwd=SCRIPT_DIR)
+    run([sys.executable, gen_script, "--all-formats"], cwd=SCRIPT_DIR)
 
 
 def write_spec():
@@ -190,13 +189,20 @@ def main():
     spec_path = write_spec()
 
     try:
-        run([
-            sys.executable, "-m", "PyInstaller",
-            spec_path,
-            "--clean", "--noconfirm",
-            "--distpath", ROOT_DIR,
-            "--workpath", build_tmp,
-        ])
+        run(
+            [
+                sys.executable,
+                "-m",
+                "PyInstaller",
+                spec_path,
+                "--clean",
+                "--noconfirm",
+                "--distpath",
+                ROOT_DIR,
+                "--workpath",
+                build_tmp,
+            ]
+        )
     except subprocess.CalledProcessError:
         print()
         print("=" * 55)

--- a/build/generate_icon.py
+++ b/build/generate_icon.py
@@ -15,21 +15,21 @@ import math
 import os
 
 # ── Colour palette (watermelon) ───────────────────────────────────────────────
-GREEN_DARK   = (28,  88,  28)   # outer rind
-GREEN_LIGHT  = (80, 160,  50)   # rind stripes
-WHITE_RIND   = (220, 242, 205)  # inner white rind
-FLESH        = (210,  38,  38)  # red flesh
-SEED         = (22,   14,   6)  # seeds
+GREEN_DARK = (28, 88, 28)  # outer rind
+GREEN_LIGHT = (80, 160, 50)  # rind stripes
+WHITE_RIND = (220, 242, 205)  # inner white rind
+FLESH = (210, 38, 38)  # red flesh
+SEED = (22, 14, 6)  # seeds
 
 
 def make_frame(size):
     """Draw one watermelon cross-section frame at the given pixel size."""
-    img  = Image.new("RGBA", (size, size), (0, 0, 0, 0))
+    img = Image.new("RGBA", (size, size), (0, 0, 0, 0))
     draw = ImageDraw.Draw(img)
 
     pad = max(1, size // 14)
-    r   = size - 1
-    cx  = cy = size // 2
+    r = size - 1
+    cx = cy = size // 2
 
     # ── 1. Outer dark-green circle (rind) ─────────────────────────────────────
     draw.ellipse([pad, pad, r - pad, r - pad], fill=GREEN_DARK)
@@ -38,11 +38,14 @@ def make_frame(size):
     rind_w = max(2, size // 7)
     if size >= 24:
         num_stripes = 3 if size >= 48 else 2
-        stripe_w    = max(1, rind_w // (num_stripes * 2 + 1))
+        stripe_w = max(1, rind_w // (num_stripes * 2 + 1))
         for i in range(num_stripes):
             offset = pad + stripe_w * (2 * i + 1)
-            draw.ellipse([offset, offset, r - offset, r - offset],
-                         outline=GREEN_LIGHT, width=max(1, stripe_w))
+            draw.ellipse(
+                [offset, offset, r - offset, r - offset],
+                outline=GREEN_LIGHT,
+                width=max(1, stripe_w),
+            )
 
     # ── 3. White inner-rind ring ───────────────────────────────────────────────
     wi = pad + rind_w
@@ -55,10 +58,10 @@ def make_frame(size):
 
     # ── 5. Seeds (only for sizes >= 32) ───────────────────────────────────────
     if size >= 32:
-        flesh_r = cx - fi          # radius of the flesh circle
-        seed_r  = flesh_r * 0.55   # orbit radius for seeds
-        sw      = max(1, size // 22)   # seed half-width
-        sh      = max(2, size // 14)   # seed half-height
+        flesh_r = cx - fi  # radius of the flesh circle
+        seed_r = flesh_r * 0.55  # orbit radius for seeds
+        sw = max(1, size // 22)  # seed half-width
+        sh = max(2, size // 14)  # seed half-height
 
         # 5 seeds at evenly-spaced angles; fewer at smaller sizes
         angles = [-90, -18, 54, 126, 198]
@@ -67,10 +70,9 @@ def make_frame(size):
 
         for deg in angles:
             rad = math.radians(deg)
-            sx  = int(cx + math.cos(rad) * seed_r)
-            sy  = int(cy + math.sin(rad) * seed_r)
-            draw.ellipse([sx - sw, sy - sh // 2,
-                          sx + sw, sy + sh // 2], fill=SEED)
+            sx = int(cx + math.cos(rad) * seed_r)
+            sy = int(cy + math.sin(rad) * seed_r)
+            draw.ellipse([sx - sw, sy - sh // 2, sx + sw, sy + sh // 2], fill=SEED)
 
     return img
 
@@ -80,16 +82,16 @@ def main():
 
     all_formats = "--all-formats" in _sys.argv
 
-    sizes  = [256, 128, 64, 48, 32, 16]
+    sizes = [256, 128, 64, 48, 32, 16]
     frames = [make_frame(s) for s in sizes]
 
     # Always generate .ico (Windows)
     ico_out = "icon.ico"
     frames[0].save(
         ico_out,
-        format        = "ICO",
-        sizes         = [(s, s) for s in sizes],
-        append_images = frames[1:],
+        format="ICO",
+        sizes=[(s, s) for s in sizes],
+        append_images=frames[1:],
     )
     kb = os.path.getsize(ico_out) / 1024
     print(f"[generate_icon] Created {ico_out}  ({kb:.1f} KB)  —  sizes: {sizes}")

--- a/build/patch_spec_encrypted.py
+++ b/build/patch_spec_encrypted.py
@@ -3,6 +3,7 @@ patch_spec_encrypted.py
 Called by build_encrypted.bat to generate an AES-encrypted spec file.
 Do NOT run this directly — use build_encrypted.bat instead.
 """
+
 import os
 import sys
 
@@ -10,7 +11,7 @@ import sys
 ENCRYPTION_KEY = "HOI4CM_BLAZER_2025"
 # ───────────────────────────────────────────────────────────────────────
 
-spec_in  = os.path.join(os.path.dirname(__file__), "hoi4_content_maker.spec")
+spec_in = os.path.join(os.path.dirname(__file__), "hoi4_content_maker.spec")
 spec_out = os.path.join(os.path.dirname(__file__), "hoi4_content_maker_enc.spec")
 
 try:

--- a/build/patch_spec_encrypted.py
+++ b/build/patch_spec_encrypted.py
@@ -3,7 +3,8 @@ patch_spec_encrypted.py
 Called by build_encrypted.bat to generate an AES-encrypted spec file.
 Do NOT run this directly — use build_encrypted.bat instead.
 """
-import sys, os
+import os
+import sys
 
 # ── Change this to your own secret string before building ──────────────
 ENCRYPTION_KEY = "HOI4CM_BLAZER_2025"
@@ -13,7 +14,7 @@ spec_in  = os.path.join(os.path.dirname(__file__), "hoi4_content_maker.spec")
 spec_out = os.path.join(os.path.dirname(__file__), "hoi4_content_maker_enc.spec")
 
 try:
-    with open(spec_in, "r", encoding="utf-8") as f:
+    with open(spec_in, encoding="utf-8") as f:
         spec = f.read()
 except FileNotFoundError:
     print(f"[patch_spec] ERROR: Could not find {spec_in}")

--- a/hoi4_content_maker.py
+++ b/hoi4_content_maker.py
@@ -1937,7 +1937,7 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):
             f.available_if_capitulated = self._fv_cap.get()
             self._save_offsets_to_focus()
             self.focuses.touch()
-        except ValueError, Exception:
+        except Exception:
             pass
 
     def _select(self, f):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,14 +11,17 @@ requires-python = ">=3.14"
 dependencies = []
 
 [project.optional-dependencies]
-image = ["Pillow>=9.0"]                            # GFX icon previews (.png/.tga)
+image = ["Pillow>=9.0"] # GFX icon previews (.png/.tga)
 dev = [
-    "pytest>=7.0",
-    "pytest-cov>=4.0",   # coverage gate for wizard generators
-    "ruff>=0.16",
-    "black>=26.5",
-]                                                     # tests + linting
-build = ["pyinstaller>=6.0", "Pillow>=9.0"]        # compile standalone executables
+  "pytest>=7.0",
+  "pytest-cov>=4.0", # coverage gate for wizard generators
+  "ruff>=0.16",
+  "black>=26.5",
+  "mypy>=1.10",
+  "pylint>=3.2",
+  "pre-commit>=3.5",
+] # tests + linting
+build = ["pyinstaller>=6.0", "Pillow>=9.0"] # compile standalone executables
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/hoi4cm"]
@@ -41,10 +44,10 @@ branch = true
 show_missing = true
 skip_covered = true
 exclude_also = [
-    "if TYPE_CHECKING:",
-    "raise NotImplementedError",
-    "class .*\\(Protocol\\):",
-    "@abstractmethod",
+  "if TYPE_CHECKING:",
+  "raise NotImplementedError",
+  "class .*\\(Protocol\\):",
+  "@abstractmethod",
 ]
 
 # Linting/formatting is scoped to the modular package + tests. The legacy
@@ -61,3 +64,89 @@ extend-exclude = ["hoi4_content_maker.py", "build"]
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "UP", "B"]
+
+# Type checking is scoped to the modular package + tests, same as ruff/black.
+# The monolith and build scripts stay out until they are refactored into the
+# package. `mypy_path` puts src/ on the search path so tests can import hoi4cm.
+[tool.mypy]
+python_version = "3.14"
+mypy_path = ["src"]
+files = ["src/hoi4cm", "tests"]
+# The monolith and build scripts stay out until refactored. The PEP 758 files
+# (unparenthesized `except A, B:`) are excluded too: mypy 2.3.0 can't parse that
+# syntax yet, even though it's valid Python 3.14. Tracked in issue #68.
+exclude = [
+  "hoi4_content_maker.py",
+  "build",
+  "src/hoi4cm/core/undo.py",
+  "src/hoi4cm/data/effects.py",
+  "src/hoi4cm/mod/workspace_cache.py",
+  "src/hoi4cm/ui/lifecycle.py",
+  "src/hoi4cm/wizards/_image_loader.py",
+  "src/hoi4cm/mod/graphics_catalog.py",
+  "tests/test_i18n.py",
+]
+warn_unused_configs = true
+
+# Pillow is an optional extra and pytest is only a dev dependency; both may be
+# absent when mypy runs, so treat their imports as untyped rather than failing.
+[[tool.mypy.overrides]]
+module = ["PIL.*", "pytest"]
+ignore_missing_imports = true
+
+# Pylint is a light gate on top of ruff/black. The disabled checks are either
+# redundant with ruff/black (line length, f-strings, unused vars, reimports,
+# dangerous defaults), too noisy for this codebase (naming, docstrings,
+# too-many-*), or false positives on Tk/dataclass/mixin patterns (no-member,
+# unused-argument on event callbacks, import-error on optional deps).
+[tool.pylint]
+max-line-length = 88
+fail-under = 8.0
+disable = [
+  "C0103", # invalid-name
+  "C0104", # disallowed-name
+  "C0114", # missing-module-docstring
+  "C0115", # missing-class-docstring
+  "C0116", # missing-function-docstring
+  "C0208", # use-sequence-for-iteration
+  "C0209", # consider-using-f-string (ruff UP032)
+  "C0301", # line-too-long (black)
+  "C0302", # too-many-lines
+  "C0325", # unnecessary-paren
+  "C0415", # import-outside-top-level
+  "C1803", # use-implicit-booleaness-not-comparison
+  "C2801", # unnecessary-dunder-call
+  "E0401", # import-error (optional deps)
+  "E0601", # used-before-assignment (false positive on except blocks)
+  "E0602", # undefined-variable (ruff F821)
+  "E0603", # undefined-all-variable
+  "E1101", # no-member (dataclass/mixin/Tk false positives)
+  "R0402", # consider-using-from-import
+  "R0801", # duplicate-code
+  "R0901", # too-many-ancestors
+  "R0902", # too-many-instance-attributes
+  "R0903", # too-few-public-methods
+  "R0904", # too-many-public-methods
+  "R0911", # too-many-return-statements
+  "R0912", # too-many-branches
+  "R0913", # too-many-arguments
+  "R0914", # too-many-locals
+  "R0915", # too-many-statements
+  "R0917", # too-many-positional-arguments
+  "R1702", # too-many-nested-blocks
+  "R1705", # no-else-return
+  "R1716", # chained-comparison
+  "R1735", # use-dict-literal
+  "W0102", # dangerous-default-value (ruff B006)
+  "W0104", # pointless-statement
+  "W0108", # unnecessary-lambda
+  "W0212", # protected-access
+  "W0221", # arguments-differ
+  "W0404", # reimported (ruff F811)
+  "W0603", # global-statement
+  "W0612", # unused-variable (ruff F841)
+  "W0613", # unused-argument (Tk event callbacks)
+  "W0621", # redefined-outer-name (pytest fixtures)
+  "W0640", # cell-var-from-loop
+  "W0718", # broad-exception-caught
+]

--- a/src/hoi4cm/core/concurrency.py
+++ b/src/hoi4cm/core/concurrency.py
@@ -5,11 +5,15 @@ import threading
 from collections.abc import Callable
 from concurrent.futures import Executor, Future
 from dataclasses import dataclass
+from typing import Any, ParamSpec, TypeVar
+
+_P = ParamSpec("_P")
+_T = TypeVar("_T")
 
 
 @dataclass(frozen=True)
 class _WorkItem:
-    future: Future[object]
+    future: Future[Any]
     work: Callable[[], object]
 
 
@@ -25,13 +29,13 @@ class DaemonThreadPoolExecutor(Executor):
         self._shutdown = False
 
     def submit(
-        self, fn: Callable[..., object], /, *args: object, **kwargs: object
-    ) -> Future[object]:
+        self, fn: Callable[_P, _T], /, *args: _P.args, **kwargs: _P.kwargs
+    ) -> Future[_T]:
         with self._lock:
             if self._shutdown:
                 raise RuntimeError("cannot schedule new futures after shutdown")
             self._start_workers_locked()
-            future: Future[object] = Future()
+            future: Future[_T] = Future()
             self._queue.put(_WorkItem(future, lambda: fn(*args, **kwargs)))
             return future
 

--- a/src/hoi4cm/core/i18n.py
+++ b/src/hoi4cm/core/i18n.py
@@ -29,7 +29,7 @@ I18N_LANGS = {
     "zh_CN": "简体中文",
 }
 I18N_LANG = None
-I18N_STRINGS = {}
+I18N_STRINGS: dict[str, str] = {}
 
 
 def _project_root():
@@ -85,7 +85,7 @@ def get_language():
     return I18N_LANG
 
 
-def tr(key, default=None, **kwargs):
+def tr(key: str, default: str | None = None, **kwargs: object) -> str:
     """Resolve a translation key. Falls back to *default* then the key itself."""
     text = I18N_STRINGS.get(key, default if default is not None else key)
     try:

--- a/src/hoi4cm/core/logger.py
+++ b/src/hoi4cm/core/logger.py
@@ -59,16 +59,16 @@ def get_logger(name):
 
 def log_startup():
     log.info("=== HOI4 Content Maker starting ===")
-    log.info(f"Python {sys.version}")
-    log.info(f"Platform: {sys.platform}")
-    log.info(f"DISPLAY={os.environ.get('DISPLAY', '(unset)')}")
+    log.info("Python %s", sys.version)
+    log.info("Platform: %s", sys.platform)
+    log.info("DISPLAY=%s", os.environ.get("DISPLAY", "(unset)"))
 
 
 # ── In-memory error buffer ───────────────────────────────────────────
 # Single shared list so the excepthook and the GUI error log read the same
 # entries. Entries are (HH:MM:SS, message) tuples — the shape the Tk viewer
 # expects. The core is the sole writer.
-_error_entries = []
+_error_entries: list[tuple[str, str]] = []
 _error_callback = None
 
 

--- a/src/hoi4cm/focus_tree/build.py
+++ b/src/hoi4cm/focus_tree/build.py
@@ -167,7 +167,8 @@ def build_focuses(
         aiblock = rf.get("ai_will_do", {})
         if isinstance(aiblock, dict):
             try:
-                f.ai_will_do = int(float(aiblock.get("factor", aiblock.get("base", 1))))
+                factor = aiblock.get("factor", aiblock.get("base", 1))
+                f.ai_will_do = int(float(factor)) if factor is not None else 1
             except Exception:
                 f.ai_will_do = 1
             f.ai_will_do_raw = dict_to_raw(aiblock)

--- a/src/hoi4cm/focus_tree/operations.py
+++ b/src/hoi4cm/focus_tree/operations.py
@@ -13,7 +13,7 @@ def group_focuses_by_tree(focuses: Iterable[Focus]) -> dict[int, list[Focus]]:
 
 
 def build_focus_name_lookup(focuses: Iterable[Focus]) -> dict[str, Focus]:
-    lookup = {}
+    lookup: dict[str, Focus] = {}
     for focus in focuses:
         lookup.setdefault(focus.name, focus)
     return lookup

--- a/src/hoi4cm/mod/graphics_catalog.py
+++ b/src/hoi4cm/mod/graphics_catalog.py
@@ -532,6 +532,7 @@ class GraphicsCatalog:
         self, reference: PathReference, record: GfxFileRecord
     ) -> _MapDelta:
         delta = _MapDelta()
+        old_declaration: SpriteDeclaration | None
         old_record = self._gfx_files.get(reference)
         old_by_name = (
             {declaration.name: declaration for declaration in old_record.declarations}
@@ -619,17 +620,17 @@ class GraphicsCatalog:
                 delta.upsert[family].add(name)
 
     def _unshadow(self, name: str, delta: _MapDelta) -> None:
-        claim = self._sprite_claims.get(name)
-        if claim is not None:
-            self._sprite_refs.setdefault(name, claim)
+        sprite_claim = self._sprite_claims.get(name)
+        if sprite_claim is not None:
+            self._sprite_refs.setdefault(name, sprite_claim)
             delta.upsert["sprites"].add(name)
-        claim = self._idea_claims.get(name)
-        if claim is not None:
-            self._idea_refs.setdefault(name, claim[1])
+        idea_claim = self._idea_claims.get(name)
+        if idea_claim is not None:
+            self._idea_refs.setdefault(name, idea_claim[1])
             delta.upsert["ideas"].add(name)
-        claim = self._decision_claims.get(name)
-        if claim is not None:
-            self._decision_refs.setdefault(name, claim)
+        decision_claim = self._decision_claims.get(name)
+        if decision_claim is not None:
+            self._decision_refs.setdefault(name, decision_claim)
             delta.upsert["decisions"].add(name)
 
     def _unclaim_image(
@@ -719,9 +720,9 @@ class GraphicsCatalog:
 
     def _claim_names_for(self, record: ImageRecord, absolute_path: str) -> _ImageClaims:
         stem = Path(record.path.relative_path).stem
-        sprites = []
-        ideas = []
-        decisions = []
+        sprites: list[str] = []
+        ideas: list[tuple[tuple[int, ...], str]] = []
+        decisions: list[str] = []
         if self._goals_root and _is_under(absolute_path, self._goals_root):
             sprites.append(f"GFX_focus_{stem}")
         if self._ideas_root and _is_under(absolute_path, self._ideas_root):
@@ -765,7 +766,7 @@ class GraphicsCatalog:
         return _absolute_key(declaration.texture_path.resolve(self._source_roots))
 
     def _declared_names_at(self, absolute_path: str) -> set[str]:
-        names = set()
+        names: set[str] = set()
         for key in _absolute_candidates(absolute_path):
             names.update(self._declared_names_by_texture.get(key, ()))
         return names
@@ -881,28 +882,28 @@ class GraphicsCatalog:
             if _stamp_from_stat(stat) != record.stamp:
                 current = False
 
-        for record in snapshot.gfx_files:
+        for gfx_record in snapshot.gfx_files:
             self.last_metrics.gfx_file_stats += 1
             try:
-                stat = os.stat(record.path.resolve(source_roots))
+                stat = os.stat(gfx_record.path.resolve(source_roots))
             except KeyError, OSError:
                 current = False
                 continue
-            if _stamp_from_stat(stat) != record.stamp:
+            if _stamp_from_stat(stat) != gfx_record.stamp:
                 current = False
 
         # Stat the known image paths too. Directory mtimes don't change when a
         # file is overwritten in place, so an image edit that keeps the same
         # name would otherwise leave a stale FileStamp — and that stamp is the
         # thumbnail cache key. Restatting is cheaper than a full rescan.
-        for record in snapshot.images:
+        for image_record in snapshot.images:
             self.last_metrics.image_stats += 1
             try:
-                stat = os.stat(record.path.resolve(source_roots))
+                stat = os.stat(image_record.path.resolve(source_roots))
             except KeyError, OSError:
                 current = False
                 continue
-            if _stamp_from_stat(stat) != record.stamp:
+            if _stamp_from_stat(stat) != image_record.stamp:
                 current = False
         return current
 

--- a/src/hoi4cm/models/focus.py
+++ b/src/hoi4cm/models/focus.py
@@ -6,6 +6,17 @@ class Focus:
 
     _next = 0
 
+    # Set only when a focus is built from a parsed file; used to preserve the
+    # original coordinates across edits. Declared here (no default) so mypy
+    # knows they exist while `hasattr` still reports them absent on fresh
+    # focuses.
+    _raw_gx: int | None
+    _raw_gy: int | None
+    _rel_dx: int | None
+    _rel_dy: int | None
+    _joint_extra: str
+    _script_extras: dict[str, object] | None
+
     def __init__(self, x=0, y=0):
         Focus._next += 1
         self.id = Focus._next
@@ -14,7 +25,7 @@ class Focus:
         self.gfx = "GFX_goal_generic_political_pressure"
         self.x = x
         self.y = y
-        self.cost = 10
+        self.cost: int | float = 10
         self.desc = ""
         self.effects = []  # [{"type":str,"fields":{name:val}}]
         self.prereqs = []  # [[fid,...]] AND of OR-groups

--- a/src/hoi4cm/script/effects.py
+++ b/src/hoi4cm/script/effects.py
@@ -13,7 +13,10 @@ __all__ = ["render_effect"]
 def render_effect(eff: Mapping[str, object]) -> str:
     """Render a single effect as HOI4 code (3-tab indent, in completion_reward)."""
     t = eff.get("type", "")
-    f = eff.get("fields", {})
+    if not isinstance(t, str):
+        t = ""
+    fields = eff.get("fields", {})
+    f: Mapping[str, object] = fields if isinstance(fields, Mapping) else {}
     IND = "\t\t\t"
 
     def block(name, pairs):
@@ -34,14 +37,16 @@ def render_effect(eff: Mapping[str, object]) -> str:
                 ("category", g("category", "infantry_weapons")),
             ],
         ),
-        "add_popularity": lambda: block(
-            "add_popularity",
-            [
-                ("ideology", g("ideology", "democratic")),
-                ("popularity", g("popularity", "0.05")),
-            ],
-        )
-        + f"\n{IND}recalculate_party = yes",
+        "add_popularity": lambda: (
+            block(
+                "add_popularity",
+                [
+                    ("ideology", g("ideology", "democratic")),
+                    ("popularity", g("popularity", "0.05")),
+                ],
+            )
+            + f"\n{IND}recalculate_party = yes"
+        ),
         "set_politics": lambda: block(
             "set_politics",
             [
@@ -125,18 +130,18 @@ def render_effect(eff: Mapping[str, object]) -> str:
         "create_unit": lambda: (
             f"{IND}create_unit = {{\n"
             f'{IND}\tdivision = "name = \\"'
-            f"{g('division_name','1st Infantry Division')}"
+            f"{g('division_name', '1st Infantry Division')}"
             f'\\" '
             f'division_template = \\"'
-            f"{g('division_template','Infantry Division')}"
+            f"{g('division_template', 'Infantry Division')}"
             f'\\" '
-            f"start_experience_factor = {g('start_experience_factor','0.2')}\"\n"
-            f"{IND}\towner = {g('owner','ROOT')}\n"
+            f'start_experience_factor = {g("start_experience_factor", "0.2")}"\n'
+            f"{IND}\towner = {g('owner', 'ROOT')}\n"
             f"{IND}}}"
         ),
         "set_technology": lambda: (
-            f'{IND}set_technology = {{ {g("tech_id","infantry_weapons1")} = '
-            f'{"1" if g("researched","yes") == "yes" else "0"} }}'
+            f"{IND}set_technology = {{ {g('tech_id', 'infantry_weapons1')} = "
+            f"{'1' if g('researched', 'yes') == 'yes' else '0'} }}"
         ),
         "modify_timed_idea": lambda: block(
             "modify_timed_idea",
@@ -148,7 +153,7 @@ def render_effect(eff: Mapping[str, object]) -> str:
         ),
         "division_template": lambda: (
             f"{IND}division_template = {{\n"
-            f'{IND}\tname = "{g("name","Infantry Division")}"\n'
+            f'{IND}\tname = "{g("name", "Infantry Division")}"\n'
             f"{IND}\tregiments = {{\n"
             + "\n".join(
                 f"{IND}\t\t{ln.strip()}"
@@ -160,85 +165,84 @@ def render_effect(eff: Mapping[str, object]) -> str:
             + f"\n{IND}\t}}\n"
             f"{IND}}}"
         ),
-        "load_oob": lambda: f'{IND}load_oob = "{g("file","TAG_1936")}"',
-        "set_oob": lambda: f'{IND}set_oob = "{g("file","TAG_1936")}"',
+        "load_oob": lambda: f'{IND}load_oob = "{g("file", "TAG_1936")}"',
+        "set_oob": lambda: f'{IND}set_oob = "{g("file", "TAG_1936")}"',
         "log": lambda: f'{IND}log = "{g("text")}"',
         "set_variable": lambda: (
-            f'{IND}set_variable = {{ {g("var","my_var")} = {g("value","0")} }}'
+            f"{IND}set_variable = {{ {g('var', 'my_var')} = {g('value', '0')} }}"
         ),
         "force_update_dynamic_modifier": lambda: (
             f"{IND}force_update_dynamic_modifier = yes"
         ),
         "unlock_decision_category_tooltip": lambda: (
-            f"{IND}unlock_decision_category_tooltip = "
-            f'{g("category","TAG_decisions")}'
+            f"{IND}unlock_decision_category_tooltip = {g('category', 'TAG_decisions')}"
         ),
         "unlock_decision_tooltip": lambda: (
-            f'{IND}unlock_decision_tooltip = {g("decision","TAG_decision")}'
+            f"{IND}unlock_decision_tooltip = {g('decision', 'TAG_decision')}"
         ),
         "ingame_update_setup": lambda: f"{IND}ingame_update_setup = yes",
         # MD scripted effects
         "md_modify_treasury": lambda: (
             f"{IND}set_temp_variable = {{ "
-            f"treasury_change = {g('amount','-10.00')} }}\n"
+            f"treasury_change = {g('amount', '-10.00')} }}\n"
             f"{IND}modify_treasury_effect = yes"
         ),
         "md_modify_debt": lambda: (
-            f"{IND}set_temp_variable = {{ debt_change = {g('amount','0.1')} }}\n"
+            f"{IND}set_temp_variable = {{ debt_change = {g('amount', '0.1')} }}\n"
             f"{IND}modify_debt_effect = yes"
         ),
         "md_modify_international_investment": lambda: (
             f"{IND}set_temp_variable = {{ "
-            f"int_investment_change = {g('amount','0.1')} }}\n"
+            f"int_investment_change = {g('amount', '0.1')} }}\n"
             f"{IND}modify_international_investment_effect = yes"
         ),
         "md_modify_corporate_tax": lambda: (
-            f"{IND}set_temp_variable = {{ corp_change = {g('amount','2')} }}\n"
+            f"{IND}set_temp_variable = {{ corp_change = {g('amount', '2')} }}\n"
             f"{IND}modify_corporate_tax_rate_effect = yes"
         ),
         "md_modify_population_tax": lambda: (
-            f"{IND}set_temp_variable = {{ pop_change = {g('amount','2')} }}\n"
+            f"{IND}set_temp_variable = {{ pop_change = {g('amount', '2')} }}\n"
             f"{IND}modify_population_tax_rate_effect = yes"
         ),
         "md_flat_productivity": lambda: (
             f"{IND}set_temp_variable = {{ "
-            f"temp_productivity_change = {g('amount','0.025')} }}\n"
+            f"temp_productivity_change = {g('amount', '0.025')} }}\n"
             f"{IND}flat_productivity_change_effect = yes"
         ),
-        "md_economic_cycle": lambda: f"{IND}{g('cycle','stable_growth')} = yes",
+        "md_economic_cycle": lambda: f"{IND}{g('cycle', 'stable_growth')} = yes",
         "md_gov_spending": lambda: (
-            f"{IND}{g('action','increase_social_spending')} = yes"
+            f"{IND}{g('action', 'increase_social_spending')} = yes"
         ),
         "md_build_random": lambda: (
             f"{IND}set_temp_variable = {{ "
-            f"treasury_change = {g('treasury_change','-7.50')} }}\n"
+            f"treasury_change = {g('treasury_change', '-7.50')} }}\n"
             f"{IND}modify_treasury_effect = yes\n"
-            f"{IND}{g('effect','one_random_industrial_complex')} = yes"
+            f"{IND}{g('effect', 'one_random_industrial_complex')} = yes"
         ),
         "md_enrichment_facility": lambda: (
-            f"{IND}set_temp_variable = {{ temp_change = {g('count','1')} }}\n"
+            f"{IND}set_temp_variable = {{ temp_change = {g('count', '1')} }}\n"
             f"{IND}build_enrichment_facilities_effect = yes"
         ),
         "md_battery_park": lambda: (
-            f"{IND}set_temp_variable = {{ temp_change = {g('count','1')} }}\n"
+            f"{IND}set_temp_variable = {{ temp_change = {g('count', '1')} }}\n"
             f"{IND}build_battery_park_effect = yes"
         ),
         "md_coalition_add": lambda: (
-            f"{IND}set_temp_variable = {{ add_col_one = {g('party_index','5')} }}\n"
+            f"{IND}set_temp_variable = {{ add_col_one = {g('party_index', '5')} }}\n"
             f"{IND}add_coalition_members_effect = yes"
         ),
         "md_coalition_remove": lambda: (
             f"{IND}set_temp_variable = {{ "
-            f"remove_col_one = {g('party_index','5')} }}\n"
+            f"remove_col_one = {g('party_index', '5')} }}\n"
             f"{IND}remove_coalition_members_effect = yes"
         ),
         "md_domestic_influence": lambda: (
-            f"{IND}set_temp_variable = {{ percent_change = {g('percent','10')} }}\n"
+            f"{IND}set_temp_variable = {{ percent_change = {g('percent', '10')} }}\n"
             f"{IND}change_domestic_influence_percentage = yes"
         ),
         "md_eurosceptic_all": lambda: (
             f"{IND}set_temp_variable = {{ "
-            f"modify_eurosceptic = {g('amount','-0.05')} }}\n"
+            f"modify_eurosceptic = {g('amount', '-0.05')} }}\n"
             f"{IND}EU_eurosceptic_change = yes"
         ),
         # MD Budget — individual yes-call entries
@@ -246,24 +250,16 @@ def render_effect(eff: Mapping[str, object]) -> str:
         "decrease_centralization": lambda: f"{IND}decrease_centralization = yes",
         "increase_social_spending": lambda: f"{IND}increase_social_spending = yes",
         "decrease_social_spending": lambda: f"{IND}decrease_social_spending = yes",
-        "increase_education_budget": lambda: (f"{IND}increase_education_budget = yes"),
-        "decrease_education_budget": lambda: (f"{IND}decrease_education_budget = yes"),
-        "increase_healthcare_budget": lambda: (
-            f"{IND}increase_healthcare_budget = yes"
-        ),
-        "decrease_healthcare_budget": lambda: (
-            f"{IND}decrease_healthcare_budget = yes"
-        ),
+        "increase_education_budget": lambda: f"{IND}increase_education_budget = yes",
+        "decrease_education_budget": lambda: f"{IND}decrease_education_budget = yes",
+        "increase_healthcare_budget": lambda: f"{IND}increase_healthcare_budget = yes",
+        "decrease_healthcare_budget": lambda: f"{IND}decrease_healthcare_budget = yes",
         "increase_policing_budget": lambda: f"{IND}increase_policing_budget = yes",
         "decrease_policing_budget": lambda: f"{IND}decrease_policing_budget = yes",
         "increase_exports": lambda: f"{IND}increase_exports = yes",
         "decrease_exports": lambda: f"{IND}decrease_exports = yes",
-        "increase_military_spending": lambda: (
-            f"{IND}increase_military_spending = yes"
-        ),
-        "decrease_military_spending": lambda: (
-            f"{IND}decrease_military_spending = yes"
-        ),
+        "increase_military_spending": lambda: f"{IND}increase_military_spending = yes",
+        "decrease_military_spending": lambda: f"{IND}decrease_military_spending = yes",
         "increase_economic_growth": lambda: f"{IND}increase_economic_growth = yes",
         "decrease_economic_growth": lambda: f"{IND}decrease_economic_growth = yes",
         "increase_corruption": lambda: f"{IND}increase_corruption = yes",
@@ -323,7 +319,7 @@ def render_effect(eff: Mapping[str, object]) -> str:
     }
     if t in _FACTION_OPINIONS:
         return (
-            f"{IND}set_temp_variable = {{ temp_opinion = {g('opinion','5')} }}\n"
+            f"{IND}set_temp_variable = {{ temp_opinion = {g('opinion', '5')} }}\n"
             f"{IND}{t} = yes"
         )
 
@@ -347,13 +343,15 @@ def render_effect(eff: Mapping[str, object]) -> str:
     if t in ("hidden_effect", "effect_tooltip"):
         raw = g("raw", "").strip()
         if not raw and "_list" in f:
-            raw = "\n".join(
-                f"{IND}\t{ik} = {iv}"
-                for item in f["_list"]
-                if isinstance(item, dict)
-                for ik, iv in item.items()
-                if not str(ik).startswith("_")
-            )
+            items = f["_list"]
+            if isinstance(items, list):
+                raw = "\n".join(
+                    f"{IND}\t{ik} = {iv}"
+                    for item in items
+                    if isinstance(item, dict)
+                    for ik, iv in item.items()
+                    if not str(ik).startswith("_")
+                )
         inner = "\n".join(f"{IND}\t{ln}" for ln in raw.splitlines())
         return f"{IND}{t} = {{\n{inner}\n{IND}}}"
 
@@ -381,45 +379,44 @@ def render_effect(eff: Mapping[str, object]) -> str:
         "modulo_temp_variable",
     }
     if t in _VAR_TWO_FIELD:
-        return f"{IND}{t} = {{ {g('var','my_var')} = {g('value','1')} }}"
+        return f"{IND}{t} = {{ {g('var', 'my_var')} = {g('value', '1')} }}"
 
     if t == "set_temp_variable":
         return (
             f"{IND}set_temp_variable = {{ "
-            f"{g('var','my_temp_var')} = {g('value','1')} }}"
+            f"{g('var', 'my_temp_var')} = {g('value', '1')} }}"
         )
 
     # single-arg variable ops (no block needed)
     if t in ("round_variable", "clear_variable"):
-        return f"{IND}{t} = {g('var','my_var')}"
+        return f"{IND}{t} = {g('var', 'my_var')}"
     if t in ("round_temp_variable",):
-        return f"{IND}{t} = {g('var','my_temp_var')}"
+        return f"{IND}{t} = {g('var', 'my_temp_var')}"
 
     # clamp = { var = { min = X max = Y } }
     if t == "clamp_variable":
         return (
-            f"{IND}clamp_variable = {{ {g('var','my_var')} = {{ "
-            f"min = {g('min','0')} max = {g('max','100')} }} }}"
+            f"{IND}clamp_variable = {{ {g('var', 'my_var')} = {{ "
+            f"min = {g('min', '0')} max = {g('max', '100')} }} }}"
         )
     if t == "clamp_temp_variable":
         return (
-            f"{IND}clamp_temp_variable = {{ {g('var','my_temp_var')} = {{ "
-            f"min = {g('min','0')} max = {g('max','100')} }} }}"
+            f"{IND}clamp_temp_variable = {{ {g('var', 'my_temp_var')} = {{ "
+            f"min = {g('min', '0')} max = {g('max', '100')} }} }}"
         )
 
     # set_variable_to_random / randomize_variable = { var = { max = X } }
     if t in ("set_variable_to_random", "randomize_variable"):
-        return f"{IND}{t} = {{ {g('var','my_var')} = {{ max = {g('max','10')} }} }}"
+        return f"{IND}{t} = {{ {g('var', 'my_var')} = {{ max = {g('max', '10')} }} }}"
     if t in ("set_temp_variable_to_random", "randomize_temp_variable"):
         return (
-            f"{IND}{t} = {{ {g('var','my_temp_var')} = {{ "
-            f"max = {g('max','10')} }} }}"
+            f"{IND}{t} = {{ {g('var', 'my_temp_var')} = {{ max = {g('max', '10')} }} }}"
         )
 
     if t == "add_dynamic_modifier":
         out = [
             f"{IND}add_dynamic_modifier = {{",
-            f"{IND}\tmodifier = {g('modifier','TAG_modifier')}",
+            f"{IND}\tmodifier = {g('modifier', 'TAG_modifier')}",
         ]
         sc = g("scope", "").strip()
         dy = g("days", "").strip()
@@ -451,7 +448,7 @@ def render_effect(eff: Mapping[str, object]) -> str:
     if t == "remove_dynamic_modifier":
         return (
             f"{IND}remove_dynamic_modifier = {{\n"
-            f"{IND}\tmodifier = {g('modifier','TAG_modifier')}\n"
+            f"{IND}\tmodifier = {g('modifier', 'TAG_modifier')}\n"
             f"{IND}}}"
         )
 
@@ -479,17 +476,17 @@ def render_effect(eff: Mapping[str, object]) -> str:
             return (
                 f"{IND}custom_effect_tooltip = {{\n"
                 f"{IND}\tlocalization_key = {loc_key}\n"
-                f"{IND}\tMODIFIER = {g('MODIFIER','TAG_modifier')}\n"
+                f"{IND}\tMODIFIER = {g('MODIFIER', 'TAG_modifier')}\n"
                 f"{IND}}}"
             )
-        return f"{IND}custom_effect_tooltip = {g('tooltip','my_tooltip_key')}"
+        return f"{IND}custom_effect_tooltip = {g('tooltip', 'my_tooltip_key')}"
 
     if t in (
         "md_small_expenditure",
         "md_medium_expenditure",
         "md_large_expenditure",
     ):
-        return f"{IND}{t.replace('md_','')} = yes"
+        return f"{IND}{t.replace('md_', '')} = yes"
 
     if t == "md_build_state":
         effect = g("effect", "one_state_industrial_complex")
@@ -520,85 +517,85 @@ def render_effect(eff: Mapping[str, object]) -> str:
 
     if t == "md_party_popularity":
         return (
-            f"{IND}set_temp_variable = {{ party_index = {g('party_index','2')} }}\n"
+            f"{IND}set_temp_variable = {{ party_index = {g('party_index', '2')} }}\n"
             f"{IND}set_temp_variable = {{ "
-            f"party_popularity_increase = {g('amount','0.10')} }}\n"
+            f"party_popularity_increase = {g('amount', '0.10')} }}\n"
             f"{IND}add_relative_party_popularity = yes"
         )
 
     if t == "md_change_ruling_party":
         return (
             f"{IND}set_temp_variable = {{ "
-            f"rul_party_temp = {g('rul_party_temp','2')} }}\n"
+            f"rul_party_temp = {g('rul_party_temp', '2')} }}\n"
             f"{IND}change_ruling_party_effect = yes\n"
             f"{IND}set_politics = {{\n"
-            f"{IND}\truling_party = {g('ruling_party','western')}\n"
-            f"{IND}\telections_allowed = {g('elections_allowed','no')}\n"
+            f"{IND}\truling_party = {g('ruling_party', 'western')}\n"
+            f"{IND}\telections_allowed = {g('elections_allowed', 'no')}\n"
             f"{IND}}}"
         )
 
     if t == "md_ban_party":
         return (
-            f"{IND}set_temp_variable = {{ party_index = {g('party_index','1')} }}\n"
+            f"{IND}set_temp_variable = {{ party_index = {g('party_index', '1')} }}\n"
             f"{IND}ban_party_scripted_call = yes"
         )
 
     if t == "md_unban_party":
         return (
-            f"{IND}set_temp_variable = {{ party_index = {g('party_index','1')} }}\n"
+            f"{IND}set_temp_variable = {{ party_index = {g('party_index', '1')} }}\n"
             f"{IND}unban_party_scripted_call = yes"
         )
 
     if t == "md_pp_loss":
-        return f"{IND}{g('duration','lose_pp_for_month')} = yes"
+        return f"{IND}{g('duration', 'lose_pp_for_month')} = yes"
 
     if t == "md_faction_opinion":
         return (
-            f"{IND}set_temp_variable = {{ temp_opinion = {g('opinion','5')} }}\n"
-            f"{IND}{g('faction','change_the_military_opinion')} = yes"
+            f"{IND}set_temp_variable = {{ temp_opinion = {g('opinion', '5')} }}\n"
+            f"{IND}{g('faction', 'change_the_military_opinion')} = yes"
         )
 
     if t == "md_influence_country":
         return (
-            f"{IND}set_temp_variable = {{ percent_change = {g('percent','5')} }}\n"
+            f"{IND}set_temp_variable = {{ percent_change = {g('percent', '5')} }}\n"
             f"{IND}set_temp_variable = {{ tag_index = ROOT }}\n"
             f"{IND}set_temp_variable = {{ "
-            f"influence_target = {g('target','GER')} }}\n"
+            f"influence_target = {g('target', 'GER')} }}\n"
             f"{IND}change_influence_percentage = yes"
         )
 
     if t == "md_eurosceptic_target":
         return (
             f"{IND}set_temp_variable = {{ "
-            f"modify_eurosceptic = {g('amount','0.05')} }}\n"
+            f"modify_eurosceptic = {g('amount', '0.05')} }}\n"
             f"{IND}set_temp_variable = {{ "
-            f"modify_eurosceptic_target = {g('target','GER')} }}\n"
+            f"modify_eurosceptic_target = {g('target', 'GER')} }}\n"
             f"{IND}eurosceptic_change = yes"
         )
 
     if t == "md_cart_strength":
         return (
             f"{IND}set_temp_variable = {{ "
-            f"cart_strength_change = {g('strength','2')} }}\n"
+            f"cart_strength_change = {g('strength', '2')} }}\n"
             f"{IND}set_temp_variable = {{ "
-            f"cart_influence_change = {g('influence','2')} }}\n"
+            f"cart_influence_change = {g('influence', '2')} }}\n"
             f"{IND}modify_cartel_variables_effect = yes"
         )
 
     if t == "md_relative_party_popularity":
         return (
-            f"{IND}set_temp_variable = {{ party_index = {g('party_index','1')} }}\n"
+            f"{IND}set_temp_variable = {{ party_index = {g('party_index', '1')} }}\n"
             f"{IND}set_temp_variable = {{ "
-            f"party_popularity_increase = {g('amount','0.02')} }}\n"
+            f"party_popularity_increase = {g('amount', '0.02')} }}\n"
             f"{IND}set_temp_variable = {{ "
-            f"temp_outlook_increase = {g('temp_outlook_increase','0.02')} }}\n"
+            f"temp_outlook_increase = {g('temp_outlook_increase', '0.02')} }}\n"
             f"{IND}add_relative_party_popularity = yes"
         )
 
     if t.startswith("md_modifier_"):
         return (
             f"{IND}# MD MODIFIER (place inside idea modifier block):\n"
-            f"{IND}# {g('modifier','')} = {g('value','0.05')}"
+            f"{IND}# {g('modifier', '')} = {g('value', '0.05')}"
         )
 
     # ── Scope / if / else blocks ───────────────────────────────
@@ -722,7 +719,6 @@ def render_effect(eff: Mapping[str, object]) -> str:
         return [f"{T}{k} = {v}"]
 
     if t in _SCOPE_TYPES:
-
         out = [f"{IND}{t} = {{"]
         limit_raw = str(g("limit", "")).strip()
         if limit_raw:
@@ -767,6 +763,8 @@ def render_effect(eff: Mapping[str, object]) -> str:
 
     # ── Generic fallback ───────────────────────────────────────
     defn = EFFECT_DEFS.get(t, {})
+    if not isinstance(defn, Mapping):
+        defn = {}
     fl = defn.get("fields", [])
     fname = fl[0][0] if fl else None
     if fname and len(fl) == 1:

--- a/src/hoi4cm/script/syntax.py
+++ b/src/hoi4cm/script/syntax.py
@@ -86,6 +86,7 @@ def tokenize(source: str) -> list[str]:
 def parse_block(tokens: Sequence[str], position: int) -> tuple[dict[str, object], int]:
     """Parse a brace block, collecting duplicate keys into ordered lists."""
     result: dict[str, object] = {}
+    value: object
     position += 1
     while position < len(tokens) and tokens[position] != "}":
         key = tokens[position]

--- a/src/hoi4cm/ui/checklist.py
+++ b/src/hoi4cm/ui/checklist.py
@@ -4,6 +4,7 @@ import re
 import tkinter as tk
 from collections.abc import Hashable, Sequence
 from dataclasses import dataclass
+from typing import Literal
 
 from hoi4cm.ui.focus_list import _PooledList
 from hoi4cm.ui.theme import BG_CARD, BG_DARK, BORDER_G, TEXT, TEXT_DIM
@@ -115,7 +116,7 @@ class _ChecklistRow:
             )
             btn.pack(side="left")
             self.type_buttons.append(btn)
-        self._palette = [
+        self._palette: list[tk.Widget] = [
             self.frame,
             self.checkbox,
             self.name_label,
@@ -128,7 +129,7 @@ class _ChecklistRow:
         self.key = item.key
         bg = LOADED_BG if item.already else BG_CARD
         self._set_background(bg)
-        state = "disabled" if item.already else "normal"
+        state: Literal["disabled", "normal"] = "disabled" if item.already else "normal"
         self.checkbox.config(variable=item.checked, state=state)
         self.name_label.config(text=item.name, fg=TEXT_DIM if item.already else TEXT)
         self.marker.config(text=self._loaded_marker if item.already else "")
@@ -140,7 +141,7 @@ class _ChecklistRow:
 
     def _set_background(self, color: str) -> None:
         for widget in self._palette:
-            widget.configure(bg=color)
+            widget["bg"] = color
 
 
 class VirtualChecklist(_PooledList):

--- a/src/hoi4cm/ui/focus_list.py
+++ b/src/hoi4cm/ui/focus_list.py
@@ -9,6 +9,13 @@ from typing import Protocol
 
 from hoi4cm.ui.theme import BG_PANEL, BLUE, TEXT_DIM
 
+
+class _Revisioned(Protocol):
+    """Minimal shape the cache keys on: a document with a revision counter."""
+
+    revision: int
+
+
 SELECTED_BG = "#1e2d4a"
 SELECTED_FG = "#93c5fd"
 HOVER_BG = "#253550"
@@ -34,13 +41,13 @@ class FocusListCache:
     """
 
     def __init__(self) -> None:
-        self._doc: object = None
+        self._doc: _Revisioned | None = None
         self._revision: int | None = None
         self._items: tuple[FocusListItem, ...] = ()
 
     def get(
         self,
-        doc,
+        doc: _Revisioned,
         build: Callable[[], Iterable[FocusListItem]],
     ) -> tuple[FocusListItem, ...]:
         if self._doc is not doc or self._revision != doc.revision:
@@ -196,7 +203,7 @@ class _PooledList[T: _PooledRow](tk.Frame, ABC):
         self._items: tuple = ()
         self._rows: list[T] = []
         self._row_windows: list[int] = []
-        self._refresh_job = None
+        self._refresh_job: str | None = None
 
         self.canvas = tk.Canvas(
             self,
@@ -301,7 +308,7 @@ class _PooledList[T: _PooledRow](tk.Frame, ABC):
         self.scrollbar.set(first, last)
         self._schedule_refresh()
 
-    def _scrollbar(self, *args: float) -> None:
+    def _scrollbar(self, *args: str) -> None:
         self.canvas.yview(*args)
         self._schedule_refresh()
 

--- a/src/hoi4cm/ui/image_broker.py
+++ b/src/hoi4cm/ui/image_broker.py
@@ -167,6 +167,7 @@ class ImageBroker:
         )
         cache_key = _cache_key(key)
         on_owner_thread = threading.get_ident() == self._owner_thread
+        pending: _Pending | None
         with self._lock:
             if self._closed:
                 return None
@@ -196,11 +197,7 @@ class ImageBroker:
                 self._pending[key] = pending
                 future = self._executor.submit(self._decode, key)
                 pending.future = future
-                future.add_done_callback(
-                    lambda completed, image_key=key: self._queue_result(
-                        image_key, completed
-                    )
-                )
+                future.add_done_callback(self._queue_result_callback(key))
             pending.subscribers[owner] = _Subscriber(asset.generation, callback)
             self._owner_requests[owner] = key
         return None
@@ -255,6 +252,11 @@ class ImageBroker:
             drained += 1
             self._finish(key, decoded, realized=realized)
         return drained
+
+    def _queue_result_callback(
+        self, key: _ImageKey
+    ) -> Callable[[Future[object | None]], None]:
+        return lambda completed: self._queue_result(key, completed)
 
     def _decode(self, key: _ImageKey) -> object | None:
         try:

--- a/src/hoi4cm/ui/scene_index.py
+++ b/src/hoi4cm/ui/scene_index.py
@@ -5,6 +5,8 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from math import floor
 
+from hoi4cm.models.focus import Focus
+
 
 @dataclass(frozen=True)
 class SceneEdge:
@@ -31,7 +33,7 @@ class SceneIndex:
         self._edge_bounds: list[tuple[float, float, float, float]] = []
         self._edges_by_focus: dict[int, list[int]] = {}
 
-    def rebuild(self, focuses: Mapping[int, object]) -> None:
+    def rebuild(self, focuses: Mapping[int, Focus]) -> None:
         focus_cells: dict[tuple[int, int], list[int]] = defaultdict(list)
         focus_order: dict[int, int] = {}
         positions: dict[int, tuple[float, float]] = {}
@@ -76,7 +78,7 @@ class SceneIndex:
         self.revision += 1
 
     def _place_edge(
-        self, index: int, edge: SceneEdge, focuses: Mapping[int, object]
+        self, index: int, edge: SceneEdge, focuses: Mapping[int, Focus]
     ) -> None:
         source = focuses[edge.source_id]
         target = focuses[edge.target_id]
@@ -114,7 +116,7 @@ class SceneIndex:
                 else:
                     del self._edge_cells[(cell_x, cell_y)]
 
-    def ensure(self, focuses: Mapping[int, object], *, validate: bool) -> bool:
+    def ensure(self, focuses: Mapping[int, Focus], *, validate: bool) -> bool:
         document_revision = getattr(focuses, "revision", None)
         changed = document_revision != self._document_revision
         if validate and not changed:
@@ -124,7 +126,7 @@ class SceneIndex:
             return True
         return False
 
-    def update_focus(self, focuses: Mapping[int, object], focus_id: int) -> None:
+    def update_focus(self, focuses: Mapping[int, Focus], focus_id: int) -> None:
         """Apply a single focus's geometry move without a full rebuild.
 
         Caller contract: only *focus_id*'s x/y changed since the last rebuild
@@ -195,7 +197,7 @@ class SceneIndex:
         return self._edges
 
     @staticmethod
-    def signature(focuses: Mapping[int, object]) -> tuple[object, ...]:
+    def signature(focuses: Mapping[int, Focus]) -> tuple[object, ...]:
         return tuple(
             (
                 focus_id,

--- a/src/hoi4cm/ui/thumbnail_grid.py
+++ b/src/hoi4cm/ui/thumbnail_grid.py
@@ -102,8 +102,8 @@ class VirtualThumbnailGrid(tk.Frame):
         self._live: dict[int, tuple[int, int, int]] = {}
         self._selected_index: int | None = None
         self._generation = 0
-        self._refresh_job = None
-        self._poll_job = None
+        self._refresh_job: str | None = None
+        self._poll_job: str | None = None
         self._broker = ImageBroker(
             get_executor(self),
             generation=lambda: self._generation,
@@ -239,9 +239,7 @@ class VirtualThumbnailGrid(tk.Frame):
             item.path,
             transform=self._transform,
             owner=owner,
-            callback=lambda photo, i=index, g=self._generation: self._show_image(
-                i, g, photo
-            ),
+            callback=self._image_callback(index, self._generation),
         )
         if image is not None:
             self._show_image(index, self._generation, image)
@@ -275,15 +273,22 @@ class VirtualThumbnailGrid(tk.Frame):
             stamp = FileStamp(0, 0, 0)
         return AssetRef("absolute", item.path, stamp, self._generation)
 
+    def _image_callback(self, index: int, generation: int) -> Callable[[object], None]:
+        return lambda photo: self._show_image(index, generation, photo)
+
+    def _click(self, index: int) -> Callable[[object], None]:
+        return lambda _event: self.select(index)
+
+    def _activate_click(self, index: int) -> Callable[[object], None]:
+        return lambda _event: self._activate(index)
+
     def _bind_items(self, index: int) -> None:
         for canvas_id in self._live[index]:
-            self.canvas.tag_bind(
-                canvas_id, "<Button-1>", lambda _event, i=index: self.select(i)
-            )
+            self.canvas.tag_bind(canvas_id, "<Button-1>", self._click(index))
             self.canvas.tag_bind(
                 canvas_id,
                 "<Double-Button-1>",
-                lambda _event, i=index: self._activate(i),
+                self._activate_click(index),
             )
 
     def _activate(self, index: int) -> None:
@@ -319,7 +324,7 @@ class VirtualThumbnailGrid(tk.Frame):
         if self._refresh_job is None:
             self._refresh_job = self.after_idle(self.refresh)
 
-    def _set_scrollbar(self, first: str, last: str) -> None:
+    def _set_scrollbar(self, first: float, last: float) -> None:
         self._scrollbar_widget.set(first, last)
         self._schedule_refresh()
 

--- a/src/hoi4cm/wizards/_image_loader.py
+++ b/src/hoi4cm/wizards/_image_loader.py
@@ -5,6 +5,7 @@ import threading
 import tkinter as tk
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
+from functools import partial
 from typing import Protocol, TypeVar
 
 from hoi4cm.ui.lifecycle import find_lifecycle
@@ -100,7 +101,7 @@ class TkImageLoader:
                         generation,
                         decoded,
                         realizer,
-                        lambda image, value=item: apply(value, image),
+                        partial(apply, item),
                     )
                 )
             self._results.put(_BatchDone(generation))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,20 +6,31 @@ of quietly dropping every widget test from the run.
 """
 
 import os
-import tkinter as tk
+import types
 
 import pytest
+
+tk: types.ModuleType | None
+try:
+    import tkinter as tk
+except ImportError:
+    tk = None
 
 
 @pytest.fixture
 def tk_root():
     """A live Tk root, destroyed after the test.
 
-    Skips when no display is reachable, so the suite still runs on a
-    headless box. `HOI4CM_REQUIRE_TK=1` (set by the CI test job) turns that
-    skip into a failure, so a broken Xvfb shows up as a red build rather
-    than a green one with every Tk test silently skipped.
+    Skips when no display is reachable (or tkinter itself is missing), so the
+    suite still runs on a headless box. `HOI4CM_REQUIRE_TK=1` (set by the CI
+    test job) turns that skip into a failure, so a broken Xvfb or missing
+    python3-tk shows up as a red build rather than a green one with every Tk
+    test silently skipped.
     """
+    if tk is None:
+        if os.environ.get("HOI4CM_REQUIRE_TK") == "1":
+            pytest.fail("HOI4CM_REQUIRE_TK=1 but tkinter is unavailable")
+        pytest.skip("tkinter is unavailable")
     try:
         root = tk.Tk()
     except tk.TclError as exc:

--- a/tests/test_focus_list.py
+++ b/tests/test_focus_list.py
@@ -1,3 +1,5 @@
+from collections.abc import Hashable
+
 import pytest
 
 from hoi4cm.ui.focus_list import (
@@ -158,7 +160,7 @@ def test_pool_always_holds_every_visible_row(
 
 
 def test_tk_list_reuses_bounded_pool_and_updates_only_selected_rows(tk_root) -> None:
-    selected = []
+    selected: list[Hashable] = []
     tk_root.geometry("220x180")
     focus_list = VirtualFocusList(tk_root, on_select=selected.append)
     focus_list.pack(fill="both", expand=True)

--- a/tests/test_graphics_catalog.py
+++ b/tests/test_graphics_catalog.py
@@ -700,7 +700,7 @@ def test_incremental_fuzz_matches_full_refresh(graphics_tree, tmp_path):
                 f'spriteType = {{ name = "{name}" texturefile = "{tex}" }}\n'
                 for name, tex in declarations
             )
-            with open(path, "w") as stream:
+            with open(path, "w", encoding="utf-8") as stream:
                 stream.write(text)
             applied.apply(catalog.note_written(path, read_text=read_file))
         check()

--- a/tests/test_image_broker.py
+++ b/tests/test_image_broker.py
@@ -40,7 +40,7 @@ def test_inflight_requests_are_deduplicated_by_stamp_and_transform() -> None:
             realizer=lambda image: image,
             pillow_available=True,
         )
-        results = []
+        results: list[object] = []
         broker.request(_asset(), "/tmp/icon.png", owner="a", callback=results.append)
         broker.request(_asset(), "/tmp/icon.png", owner="b", callback=results.append)
         gate.set()
@@ -86,8 +86,8 @@ def test_changed_stamp_or_transform_starts_distinct_work() -> None:
 def test_stale_generation_is_not_realized_or_delivered() -> None:
     generation = 1
     gate = threading.Event()
-    realized = []
-    delivered = []
+    realized: list[object] = []
+    delivered: list[object] = []
 
     def decode(path: str, transform: ImageTransform) -> object:
         gate.wait(timeout=2)
@@ -114,8 +114,8 @@ def test_new_generation_does_not_reuse_stale_inflight_decode() -> None:
     generation = 1
     gate = threading.Event()
     decode_count = 0
-    old_results = []
-    new_results = []
+    old_results: list[object] = []
+    new_results: list[object] = []
 
     def decode(path: str, transform: ImageTransform) -> object:
         nonlocal decode_count
@@ -253,7 +253,7 @@ def test_release_cancels_queued_decode() -> None:
 
 
 def test_failed_decode_delivers_none_to_subscribers() -> None:
-    delivered = []
+    delivered: list[object] = []
 
     def decode(path: str, transform: ImageTransform) -> object:
         raise OSError("boom")
@@ -271,7 +271,7 @@ def test_failed_decode_delivers_none_to_subscribers() -> None:
 
         # A later request for the same failed asset is served from the cache
         # and still delivers None rather than hanging on a placeholder.
-        cached = []
+        cached: list[object] = []
         broker.request(_asset(), "/tmp/icon.png", owner="b", callback=cached.append)
         broker.drain()
 
@@ -362,7 +362,7 @@ def test_missing_pillow_does_not_submit_or_realize() -> None:
 
 def test_close_drops_inflight_owner_callback_without_waiting() -> None:
     gate = threading.Event()
-    delivered = []
+    delivered: list[object] = []
 
     def decode(path: str, transform: ImageTransform) -> object:
         gate.wait(timeout=2)

--- a/tests/test_import_coverage.py
+++ b/tests/test_import_coverage.py
@@ -27,7 +27,11 @@ def _run_in_subprocess(code):
     repo_root = str(Path(__file__).resolve().parent.parent)
     env = {**os.environ, "PYTHONPATH": os.pathsep.join([repo_root, *sys.path])}
     return subprocess.run(
-        [sys.executable, "-c", code], capture_output=True, text=True, env=env
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
     )
 
 

--- a/tests/test_import_order.py
+++ b/tests/test_import_order.py
@@ -14,6 +14,7 @@ def test_ui_import_before_core_facade_has_no_cycle():
         capture_output=True,
         text=True,
         env=env,
+        check=True,
     )
 
     assert result.returncode == 0, result.stderr

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -4,13 +4,24 @@ import threading
 import time
 from collections.abc import Callable
 from concurrent.futures import Executor, Future
+from typing import cast
 
-from hoi4cm.ui.lifecycle import ApplicationLifecycle, DaemonThreadPoolExecutor
+from hoi4cm.ui.lifecycle import (
+    ApplicationLifecycle,
+    DaemonThreadPoolExecutor,
+    TclInterpreter,
+)
+
+
+class _FakeTk:
+    def call(self, *args: object) -> object:
+        return ()
 
 
 class FakeTkOwner:
     def __init__(self) -> None:
         self.exists = True
+        self.tk = cast(TclInterpreter, _FakeTk())
         self.callbacks: dict[object, Callable[[], None]] = {}
         self.cancelled: list[object] = []
 
@@ -25,6 +36,14 @@ class FakeTkOwner:
 
     def winfo_exists(self) -> int:
         return int(self.exists)
+
+    def bind(
+        self,
+        sequence: str,
+        callback: Callable[[object], None],
+        add: str | None = None,
+    ) -> object:
+        return None
 
 
 class FakeExecutor(Executor):

--- a/tests/test_wizard_image_loader.py
+++ b/tests/test_wizard_image_loader.py
@@ -23,6 +23,14 @@ class FakeOwner:
     def after_cancel(self, identifier: object) -> None:
         self.cancelled.append(identifier)
 
+    def bind(
+        self,
+        sequence: str,
+        callback: Callable[[object], None],
+        add: str | None = None,
+    ) -> object:
+        return None
+
     def run_next(self) -> None:
         self.callbacks.pop(0)()
 
@@ -77,10 +85,14 @@ def test_invalidated_callback_is_not_realized_or_applied() -> None:
         gate.wait(timeout=2)
         return object()
 
+    def realize(decoded: object) -> object:
+        realized.append(decoded)
+        return decoded
+
     loader.submit(
         "image",
         decode,
-        realizer=lambda image: realized.append(image) or image,
+        realizer=realize,
         apply=lambda item, image: applied.append(image),
     )
     loader.invalidate()
@@ -105,10 +117,14 @@ def test_destroyed_owner_drops_queued_callback() -> None:
         decoded.set()
         return object()
 
+    def realize(decoded: object) -> object:
+        realized.append(decoded)
+        return decoded
+
     loader.submit(
         "image",
         decode,
-        realizer=lambda image: realized.append(image) or image,
+        realizer=realize,
         apply=lambda item, image: applied.append(image),
     )
     assert decoded.wait(timeout=2)


### PR DESCRIPTION
## Summary

Adds pre-commit, mypy and pylint to the dev toolchain alongside the existing ruff/black gates, and fixes the type and lint issues they surface.

- **`.pre-commit-config.yaml`** (new): ruff (`--fix`), black (`--force-exclude` for the monolith/build), mypy, pylint, plus hygiene hooks (trailing whitespace, EOF, YAML/TOML/merge-conflict, AST).
- **`pyproject.toml`**: added `mypy`, `pylint`, `pre-commit` to the `dev` extra; added `[tool.mypy]` and `[tool.pylint]` config.
- **CI**: added `Mypy` and `Pylint` steps to the lint job.
- **`AGENTS.md`**: documented the new commands and lint scope.

## Bug fixes surfaced by the new tools

- Fixed ~20 Python 2-style `except A, B:` clauses that are invalid in Python 3. These were reverted to the PEP 758 unparenthesized form (valid in Python 3.14, which black 26.1+ enforces). mypy 2.3.0 can't parse PEP 758 yet, so those files are excluded from mypy until it adds support — tracked in **#68**.
- Fixed 71 mypy type errors in the package and 27 in tests (dynamic `Focus` attrs, `object`-typed dicts, tkinter callback typing, test fakes missing protocol members).
- Fixed pylint findings (logging f-strings, `subprocess.run(check=...)`, `open(encoding=...)`).
- Made `tests/conftest.py` skip Tk tests when tkinter is missing (still fails in CI via `HOI4CM_REQUIRE_TK=1`).

## Verification

- `mypy` — clean (117 files; 7 PEP 758 files excluded, see #68)
- `pylint src/hoi4cm tests` — 10.00/10
- `ruff check .` — clean
- `black --check .` — clean
- `pytest` — needs `python3-tk` for Python 3.14 (not installed on this machine; the suite imports tkinter directly)

## Note

`build/build.py` and `build/patch_spec_encrypted.py` carry cosmetic ruff auto-fix changes (import sorting, f-string removal). They're excluded from CI linting and are valid Python; happy to drop them if you'd prefer the build scripts untouched.