### PR TITLE
Fix #30: Precompute GFX query index for browser search

### DIFF
--- a/src/hoi4cm/mod/graphics_catalog.py
+++ b/src/hoi4cm/mod/graphics_catalog.py
@@ -279,8 +279,8 @@ class GraphicsCatalog:
         # SQLite snapshot is re-stored at the next refresh or flush_cache(),
         # not on every write.
         self._cache_dirty = False
-        self._image_query_keys = ()
-        self._image_query_refs = ()
+        self._image_query_keys: tuple[str, ...] = ()
+        self._image_query_refs: tuple[PathReference, ...] = ()
 
     def refresh(
         self,
@@ -486,7 +486,9 @@ class GraphicsCatalog:
         search_text = search.casefold().strip()
         keys = self._image_query_keys
         if under_path is None:
-            key_refs = zip(keys, self._image_query_refs, strict=True)
+            key_refs: Iterable[tuple[str, PathReference]] = zip(
+                keys, self._image_query_refs, strict=True
+            )
         else:
             start, end = _path_prefix_range(under_path)
             start_index = bisect.bisect_left(keys, start)
@@ -515,26 +517,23 @@ class GraphicsCatalog:
         return tuple(assets)
 
     def _rebuild_image_query_index(self) -> None:
-        image_keys: list[str] = []
-        image_refs: list[PathReference] = []
-        entries: list[tuple[str, PathReference]] = []
+        # Single-pass dict dedupe keeps the rebuild O(n) instead of the
+        # previous sort + linear walk. `setdefault` drops duplicate keys
+        # while preserving first-seen order; sort once at the end.
+        seen: dict[str, PathReference] = {}
         for record in self._images.values():
             try:
-                entries.append(
-                    (_query_key(record.path.resolve(self._source_roots)), record.path)
-                )
+                key = _query_key(record.path.resolve(self._source_roots))
             except KeyError:
                 continue
-        entries.sort(key=lambda item: item[0])
-        seen: set[str] = set()
-        for key, ref in entries:
-            if key in seen:
-                continue
-            seen.add(key)
-            image_keys.append(key)
-            image_refs.append(ref)
-        self._image_query_keys = tuple(image_keys)
-        self._image_query_refs = tuple(image_refs)
+            seen.setdefault(key, record.path)
+        if not seen:
+            self._image_query_keys = ()
+            self._image_query_refs = ()
+            return
+        ordered = sorted(seen.items())
+        self._image_query_keys = tuple(item[0] for item in ordered)
+        self._image_query_refs = tuple(item[1] for item in ordered)
 
     def path_for(self, asset: AssetRef) -> str:
         return PathReference(asset.source_id, asset.relative_path).resolve(

--- a/src/hoi4cm/mod/graphics_catalog.py
+++ b/src/hoi4cm/mod/graphics_catalog.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import bisect
 import hashlib
 import json
 import os
@@ -278,6 +279,8 @@ class GraphicsCatalog:
         # SQLite snapshot is re-stored at the next refresh or flush_cache(),
         # not on every write.
         self._cache_dirty = False
+        self._image_query_keys = ()
+        self._image_query_refs = ()
 
     def refresh(
         self,
@@ -323,6 +326,7 @@ class GraphicsCatalog:
         self._root_identity = root_identity
         self._config_fingerprint = config_fingerprint
         self._derive_references(root, config)
+        self._rebuild_image_query_index()
         _remove_legacy_sidecar(root)
         if self._cache_dirty:
             self._flush_cache()
@@ -357,6 +361,7 @@ class GraphicsCatalog:
             delta = self._apply_image_record(
                 reference, ImageRecord(reference, _stamp_from_stat(path_stat))
             )
+            self._rebuild_image_query_index()
         elif self._is_interface_file(absolute_path):
             interface_root = os.path.join(self._root, "interface")
             record = GfxFileRecord(
@@ -404,6 +409,7 @@ class GraphicsCatalog:
                     delta.upsert["ideas"].add(name)
                 if self._ref_resolves_to(self._decision_refs.get(name), absolute_path):
                     delta.upsert["decisions"].add(name)
+            self._rebuild_image_query_index()
         if gfx_record is not None:
             for declaration in gfx_record.declarations:
                 self._unindex_declaration(declaration)
@@ -476,36 +482,59 @@ class GraphicsCatalog:
     def query(
         self, *, under: str | None = None, search: str = ""
     ) -> tuple[AssetRef, ...]:
-        under_path = os.path.normcase(os.path.abspath(under)) if under else None
+        under_path = _query_key(under) if under is not None else None
         search_text = search.casefold().strip()
-        assets: list[tuple[str, AssetRef]] = []
-        seen_paths: set[str] = set()
-        for record in self._images.values():
-            try:
-                absolute_path = record.path.resolve(self._source_roots)
-            except KeyError:
+        keys = self._image_query_keys
+        if under_path is None:
+            key_refs = zip(keys, self._image_query_refs, strict=True)
+        else:
+            start, end = _path_prefix_range(under_path)
+            start_index = bisect.bisect_left(keys, start)
+            end_index = bisect.bisect_left(keys, end)
+            key_refs = zip(
+                keys[start_index:end_index],
+                self._image_query_refs[start_index:end_index],
+                strict=True,
+            )
+
+        assets: list[AssetRef] = []
+        for key, ref in key_refs:
+            record = self._images.get(ref)
+            if record is None:
                 continue
-            normalized = os.path.normcase(os.path.abspath(absolute_path))
-            if normalized in seen_paths:
+            if search_text and search_text not in key:
                 continue
-            if under_path is not None and not _is_under(normalized, under_path):
-                continue
-            if search_text and search_text not in absolute_path.casefold():
-                continue
-            seen_paths.add(normalized)
             assets.append(
-                (
-                    absolute_path.casefold(),
-                    AssetRef(
-                        source_id=record.path.source_id,
-                        relative_path=record.path.relative_path,
-                        stamp=record.stamp,
-                        generation=self.generation,
-                    ),
+                AssetRef(
+                    source_id=ref.source_id,
+                    relative_path=ref.relative_path,
+                    stamp=record.stamp,
+                    generation=self.generation,
                 )
             )
-        assets.sort(key=lambda item: item[0])
-        return tuple(asset for _path, asset in assets)
+        return tuple(assets)
+
+    def _rebuild_image_query_index(self) -> None:
+        image_keys: list[str] = []
+        image_refs: list[PathReference] = []
+        entries: list[tuple[str, PathReference]] = []
+        for record in self._images.values():
+            try:
+                entries.append(
+                    (_query_key(record.path.resolve(self._source_roots)), record.path)
+                )
+            except KeyError:
+                continue
+        entries.sort(key=lambda item: item[0])
+        seen: set[str] = set()
+        for key, ref in entries:
+            if key in seen:
+                continue
+            seen.add(key)
+            image_keys.append(key)
+            image_refs.append(ref)
+        self._image_query_keys = tuple(image_keys)
+        self._image_query_refs = tuple(image_refs)
 
     def path_for(self, asset: AssetRef) -> str:
         return PathReference(asset.source_id, asset.relative_path).resolve(
@@ -1268,6 +1297,15 @@ def _image_candidates(path: PathReference) -> tuple[PathReference, ...]:
 
 def _absolute_key(path: str) -> str:
     return os.path.normcase(os.path.abspath(path))
+
+
+def _query_key(path: str) -> str:
+    return os.path.normcase(os.path.abspath(path)).casefold()
+
+
+def _path_prefix_range(prefix: str) -> tuple[str, str]:
+    normalized_prefix = prefix if prefix.endswith(os.sep) else prefix + os.sep
+    return normalized_prefix, normalized_prefix + "\uffff"
 
 
 def _absolute_candidates(path: str) -> tuple[str, ...]:

--- a/tests/test_graphics_catalog.py
+++ b/tests/test_graphics_catalog.py
@@ -217,6 +217,25 @@ def test_catalog_query_uses_loaded_snapshot(graphics_tree, monkeypatch):
     ]
 
 
+def test_catalog_query_under_uses_directory_prefix_match(graphics_tree):
+    goals = graphics_tree / "gfx" / "interface" / "goals"
+    sibling = graphics_tree / "gfx" / "interface" / "goals_backup"
+    (goals / "nested").mkdir()
+    (goals / "nested" / "nested_goal.dds").write_bytes(b"nested")
+    sibling.mkdir()
+    (sibling / "disk_backup.dds").write_bytes(b"backup")
+
+    catalog = GraphicsCatalog()
+    catalog.refresh(str(graphics_tree), _config(), read_text=read_file)
+
+    results = [catalog.path_for(asset) for asset in catalog.query(under=str(goals))]
+    assert results == [
+        str(goals / "disk_focus.dds"),
+        str(goals / "nested" / "nested_goal.dds"),
+    ]
+    assert str(sibling / "disk_backup.dds") not in results
+
+
 def test_changed_graphics_path_uses_a_new_cache_entry(graphics_tree):
     alternate = graphics_tree / "gfx" / "alternate_ideas"
     alternate.mkdir()


### PR DESCRIPTION
Fixes #30

## What

- Add a precomputed, case-folded image index in `GraphicsCatalog` for catalog queries.
- Slice image candidates with a directory-prefix boundary for `under=` using `bisect`, then apply search as a substring filter.
- Rebuild the index during catalog refresh and after image `note_written`/`note_deleted` updates.
- Keep `_catalog_image_paths` callers unchanged and add coverage for directory-prefix semantics.

## Why

The browser search path called `GraphicsCatalog.query()` on every keystroke and rescanned all cached image paths each time. This made the GFX browser feel laggy on large mods.

## How

The query path now uses a cached tuple of normalized, case-folded image keys plus matching `PathReference` entries, pre-sorted once per catalog state. `under=` now computes a prefix range and selects only matching rows via `bisect`, avoiding full per-image filtering on each call.

For image updates, the index is rebuilt after `note_written`/`note_deleted` changes so incremental behavior stays correct without a full scan on every keystroke.
