### PR TITLE
Delete connector lines when unloading extra trees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@
 
 ## Application Modernization — Bug Fixes
 
+### Extra-tree unload removes connector lines (issue #80)
+
+**[BUG FIX] Unloading a shared or joint tree now removes its connection lines**
+- The focus cards disappeared correctly, but their prerequisite and mutex
+  connectors remained visible at their old canvas positions for the rest of
+  the session.
+- Unloading now deletes the pooled connector items before resetting their
+  tracking state, so the next redraw contains only connections between the
+  remaining focuses.
+
 ### Minimap opens and renders (issue #81)
 
 **[BUG FIX] Opening the minimap no longer raises `TclError` or leaves its toggle state inconsistent**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,0 @@
-AGENTS.md

--- a/hoi4_content_maker.py
+++ b/hoi4_content_maker.py
@@ -4183,7 +4183,9 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):
             if fid in self.focuses:
                 self.cv.delete("F" + str(fid))
         self.focuses.delete_many(info["focus_ids"], clean_references=False)
+        self.cv.delete("line")
         self._lines.clear()
+        self._lines_used = 0
         if self.selected and self.selected.id not in self.focuses:
             self.selected = None
             self._hide_form()

--- a/src/hoi4cm/ui/canvas.py
+++ b/src/hoi4cm/ui/canvas.py
@@ -653,8 +653,8 @@ class CanvasMixin:
         # tens of thousands of items in it — and everything past the previous
         # frame's mark is already hidden, so walking to len(self._lines) is a
         # Tk call per surplus item per frame for no visible effect. A
-        # `self._lines.clear()` elsewhere (new/clear document, after a
-        # `cv.delete("all")`) shrinks the pool, hence the clamp.
+        # `self._lines.clear()` elsewhere follows deletion of the matching
+        # canvas items and shrinks the pool, hence the clamp.
         pool_size = len(self._lines)
         previous_used = min(getattr(self, "_lines_used", pool_size), pool_size)
         for idx in range(need, previous_used):

--- a/tests/test_canvas_tk.py
+++ b/tests/test_canvas_tk.py
@@ -9,6 +9,7 @@ import tkinter as tk
 
 import pytest
 
+import hoi4_content_maker as app_module
 from hoi4cm.models import Focus
 from hoi4cm.models.document import FocusDocument
 from hoi4cm.ui.canvas import CanvasMixin
@@ -386,6 +387,36 @@ def _linked_chain(count, *, spacing=1):
     for previous, focus in zip(focuses, focuses[1:], strict=False):
         focus.prereqs = [[previous.id]]
     return focuses
+
+
+def test_unload_extra_tree_deletes_pooled_connection_items(tk_root):
+    cv = tk.Canvas(tk_root, width=200, height=200)
+    app = _FakeApp(cv)
+    focuses = _linked_chain(12)
+    app.focuses = FocusDocument(focuses)
+    app._extra_trees = [
+        {
+            "tree_id": "shared_tree",
+            "type": "shared",
+            "focus_ids": {focus.id for focus in focuses},
+        }
+    ]
+    app._shared_focuses = ["shared_tree"]
+    app._joint_focuses = []
+    app._invalidate_tree_badges = lambda: None
+    app._refresh_tree_meta_panel = lambda: None
+    app._refresh_loaded_trees_panel = lambda: None
+    app._redraw = lambda: None
+    app._invalidate_focus_list_structure = lambda: None
+    app._draw_lines((-1.0, -1.0, 100.0, 1.0))
+    assert len(cv.find_withtag("line")) == 22
+
+    app_module.App._unload_extra_tree(app, 1)
+
+    assert not app.focuses
+    assert not cv.find_withtag("line")
+    assert app._lines == []
+    assert app._lines_used == 0
 
 
 def test_narrow_frame_hides_the_lines_the_wide_frame_left_behind(tk_root):


### PR DESCRIPTION
Closes #80

**What**
- Delete pooled prerequisite and mutex connector items when unloading an extra tree.
- Reset the line-pool usage marker and add regression coverage for the unload path.

**Why**
Clearing only the Python pool lost the canvas item IDs, leaving orphaned connectors visible for the rest of the session.

**How**
Delete canvas items tagged `line` before clearing the pool, then reset `_lines_used` so the next redraw rebuilds only the surviving connections.