### PR TITLE
Fix #39: Preserve tree-level fields on round-trip

### DIFF
--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -95,11 +95,16 @@ source of truth.
 
 `tests/test_focus_tree_roundtrip.py` extends the same fixtures through
 `export_focus_tree` and back, checking export idempotence and structural
-field survival. `country_raw` is excluded from that round-trip: `export.py`
-still emits a canned `country` block rather than the captured verbatim text,
-so there's nothing to round-trip yet (wiring `country_raw` into `export.py`
-is a separate, later change). `country_raw` capture at parse time is
-checked directly in `test_focus_tree_fixtures.py` instead.
+field survival. `country_raw` and `tree_extras` (unrecognized `focus_tree`
+wrapper keys — `default`, `reset_on_civilwar`, `initial_show_position`, ...)
+are both written verbatim by `export_focus_tree` and `export_main_tree`,
+mirroring how `_script_extras` preserves unknown per-focus keys; dedicated
+tests in `test_focus_tree_roundtrip.py` and `test_focus_tree_export_main.py`
+cover both fields, falling back to the canned `country` block only when
+`country_raw` is blank (a brand-new tree with nothing captured on import).
+`country_raw` capture at parse time is checked directly in
+`test_focus_tree_fixtures.py`; `tree_extras` capture is checked in
+`test_focus_tree_parse.py` (it's not part of the golden-fixture `meta` shape).
 
 ## One-off comparison against a real mod
 

--- a/hoi4_content_maker.py
+++ b/hoi4_content_maker.py
@@ -368,7 +368,7 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):
         self._shared_focuses = self.workspace.main_tree.metadata.shared_focuses
         self._joint_focuses = self.workspace.main_tree.metadata.joint_focuses
         # Extra loaded trees (shared/joint trees loaded alongside the main tree)
-        self._extra_trees = []  # list of dicts: {type, file_path, tree_id, cfp_x, cfp_y, shared_focuses, joint_focuses, country_tag, focus_ids}
+        self._extra_trees = []  # list of dicts: {type, file_path, tree_id, cfp_x, cfp_y, shared_focuses, joint_focuses, country_tag, country_raw, tree_extras, focus_ids}
         toolbar = tk.Frame(self, bg=BG_DARK)
         toolbar.pack(fill="x")
         build_menubar(self, toolbar)
@@ -3925,6 +3925,7 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):
             self._cfp_x_var.set("" if self._cfp_x is None else str(self._cfp_x))
             self._cfp_y_var.set("" if self._cfp_y is None else str(self._cfp_y))
             self._tree_country_raw = parsed.country_raw
+            self._tree_extras = parsed.tree_extras
             self._tree_had_wrapper = parsed.had_wrapper
             self._shared_focuses = parsed.shared_refs
             self._joint_focuses = parsed.joint_refs
@@ -4021,6 +4022,8 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):
             "shared_focuses": parsed.shared_refs,
             "joint_focuses": parsed.joint_refs,
             "country_tag": parsed.country_tag,
+            "country_raw": parsed.country_raw,
+            "tree_extras": parsed.tree_extras,
             "had_wrapper": parsed.had_wrapper,
             "focus_ids": set(),
         }
@@ -4561,6 +4564,8 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):
                         "shared_focuses": parsed.shared_refs,
                         "joint_focuses": parsed.joint_refs,
                         "country_tag": parsed.country_tag,
+                        "country_raw": parsed.country_raw,
+                        "tree_extras": parsed.tree_extras,
                         "had_wrapper": parsed.had_wrapper,
                         "focus_ids": set(),
                     }
@@ -4701,7 +4706,10 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):
 
     # ── SAVE / LOAD ─────────────────────────────────────────────
     def _capture_workspace(self):
-        main_extras = self.workspace.main_tree.extras
+        main_extras = dict(self.workspace.main_tree.extras)
+        tree_extras = getattr(self, "_tree_extras", None)
+        if tree_extras:
+            main_extras["tree_extras"] = tree_extras
         try:
             cfp_x = int(self._cfp_x_var.get())
         except TypeError, ValueError:
@@ -4778,6 +4786,7 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):
         self._tree_country_tag = meta.country_tag
         self._tree_country_name = meta.country_name
         self._tree_country_raw = meta.country_raw
+        self._tree_extras = workspace.main_tree.extras.get("tree_extras", {})
         self._tree_focus_prefix = meta.focus_prefix
         self._tree_had_wrapper = workspace.main_tree.had_wrapper
         # Legacy projects decode with an empty file_path; keep the user's
