### PR TITLE
Close sqlite connections in WorkspaceCache and ScanCache

### DIFF
--- a/src/hoi4cm/mod/scan_cache.py
+++ b/src/hoi4cm/mod/scan_cache.py
@@ -48,6 +48,7 @@ class ScanCache:
 
     def __init__(self, mod_root):
         self._conn = None
+        conn = None
         try:
             path = database_path(mod_root)
             os.makedirs(os.path.dirname(path), exist_ok=True)
@@ -56,6 +57,8 @@ class ScanCache:
             conn.commit()
             self._conn = conn
         except Exception as e:  # pragma: no cover - depends on FS/db state
+            if conn is not None:
+                conn.close()
             _log.warning("scan cache disabled (open failed): %s", e)
             self._conn = None
 

--- a/src/hoi4cm/mod/workspace_cache.py
+++ b/src/hoi4cm/mod/workspace_cache.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import contextlib
 import json
 import sqlite3
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
 from pathlib import Path
 
 from hoi4cm.core.logger import get_logger
@@ -31,7 +32,7 @@ class WorkspaceCache:
         config_fingerprint: str,
     ) -> dict[str, object] | None:
         try:
-            with self._connect() as connection:
+            with self._connection() as connection:
                 row = connection.execute(
                     "SELECT schema_version, root_identity, data "
                     "FROM graphics_snapshot WHERE config_fingerprint = ?",
@@ -59,7 +60,7 @@ class WorkspaceCache:
     ) -> None:
         try:
             encoded = json.dumps(data, ensure_ascii=False, separators=(",", ":"))
-            with self._connect() as connection:
+            with self._connection() as connection:
                 connection.execute(
                     "INSERT OR REPLACE INTO graphics_snapshot "
                     "(config_fingerprint, schema_version, root_identity, data) "
@@ -73,6 +74,15 @@ class WorkspaceCache:
                 )
         except (OSError, TypeError, ValueError, sqlite3.Error) as error:
             _log.debug("graphics cache write failed: %s", error)
+
+    @contextlib.contextmanager
+    def _connection(self) -> Iterator[sqlite3.Connection]:
+        connection = self._connect()
+        try:
+            with connection:
+                yield connection
+        finally:
+            connection.close()
 
     def _connect(self) -> sqlite3.Connection:
         self._database_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_graphics_catalog.py
+++ b/tests/test_graphics_catalog.py
@@ -190,8 +190,10 @@ def test_cached_graphics_paths_are_relative(graphics_tree):
     catalog.refresh(str(graphics_tree), _config(), read_text=read_file)
 
     database = scan_cache.database_path(str(graphics_tree))
-    with sqlite3.connect(database) as connection:
+    connection = sqlite3.connect(database)
+    with connection:
         encoded = connection.execute("SELECT data FROM graphics_snapshot").fetchone()[0]
+    connection.close()
     assert str(graphics_tree) not in encoded
     data = json.loads(encoded)
     assert all(
@@ -264,8 +266,10 @@ def test_corrupt_graphics_snapshot_degrades_to_rescan(graphics_tree):
     first = GraphicsCatalog()
     expected = first.refresh(str(graphics_tree), _config(), read_text=read_file)
     database = scan_cache.database_path(str(graphics_tree))
-    with sqlite3.connect(database) as connection:
+    connection = sqlite3.connect(database)
+    with connection:
         connection.execute("UPDATE graphics_snapshot SET data = ?", ("{",))
+    connection.close()
 
     second = GraphicsCatalog()
     actual = second.refresh(str(graphics_tree), _config(), read_text=read_file)

--- a/tests/test_mod_context.py
+++ b/tests/test_mod_context.py
@@ -601,8 +601,10 @@ def test_gfx_cache_version_mismatch_forces_rescan(gfx_mod_tree):
     MOD.scan(root)
     expected_sprites = dict(MOD.sprites)
     database = scan_cache_mod.database_path(root)
-    with sqlite3.connect(database) as connection:
+    connection = sqlite3.connect(database)
+    with connection:
         connection.execute("UPDATE graphics_snapshot SET schema_version = 0")
+    connection.close()
 
     MOD.scan(root)
     assert MOD.sprites == expected_sprites

--- a/tests/test_scan_cache.py
+++ b/tests/test_scan_cache.py
@@ -127,6 +127,24 @@ def test_disabled_cache_never_raises(tmp_path, monkeypatch):
     c.close()
 
 
+def test_disabled_cache_does_not_leak_connection(tmp_path, monkeypatch):
+    """The half-opened connection on a corrupt DB must be closed, not leaked."""
+    import gc
+    import warnings
+
+    monkeypatch.setattr(sc, "STATE_DIR", str(tmp_path / "state"))
+    db = sc._db_path(str(tmp_path / "mod"))
+    os.makedirs(os.path.dirname(db), exist_ok=True)
+    with open(db, "wb") as f:
+        f.write(b"this is not a sqlite database")
+    c = sc.ScanCache(str(tmp_path / "mod"))
+    assert not c.enabled
+    c.close()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", ResourceWarning)
+        gc.collect()
+
+
 def test_get_many_skips_corrupt_json(cache):
     """A row whose data is not valid JSON must be skipped, not raise."""
     conn = cache._conn

--- a/tests/test_workspace_cache.py
+++ b/tests/test_workspace_cache.py
@@ -81,8 +81,10 @@ def test_corrupt_json_degrades_to_none(tmp_path):
     # Corrupt the stored JSON directly in the db.
     import sqlite3
 
-    with sqlite3.connect(tmp_path / "state" / "cache.db") as conn:
+    conn = sqlite3.connect(tmp_path / "state" / "cache.db")
+    with conn:
         conn.execute("UPDATE graphics_snapshot SET data = 'not-json'")
+    conn.close()
     assert (
         cache.load_graphics(
             schema_version=1, root_identity="root-1", config_fingerprint="fp"
@@ -117,3 +119,18 @@ def test_store_non_jsonable_degrades_without_raising(tmp_path, monkeypatch):
         )
         is None
     )
+
+
+def test_store_load_does_not_leak_connection(cache):
+    import gc
+    import warnings
+
+    cache.store_graphics(
+        {"a": 1}, schema_version=1, root_identity="root-1", config_fingerprint="fp"
+    )
+    cache.load_graphics(
+        schema_version=1, root_identity="root-1", config_fingerprint="fp"
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", ResourceWarning)
+        gc.collect()


### PR DESCRIPTION
Closes #61

## What
Stop leaking a `sqlite3.Connection` on every graphics-cache read/write and on the corrupt-DB path of the scan cache.

- `WorkspaceCache` now goes through a `_connection()` context manager that commits/rolls back and then closes the handle, instead of relying on `with self._connect() as connection:` which only commits.
- `ScanCache.__init__` closes the half-opened connection when schema setup fails on a corrupt DB file.
- The three test helpers that open raw `sqlite3.connect` handles now close them.

## Why
Each `load_graphics`/`store_graphics` call leaked a connection until GC finalized it, surfacing as 139 `ResourceWarning` noise across the suite (`unclosed database in <sqlite3.Connection object>`). On Windows an open handle can block deleting/replacing the cache file.

## How
The naive `contextlib.closing` wrapper drops the commit that the sqlite `with`-statement performs, so `_connection()` nests the connection's own context manager inside a `finally: close()` to preserve commit/rollback semantics while closing. New tests assert a store/load cycle and a corrupt-DB construction leave no `ResourceWarning` after `gc.collect()`.