@@ -5429,6 +5438,7 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):
                 "cfp_x": cfp_x,
                 "cfp_y": cfp_y,
                 "country_raw": getattr(self, "_tree_country_raw", ""),
+                "tree_extras": getattr(self, "_tree_extras", {}),
                 "shared_focuses": getattr(self, "_shared_focuses", []),
                 "joint_focuses": getattr(self, "_joint_focuses", []),
             },

--- a/src/hoi4cm/focus_tree/export.py
+++ b/src/hoi4cm/focus_tree/export.py
@@ -7,11 +7,29 @@ writing the file.
 import re
 
 from hoi4cm.script.effects import render_effect
+from hoi4cm.script.syntax import serialize_block
 
 from .codec import render_focus_body
 from .operations import build_focus_name_lookup
 
 GFX_DEFAULT = "GFX_goal_generic_political_pressure"
+
+
+def _emit_tree_extras(out, info):
+    """Re-emit unrecognized focus_tree wrapper keys captured at parse time.
+
+    Mirrors how ``_script_extras`` preserves unknown per-focus keys — see
+    ``codec.render_focus_body``.
+    """
+    tree_extras = info.get("tree_extras") or {}
+    if not tree_extras:
+        return
+    rendered = serialize_block(
+        tree_extras, indent="\t", include_bare_values=True, strip_strings=True
+    )
+    if rendered:
+        out.extend(rendered.splitlines())
+        out.append("")
 
 
 def export_focus_tree(
@@ -26,10 +44,13 @@ def export_focus_tree(
 
     ``focuses_in_tree`` is the list of focuses to write. ``info`` is the tree
     metadata dict (``tree_id``, ``country_tag``, ``cfp_x``/``cfp_y``, ``type``,
-    ``had_wrapper``, ``shared_focuses``, ``joint_focuses``). ``focus_lookup`` is
-    a ``{id: Focus}`` mapping covering every loaded focus (for prerequisite /
-    mutex / relative-position name resolution). ``effect_renderer`` renders one
-    effect dict to script text.
+    ``had_wrapper``, ``shared_focuses``, ``joint_focuses``, ``country_raw`` —
+    the verbatim ``country = { ... }`` body captured on import, blank falls
+    back to the canned block — and ``tree_extras``, other unrecognized
+    ``focus_tree`` wrapper keys such as ``default`` or ``reset_on_civilwar``).
+    ``focus_lookup`` is a ``{id: Focus}`` mapping covering every loaded focus
+    (for prerequisite / mutex / relative-position name resolution).
+    ``effect_renderer`` renders one effect dict to script text.
     """
     tid = re.sub(r"[^A-Za-z0-9_]", "_", info["tree_id"].strip()) or "TAG_focus_tree"
     country_tag = info.get("country_tag", "TAG")
@@ -78,12 +99,18 @@ def export_focus_tree(
         out.append("focus_tree = {")
         out.append(f"\tid = {tid}")
         out.append("")
+        country_raw = (info.get("country_raw") or "").strip()
         out.append("\tcountry = {")
-        out.append("\t\tfactor = 0")
-        out.append("\t\tmodifier = {")
-        out.append("\t\t\tadd = 20")
-        out.append(f"\t\t\toriginal_tag = {country_tag}")
-        out.append("\t\t}")
+        if country_raw:
+            for ln in country_raw.splitlines():
+                if ln.strip():
+                    out.append(f"\t\t{ln}")
+        else:
+            out.append("\t\tfactor = 0")
+            out.append("\t\tmodifier = {")
+            out.append("\t\t\tadd = 20")
+            out.append(f"\t\t\toriginal_tag = {country_tag}")
+            out.append("\t\t}")
         out.append("\t}")
         out.append("")
         for sf in info.get("shared_focuses", []):
@@ -100,6 +127,7 @@ def export_focus_tree(
                 cfp_x = cfp_y = 0
         out.append(f"\tcontinuous_focus_position = {{ x = {cfp_x} y = {cfp_y} }}")
         out.append("")
+        _emit_tree_extras(out, info)
         for f in focuses_in_tree:
             out.append("\tfocus = {")
             out.append(f"\t\tid = {f.name}")
@@ -125,8 +153,10 @@ def export_main_tree(
     is the tree metadata dict: ``tree_id``, ``country_tag``, ``cfp_x``/``cfp_y``
     (``None`` to auto-derive from the focuses), ``country_raw`` (the verbatim
     ``country = { ... }`` body captured on import — blank falls back to the
-    MD-convention default block), and ``shared_focuses``/``joint_focuses``
-    (reference lines preserved from import). ``focus_lookup`` is the full
+    MD-convention default block), ``shared_focuses``/``joint_focuses``
+    (reference lines preserved from import), and ``tree_extras`` (other
+    unrecognized ``focus_tree`` wrapper keys, such as ``default`` or
+    ``reset_on_civilwar``, preserved verbatim). ``focus_lookup`` is the full
     ``{id: Focus}`` map (every loaded focus, including linked focuses) used to
     resolve prerequisite/mutex/relative-position names. ``effect_renderer``
     renders one effect dict to script text, exactly like ``export_focus_tree``.
@@ -180,6 +210,7 @@ def export_main_tree(
             cfp_x = cfp_y = 0
     out.append(f"\tcontinuous_focus_position = {{ x = {cfp_x} y = {cfp_y} }}")
     out.append("")
+    _emit_tree_extras(out, info)
 
     for f in focuses_in_tree:
         out.append("\tfocus = {")

--- a/src/hoi4cm/focus_tree/parse.py
+++ b/src/hoi4cm/focus_tree/parse.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import os
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from hoi4cm.script.syntax import (
     match_brace,
@@ -30,6 +30,20 @@ _COND_KEYS = (
     "select_effect",
     "bypass_effect",
     "allow_branch",
+)
+
+# focus_tree = { ... } wrapper keys already captured by named ParsedFocusTree
+# fields. Anything else (default, reset_on_civilwar, initial_show_position,
+# ...) is preserved verbatim in tree_extras so it survives a round-trip.
+_KNOWN_TREE_FIELDS = frozenset(
+    {
+        "id",
+        "continuous_focus_position",
+        "country",
+        "focus",
+        "shared_focus",
+        "joint_focus",
+    }
 )
 
 
@@ -56,6 +70,7 @@ class ParsedFocusTree:
     focuses_data: list
     raw_rewards: dict
     country_raw: str = ""
+    tree_extras: dict = field(default_factory=dict)
 
 
 def extract_raw_block(source, key):
@@ -142,6 +157,7 @@ def parse_focus_tree(raw, path):
     cfp_x = cfp_y = None
     country_tag = "TAG"
     country_raw = ""
+    tree_extras: dict = {}
     i = 0
     while i < len(tokens):
         if tokens[i] == "focus_tree" and i + 1 < len(tokens) and tokens[i + 1] == "=":
@@ -171,6 +187,11 @@ def parse_focus_tree(raw, path):
             # Preserve the full country block verbatim so it can be written
             # back unchanged on export.
             country_raw = extract_raw_block(txt, "country")
+            tree_extras = {
+                key: value
+                for key, value in block.items()
+                if key not in _KNOWN_TREE_FIELDS
+            }
             raw_focuses = block.get("focus", [])
             if isinstance(raw_focuses, dict):
                 raw_focuses = [raw_focuses]
@@ -253,4 +274,5 @@ def parse_focus_tree(raw, path):
         focuses_data=focuses_data,
         raw_rewards=raw_rewards,
         country_raw=country_raw,
+        tree_extras=tree_extras,
     )

--- a/tests/test_focus_tree_export_main.py
+++ b/tests/test_focus_tree_export_main.py
@@ -252,6 +252,31 @@ def test_country_raw_written_verbatim_with_nested_indent_preserved():
     assert "base = 0" not in text
 
 
+def test_tree_extras_written_after_continuous_focus_position():
+    """Wrapper-level keys with no named field (default, reset_on_civilwar,
+    initial_show_position, ...) must survive via tree_extras (#39)."""
+    root = Focus(0, 0)
+    root.name = "TST_root"
+    info = _info(tree_extras={"default": "yes", "initial_show_position": "yes"})
+    text = export_main_tree(
+        [root], info, focus_lookup={root.id: root}, effect_renderer=raw_block_renderer
+    )
+    assert "\tdefault = yes" in text
+    assert "\tinitial_show_position = yes" in text
+
+
+def test_tree_extras_omitted_when_empty():
+    root = Focus(0, 0)
+    root.name = "TST_root"
+    text = export_main_tree(
+        [root],
+        _info(),
+        focus_lookup={root.id: root},
+        effect_renderer=raw_block_renderer,
+    )
+    assert "default" not in text
+
+
 def _summary(focuses):
     by_id = {f.id: f.name for f in focuses}
     return [
@@ -281,6 +306,7 @@ def _main_info(parsed):
         "country_raw": parsed.country_raw,
         "shared_focuses": parsed.shared_refs,
         "joint_focuses": parsed.joint_refs,
+        "tree_extras": parsed.tree_extras,
     }
 
 

--- a/tests/test_focus_tree_parse.py
+++ b/tests/test_focus_tree_parse.py
@@ -87,6 +87,45 @@ def test_parse_tree_metadata():
     assert [f["id"] for f in p.focuses_data] == ["TST_alpha", "TST_beta"]
 
 
+def test_parse_tree_extras_empty_when_no_unknown_wrapper_keys():
+    p = parse_focus_tree(WRAPPED, "/tmp/TST_shared_tree.txt")
+    assert p.tree_extras == {}
+
+
+def test_parse_tree_extras_captures_unknown_wrapper_keys():
+    """default/reset_on_civilwar/initial_show_position aren't named fields on
+    ParsedFocusTree — they must survive via tree_extras (issue #39)."""
+    src = """\
+focus_tree = {
+\tid = TST_extras_tree
+\tcountry = {
+\t\tfactor = 0
+\t}
+\tdefault = yes
+\treset_on_civilwar = no
+\tinitial_show_position = yes
+\tcontinuous_focus_position = { x = 0 y = 0 }
+\tshared_focus = OTHER_shared
+\tfocus = {
+\t\tid = TST_only
+\t\ticon = GFX_x
+\t\tx = 0
+\t\ty = 0
+\t\tcost = 1
+\t}
+}
+"""
+    p = parse_focus_tree(src, "/tmp/x.txt")
+    # Known wrapper fields (id, country, continuous_focus_position, focus,
+    # shared_focus) must NOT leak into tree_extras — only genuinely unknown
+    # keys belong there.
+    assert p.tree_extras == {
+        "default": "yes",
+        "reset_on_civilwar": "no",
+        "initial_show_position": "yes",
+    }
+
+
 def test_parse_keeps_focus_fields():
     p = parse_focus_tree(WRAPPED, "/tmp/TST_shared_tree.txt")
     alpha, beta = p.focuses_data

--- a/tests/test_focus_tree_roundtrip.py
+++ b/tests/test_focus_tree_roundtrip.py
@@ -47,6 +47,8 @@ def _info(parsed, tree_type):
         "joint_focuses": parsed.joint_refs,
         "country_tag": parsed.country_tag,
         "had_wrapper": parsed.had_wrapper,
+        "country_raw": parsed.country_raw,
+        "tree_extras": parsed.tree_extras,
         "focus_ids": set(),
     }
 
@@ -194,14 +196,134 @@ def test_extra_tree_export_preserves_main_tree_only_focus_fields(
     assert restored.available_if_capitulated is True
 
 
+def _extra_tree_info(**overrides):
+    info = {
+        "tree_id": "TST_shared_tree",
+        "country_tag": "TST",
+        "cfp_x": 0,
+        "cfp_y": 0,
+        "type": "shared",
+        "had_wrapper": True,
+        "shared_focuses": [],
+        "joint_focuses": [],
+    }
+    info.update(overrides)
+    return info
+
+
+def test_extra_tree_export_preserves_country_raw_verbatim():
+    """export_focus_tree must not discard an imported country block (#39)."""
+    focus = Focus(0, 0)
+    focus.name = "TST_root"
+    country_raw = "base = 0\nmodifier = {\n\tadd = 20\n\toriginal_tag=TST\n}"
+    info = _extra_tree_info(country_raw=country_raw)
+
+    text = export_focus_tree(
+        [focus],
+        info,
+        focus_lookup={focus.id: focus},
+        effect_renderer=raw_block_renderer,
+    )
+    expected_country_block = "\n".join(
+        [
+            "\tcountry = {",
+            "\t\tbase = 0",
+            "\t\tmodifier = {",
+            "\t\t\tadd = 20",
+            "\t\t\toriginal_tag=TST",
+            "\t\t}",
+            "\t}",
+        ]
+    )
+    assert expected_country_block in text
+    # The canned default must not also appear alongside the verbatim block.
+    assert "factor = 0" not in text
+
+
+def test_extra_tree_export_falls_back_to_canned_country_block_when_blank():
+    focus = Focus(0, 0)
+    focus.name = "TST_root"
+    info = _extra_tree_info()  # no country_raw override -> blank
+
+    text = export_focus_tree(
+        [focus],
+        info,
+        focus_lookup={focus.id: focus},
+        effect_renderer=raw_block_renderer,
+    )
+    assert "factor = 0" in text
+    assert "original_tag = TST" in text
+
+
+def test_extra_tree_export_emits_tree_extras():
+    """Wrapper-level keys with no named field (default, reset_on_civilwar,
+    initial_show_position, ...) must survive via tree_extras (#39)."""
+    focus = Focus(0, 0)
+    focus.name = "TST_root"
+    info = _extra_tree_info(tree_extras={"default": "yes", "reset_on_civilwar": "no"})
+
+    text = export_focus_tree(
+        [focus],
+        info,
+        focus_lookup={focus.id: focus},
+        effect_renderer=raw_block_renderer,
+    )
+    assert "\tdefault = yes" in text
+    assert "\treset_on_civilwar = no" in text
+
+
+def test_extra_tree_export_omits_tree_extras_block_when_empty():
+    focus = Focus(0, 0)
+    focus.name = "TST_root"
+    info = _extra_tree_info()
+
+    text = export_focus_tree(
+        [focus],
+        info,
+        focus_lookup={focus.id: focus},
+        effect_renderer=raw_block_renderer,
+    )
+    assert "default" not in text
+
+
+def test_extra_tree_roundtrip_preserves_country_raw_and_tree_extras():
+    """Full parse -> export -> reparse cycle for both fields at once."""
+    src = """\
+focus_tree = {
+\tid = TST_shared_tree
+\tcountry = {
+\t\tbase = 0
+\t\tmodifier = {
+\t\t\tadd = 20
+\t\t\toriginal_tag = TST
+\t\t}
+\t}
+\tdefault = yes
+\treset_on_civilwar = no
+\tcontinuous_focus_position = { x = 0 y = 0 }
+\tfocus = {
+\t\tid = TST_only
+\t\ticon = GFX_x
+\t\tx = 0
+\t\ty = 0
+\t\tcost = 1
+\t\tcompletion_reward = {
+\t\t\tadd_political_power = 1
+\t\t}
+\t}
+}
+"""
+    focuses1, t1 = _load_and_export(src, "shared")
+    focuses2, t2 = _load_and_export(t1, "shared")
+    assert t1 == t2
+    assert _summary(focuses1) == _summary(focuses2)
+    assert "\tdefault = yes" in t1
+    assert "\treset_on_civilwar = no" in t1
+    assert "base = 0" in t1
+    assert "factor = 0" not in t1  # canned block must not appear alongside it
+
+
 # ── Fixture-file round-trips (see tests/fixtures/focus_trees/) ────────────
-#
-# country_raw is NOT covered here: export_focus_tree always emits a canned
-# country block (factor/add/original_tag) rather than info["country_raw"]
-# verbatim. Wiring the verbatim block into export.py is the next phase (see
-# docs/dev/monolith-migration.md); until then this stays out of round-trip
-# scope. country_raw's own capture-at-parse-time is covered directly in
-# tests/test_focus_tree_fixtures.py.
 
 FIXTURE_FILES = [
     ("wrapper_basic.txt", "shared"),


### PR DESCRIPTION
## Summary
- `export_focus_tree` (shared/joint trees) now writes the verbatim `country = { ... }` block captured at parse time (`country_raw`), instead of always emitting a canned `factor = 0 / add = 20 / original_tag` block. Falls back to the canned block only when `country_raw` is blank (nothing captured on import).
- Added `tree_extras` to `ParsedFocusTree`, capturing any `focus_tree` wrapper key with no dedicated field (`default`, `reset_on_civilwar`, `initial_show_position`, ...), threaded through `info` and re-emitted by both `export_focus_tree` and `export_main_tree` — mirroring how `_script_extras` already preserves unknown per-focus keys.
- Wired `tree_extras` through the monolith's tree-loading/saving/project-serialization paths (`hoi4_content_maker.py`) alongside the existing `country_raw` plumbing.
- Updated `docs/dev/testing.md` to describe the new round-trip coverage and drop the stale "out of scope" note.

Closes #39.

## Test plan
- [x] `pytest -q` — 706 passed (full suite, this branch only)
- [x] `ruff check .` / `black --check .` — clean
- [x] `mypy` / `pylint src/hoi4cm tests` — same pre-existing findings as `main` (unrelated files: `core/undo.py` PEP 758 syntax mypy can't parse yet, tracked in #68; `core/image.py` Pillow stub gap; one pylint style nit in `test_wizard_generators_dyn_mod.py`), nothing new
- [x] New/updated tests cover: parse-time capture of unknown wrapper keys (and non-capture of known ones), export of `country_raw` with canned-block fallback, export of `tree_extras`, and a full parse→export→reparse round-trip exercising both fields together

🤖 Generated with [Claude Code](https://claude.com/claude-code)