### PR TITLE
Feed handled errors into the in-app error log

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,6 @@ repos:
         args: [--config-file=pyproject.toml]
 
   - repo: https://github.com/PyCQA/pylint
-    rev: v4.0.6
+    rev: v4.0.7
     hooks:
       - id: pylint

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -101,6 +101,14 @@ monolith's `_export`, `_export_extra_tree` and `_save` all return `None`
 through it rather than showing a success dialog for an export that never
 landed.
 
+`report_write_failure` delegates to the generic `hoi4cm.ui.error_report`'s
+`report_error(msg, exc=None, *, parent=None, title=None)`, which is the one
+place a handled error turns into a log entry (with the traceback when an
+exception is given) plus a dialog. Synchronous import/parse/export failures
+across the monolith and the wizards go through it (issue #52), so the
+in-app error log sees what used to be dialog-only errors; background-task
+failures were already covered by `run_bg` in `ui/tasks.py`.
+
 One deliberate consequence: an atomic write needs write permission on the
 target's **directory**, not just on the file. A read-only mod folder that used
 to accept an in-place overwrite now fails with a clear dialog. That is the

--- a/hoi4_content_maker.py
+++ b/hoi4_content_maker.py
@@ -129,6 +129,7 @@ from hoi4cm.ui import (
     _safe_after,
     make_progress,
     progress_modal,
+    report_error,
     report_write_failure,
     run_bg,
 )
@@ -2087,14 +2088,14 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):
             self.cv.after(30, _restore_vp)
             return True
         except Exception as ex:
-            self._log_error(str(ex))
-            messagebox.showerror(
-                tr("dialog.parse_error.title", "Parse Error"),
+            report_error(
                 tr(
                     "dialog.parse_error.body",
                     "Could not parse your edits:\n{error}\n\nCheck Error Log for details.",
                     error=ex,
                 ),
+                ex,
+                title=tr("dialog.parse_error.title", "Parse Error"),
             )
             return False
 
@@ -3293,11 +3294,12 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):
             with open(path, encoding="utf-8", errors="replace") as fp:
                 raw_file = fp.read()
         except Exception as e:
-            messagebox.showerror(
-                tr("dialog.drawio_import.title", "Draw.io Import"),
+            report_error(
                 tr(
                     "dialog.drawio_read_error", "Could not read file:\n{error}", error=e
                 ),
+                e,
+                title=tr("dialog.drawio_import.title", "Draw.io Import"),
             )
             return
 
@@ -3893,9 +3895,10 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):
             with open(path, encoding="utf-8-sig", errors="replace") as fp:
                 raw = fp.read()
         except Exception as e:
-            messagebox.showerror(
-                tr("dialog.import_error.title", "Import Error"),
+            report_error(
                 tr("dialog.read_file_error", "Could not read file:\n{error}", error=e),
+                e,
+                title=tr("dialog.import_error.title", "Import Error"),
             )
             return
 
@@ -4146,9 +4149,10 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):
             with open(path, encoding="utf-8-sig", errors="replace") as fp:
                 raw = fp.read()
         except Exception as e:
-            messagebox.showerror(
-                tr("dialog.load_error.title", "Load Error"),
+            report_error(
                 tr("dialog.read_file_error", "Could not read file:\n{error}", error=e),
+                e,
+                title=tr("dialog.load_error.title", "Load Error"),
             )
             return
         try:
@@ -5135,7 +5139,19 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):
         )
         if not path:
             return
-        workspace = read_project(path)
+        try:
+            workspace = read_project(path)
+        except Exception as e:
+            report_error(
+                tr(
+                    "dialog.load_project_error.body",
+                    "Could not load project:\n{error}",
+                    error=e,
+                ),
+                e,
+                title=tr("dialog.load_project_error.title", "Load Project Error"),
+            )
+            return
         self.cv.delete("all")
         self.selected = None
         self._lines.clear()
@@ -5373,7 +5389,8 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):
             win,
             text=tr(
                 "bulk_rename.description",
-                "Replaces prefix across all {count} focus IDs,\nprerequisite references, and mutex links.",
+                "Replaces prefix across all {count} focus IDs,\n"
+                "prerequisite references, and mutex links.",
                 count=len(self.focuses),
             ),
             bg=BG_DARK,
@@ -5685,7 +5702,11 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):
                 tr("dialog.exported.title", "Exported"),
                 tr(
                     "dialog.exported.body",
-                    "Export complete!\n\nFocus tree: {focus_file}{loc_saved}\n\nInstall paths:\n  .txt  ->  common/national_focus/{default_filename}\n\nReminders:\n  - Replace placeholder icons with real GFX keys\n  - Add shared_focus lines if using shared trees",
+                    "Export complete!\n\nFocus tree: {focus_file}{loc_saved}\n\n"
+                    "Install paths:\n"
+                    "  .txt  ->  common/national_focus/{default_filename}\n\n"
+                    "Reminders:\n  - Replace placeholder icons with real GFX keys\n"
+                    "  - Add shared_focus lines if using shared trees",
                     focus_file=os.path.basename(plan.focus_path),
                     loc_saved=loc_saved,
                     default_filename=os.path.basename(plan.focus_path),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dev = [
   "pytest-cov>=4.0", # coverage gate for wizard generators
   "ruff>=0.16",
   "black>=26.5",
-  "mypy>=2.3.0", # native_parser config requires 2.3.0 (PEP 758 support)
+  "mypy>=2.3.0",     # native_parser config requires 2.3.0 (PEP 758 support)
   "pylint>=4.0.7",
   "pre-commit>=3.5",
 ] # tests + linting
@@ -77,10 +77,7 @@ native_parser = true
 # parser (above) handles PEP 758's unparenthesized `except A, B:` on 3.14,
 # which the default parser could not (issue #68) — that is why those files
 # no longer need excluding.
-exclude = [
-  "hoi4_content_maker.py",
-  "build",
-]
+exclude = ["hoi4_content_maker.py", "build"]
 warn_unused_configs = true
 
 # Pillow is an optional extra and pytest is only a dev dependency; both may be

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,8 @@ dev = [
   "pytest-cov>=4.0", # coverage gate for wizard generators
   "ruff>=0.16",
   "black>=26.5",
-  "mypy>=1.10",
-  "pylint>=3.2",
+  "mypy>=2.3.0", # native_parser config requires 2.3.0 (PEP 758 support)
+  "pylint>=4.0.7",
   "pre-commit>=3.5",
 ] # tests + linting
 build = ["pyinstaller>=6.0", "Pillow>=9.0"] # compile standalone executables
@@ -72,19 +72,14 @@ select = ["E", "F", "W", "I", "UP", "B"]
 python_version = "3.14"
 mypy_path = ["src"]
 files = ["src/hoi4cm", "tests"]
-# The monolith and build scripts stay out until refactored. The PEP 758 files
-# (unparenthesized `except A, B:`) are excluded too: mypy 2.3.0 can't parse that
-# syntax yet, even though it's valid Python 3.14. Tracked in issue #68.
+native_parser = true
+# The monolith and build scripts stay out until refactored. The native
+# parser (above) handles PEP 758's unparenthesized `except A, B:` on 3.14,
+# which the default parser could not (issue #68) — that is why those files
+# no longer need excluding.
 exclude = [
   "hoi4_content_maker.py",
   "build",
-  "src/hoi4cm/core/undo.py",
-  "src/hoi4cm/data/effects.py",
-  "src/hoi4cm/mod/workspace_cache.py",
-  "src/hoi4cm/ui/lifecycle.py",
-  "src/hoi4cm/wizards/_image_loader.py",
-  "src/hoi4cm/mod/graphics_catalog.py",
-  "tests/test_i18n.py",
 ]
 warn_unused_configs = true
 

--- a/src/hoi4cm/ui/__init__.py
+++ b/src/hoi4cm/ui/__init__.py
@@ -1,5 +1,6 @@
 """Tkinter UI helpers for HOI4 Content Maker."""
 
+from hoi4cm.ui.error_report import report_error
 from hoi4cm.ui.file_errors import report_write_failure
 from hoi4cm.ui.gfx_browser import (
     open_focus_icon_browser,
@@ -101,6 +102,7 @@ __all__ = [
     "open_settings",
     "open_universal_gfx_browser",
     "progress_modal",
+    "report_error",
     "report_write_failure",
     "run_bg",
     "show_splash",

--- a/src/hoi4cm/ui/error_report.py
+++ b/src/hoi4cm/ui/error_report.py
@@ -23,12 +23,14 @@ def report_error(msg, exc=None, *, parent=None, title=None):
     """Record ``msg`` (plus ``exc``'s traceback) and tell the user about it.
 
     Writes one entry to the in-app error log, one to the HOI4CM file log,
-    then raises a dialog. ``parent`` is the window the dialog should belong
-    to (``None`` for the default root). Returns the message shown, which is
-    handy for tests and status lines.
+    then raises a dialog. Only real exceptions contribute a traceback; any
+    other error object is ignored for it, so the reporter itself never
+    raises. ``parent`` is the window the dialog should belong to (``None``
+    for the default root). Returns the message shown, which is handy for
+    tests and status lines.
     """
     entry = msg
-    if exc is not None:
+    if isinstance(exc, BaseException):
         entry = f"{msg}\n" + "".join(traceback.format_exception(exc))
     log.error("%s", entry)
     add_error(entry)

--- a/src/hoi4cm/ui/error_report.py
+++ b/src/hoi4cm/ui/error_report.py
@@ -1,0 +1,37 @@
+"""Generic error reporter: in-app error log entry + file log + dialog.
+
+``report_write_failure`` (:mod:`hoi4cm.ui.file_errors`) covers failed mod
+writes, where the message has to promise the target file survived. Everything
+else — a corrupt project file, an import/parse/export failure — lands here,
+so a handled error stops disappearing the moment its dialog is dismissed.
+"""
+
+import traceback
+from tkinter import messagebox
+
+# Core *submodules*, not the facade: core/__init__ imports hoi4cm.ui before it
+# binds these names (see tests/test_import_order.py).
+from hoi4cm.core.i18n import tr
+from hoi4cm.core.logger import add_error, get_logger
+
+log = get_logger("errors")
+
+__all__ = ["report_error"]
+
+
+def report_error(msg, exc=None, *, parent=None, title=None):
+    """Record ``msg`` (plus ``exc``'s traceback) and tell the user about it.
+
+    Writes one entry to the in-app error log, one to the HOI4CM file log,
+    then raises a dialog. ``parent`` is the window the dialog should belong
+    to (``None`` for the default root). Returns the message shown, which is
+    handy for tests and status lines.
+    """
+    entry = msg
+    if exc is not None:
+        entry = f"{msg}\n" + "".join(traceback.format_exception(exc))
+    log.error("%s", entry)
+    add_error(entry)
+    options = {"parent": parent} if parent is not None else {}
+    messagebox.showerror(title or tr("dialog.error.title", "Error"), msg, **options)
+    return msg

--- a/src/hoi4cm/ui/file_errors.py
+++ b/src/hoi4cm/ui/file_errors.py
@@ -8,12 +8,11 @@ targets still hold their previous contents — the message says so.
 """
 
 import os
-from tkinter import messagebox
 
 # Core *submodules*, not the facade: core/__init__ imports hoi4cm.ui before it
 # binds these names (see tests/test_import_order.py).
 from hoi4cm.core.i18n import tr
-from hoi4cm.core.logger import add_error
+from hoi4cm.ui.error_report import report_error
 
 __all__ = ["report_write_failure"]
 
@@ -26,7 +25,6 @@ def report_write_failure(parent, path, error, *, title=None):
     callers that also want it in a status line.
     """
     name = os.path.basename(str(path)) or str(path)
-    add_error(f"Write failed: {path}: {error}")
     message = tr(
         "dialog.write_failed.body",
         "Could not write {file}:\n{error}\n\n"
@@ -34,10 +32,10 @@ def report_write_failure(parent, path, error, *, title=None):
         file=name,
         error=error,
     )
-    options = {"parent": parent} if parent is not None else {}
-    messagebox.showerror(
-        title or tr("dialog.write_failed.title", "Write Failed"),
+    report_error(
         message,
-        **options,
+        error,
+        parent=parent,
+        title=title or tr("dialog.write_failed.title", "Write Failed"),
     )
     return message

--- a/src/hoi4cm/ui/mod_loading.py
+++ b/src/hoi4cm/ui/mod_loading.py
@@ -24,6 +24,7 @@ from hoi4cm.ui import (
     TEXT,
     TEXT_DIM,
 )
+from hoi4cm.ui.error_report import report_error
 from hoi4cm.ui.tasks import make_progress, run_bg
 from hoi4cm.wizards import _shared as _wiz_shared
 
@@ -37,14 +38,14 @@ class ModLoadingMixin:
     def _load_mod_path(self, root):
         """Load a mod directly from a known path (used by Recent Mods menu)."""
         if not root or not os.path.isdir(root):
-            messagebox.showerror(
-                tr("dialog.mod_not_found.title", "Mod Not Found"),
+            report_error(
                 tr(
                     "dialog.mod_not_found.body",
                     "The folder no longer exists:\n{path}",
                     path=root,
                 ),
                 parent=self,
+                title=tr("dialog.mod_not_found.title", "Mod Not Found"),
             )
             # Remove stale entry
             if hasattr(MOD, "_recent_mods") and root in MOD._recent_mods:

--- a/src/hoi4cm/wizards/decision.py
+++ b/src/hoi4cm/wizards/decision.py
@@ -42,6 +42,7 @@ from hoi4cm.ui import (
     TEXT_DIM,
     open_gfx_placement_editor,
     open_universal_gfx_browser,
+    report_error,
 )
 from hoi4cm.wizards import _generators
 from hoi4cm.wizards._graphics import find_catalog_image
@@ -4511,7 +4512,7 @@ def open_decision_wizard(app):
                 with open(path, encoding="utf-8", errors="replace") as f:
                     raw = f.read()
             except Exception as e:
-                messagebox.showerror("Import Error", str(e), parent=win)
+                report_error(str(e), e, parent=win, title="Import Error")
                 continue
 
             for cat_name, cat_inner, _ in find_blocks(raw):
@@ -4751,7 +4752,7 @@ def open_decision_wizard(app):
                         if lm:
                             loc2[lm.group(1)] = lm.group(2)
             except Exception as e:
-                messagebox.showerror("YML Error", str(e), parent=win)
+                report_error(str(e), e, parent=win, title="YML Error")
                 return
         updated = 0
         for c in dm_cats:
@@ -4790,7 +4791,7 @@ def open_decision_wizard(app):
             )
             _dm_status.config(text="  ✓  Exported")
         except Exception as e:
-            messagebox.showerror("Export Error", str(e), parent=win)
+            report_error(str(e), e, parent=win, title="Export Error")
 
     def _copy_yml():
         _collect()

--- a/src/hoi4cm/wizards/dyn_mod.py
+++ b/src/hoi4cm/wizards/dyn_mod.py
@@ -33,6 +33,7 @@ from hoi4cm.ui import (
     TEXT_DIM,
     _safe_after,
     _safe_after_idle,
+    report_error,
 )
 from hoi4cm.wizards._generators import build_dyn_mod_output
 from hoi4cm.wizards._graphics import browser_folders, collect_image_pairs
@@ -1222,7 +1223,7 @@ def open_dyn_mod_wizard(app):
 
         # ── Summary ───────────────────────────────────────────
         if errors:
-            messagebox.showerror("Errors during file generation", "\n".join(errors))
+            report_error("\n".join(errors), title="Errors during file generation")
 
         lines = [f"Mod root: {mod_root}\n"]
         for rel, action, note in results:
@@ -1341,14 +1342,14 @@ def open_dyn_mod_wizard(app):
                 parsed = parse_script(src)
                 blk = parsed.get(modifier_id, {})
                 if not isinstance(blk, dict):
-                    messagebox.showerror(
-                        "Parse Error",
+                    report_error(
                         f"Could not parse modifier '{modifier_id}'",
                         parent=dlg,
+                        title="Parse Error",
                     )
                     return
             except Exception as e:
-                messagebox.showerror("Parse Error", str(e), parent=dlg)
+                report_error(str(e), e, parent=dlg, title="Parse Error")
                 return
 
             # Populate identity fields

--- a/src/hoi4cm/wizards/event.py
+++ b/src/hoi4cm/wizards/event.py
@@ -37,6 +37,7 @@ from hoi4cm.ui import (
     TEXT_DIM,
     _safe_after,
     _safe_after_idle,
+    report_error,
 )
 from hoi4cm.wizards import _generators
 from hoi4cm.wizards._graphics import (
@@ -1074,7 +1075,7 @@ def open_event_wizard(app):
         try:
             WorkspaceFiles().write_text(path, _generate_all_txt(), encoding="utf-8")
         except Exception as e:
-            messagebox.showerror("Export Error", str(e), parent=win)
+            report_error(str(e), e, parent=win, title="Export Error")
             return
         status_lbl.config(text=f"  ✓  Exported {len(events)} events")
 
@@ -1392,7 +1393,7 @@ def open_event_wizard(app):
             with open(path, encoding="utf-8", errors="replace") as f:
                 raw = f.read()
         except Exception as e:
-            messagebox.showerror("Import Error", str(e), parent=win)
+            report_error(str(e), e, parent=win, title="Import Error")
             return
 
         def _str_val(v, default=""):

--- a/src/hoi4cm/wizards/national_spirit.py
+++ b/src/hoi4cm/wizards/national_spirit.py
@@ -39,6 +39,7 @@ from hoi4cm.ui import (
     TEXT_DIM,
     _safe_after,
     _safe_after_idle,
+    report_error,
 )
 from hoi4cm.wizards._generators import build_national_spirit_output
 from hoi4cm.wizards._graphics import browser_folders, collect_image_pairs
@@ -1815,14 +1816,14 @@ def open_national_spirit_wizard(app):
                     slot_data.get(spirit_id, {}) if isinstance(slot_data, dict) else {}
                 )
                 if not isinstance(spirit, dict):
-                    messagebox.showerror(
-                        "Parse Error",
+                    report_error(
                         f"Could not parse spirit '{spirit_id}'",
                         parent=dlg,
+                        title="Parse Error",
                     )
                     return
             except Exception as e:
-                messagebox.showerror("Parse Error", str(e), parent=dlg)
+                report_error(str(e), e, parent=dlg, title="Parse Error")
                 return
 
             # Populate identity fields

--- a/tests/test_canvas_tk.py
+++ b/tests/test_canvas_tk.py
@@ -54,6 +54,14 @@ class _FakeApp(CanvasMixin):
         # them declared on the class for the tests that widen the bounds.
         self._canvas_min = [0, 0]
         self._canvas_max = [self.CANVAS_MIN_SIZE - 1, self.CANVAS_MIN_SIZE - 1]
+        # _unload_extra_tree touches these; the App defines them, the bare
+        # host declares them so tests can override without surprising pylint.
+        self._shared_focuses = []
+        self._joint_focuses = []
+        self._invalidate_tree_badges = lambda: None
+        self._refresh_tree_meta_panel = lambda: None
+        self._refresh_loaded_trees_panel = lambda: None
+        self._invalidate_focus_list_structure = lambda: None
         self._reset_canvas_bounds()
 
     def _get_tree_badge(self, tree_idx):
@@ -406,7 +414,7 @@ def test_unload_extra_tree_deletes_pooled_connection_items(tk_root):
     app._invalidate_tree_badges = lambda: None
     app._refresh_tree_meta_panel = lambda: None
     app._refresh_loaded_trees_panel = lambda: None
-    app._redraw = lambda: None
+    app._redraw = lambda *args, **kwargs: None
     app._invalidate_focus_list_structure = lambda: None
     app._draw_lines((-1.0, -1.0, 100.0, 1.0))
     assert len(cv.find_withtag("line")) == 22

--- a/tests/test_error_report.py
+++ b/tests/test_error_report.py
@@ -1,0 +1,67 @@
+"""Tests for hoi4cm.ui.error_report — the generic error reporter (issue #52).
+
+Headless: the dialog call is stubbed, no Tk root is ever created.
+"""
+
+import pytest
+
+import hoi4cm.core.logger as logmod
+import hoi4cm.ui.error_report as error_report
+
+
+@pytest.fixture
+def shown(monkeypatch):
+    """Capture the messagebox call and isolate the shared error buffer."""
+    calls = []
+    monkeypatch.setattr(
+        error_report.messagebox,
+        "showerror",
+        lambda title, message, **options: calls.append((title, message, options)),
+    )
+    logmod.clear_errors()
+    yield calls
+    logmod.clear_errors()
+
+
+def test_message_is_logged_and_shown(shown):
+    message = error_report.report_error("Could not parse XML")
+
+    assert shown == [("Error", "Could not parse XML", {})]
+    assert message == "Could not parse XML"
+    entries = logmod.get_error_entries()
+    assert len(entries) == 1
+    assert entries[0][1] == "Could not parse XML"
+
+
+def test_exception_appends_traceback_to_log_entry_only(shown):
+    try:
+        raise ValueError("bad value")
+    except ValueError as exc:
+        error_report.report_error("Parse failed", exc)
+
+    entry = logmod.get_error_entries()[0][1]
+    assert entry.startswith("Parse failed\nTraceback")
+    assert "ValueError: bad value" in entry
+    # The dialog shows the message only, not the traceback.
+    assert shown[0][1] == "Parse failed"
+
+
+def test_parent_is_omitted_rather_than_passed_as_none(shown):
+    # Tk rejects `-parent None`; the reporter has to leave the option out.
+    error_report.report_error("boom")
+
+    assert shown[0][2] == {}
+
+
+def test_parent_window_is_forwarded_when_given(shown):
+    sentinel = object()
+
+    error_report.report_error("boom", parent=sentinel)
+
+    assert shown[0][2] == {"parent": sentinel}
+
+
+def test_custom_title_overrides_the_default(shown):
+    error_report.report_error("boom", title="Parse Error")
+
+    assert shown[0][0] == "Parse Error"

--- a/tests/test_error_report.py
+++ b/tests/test_error_report.py
@@ -65,3 +65,13 @@ def test_custom_title_overrides_the_default(shown):
     error_report.report_error("boom", title="Parse Error")
 
     assert shown[0][0] == "Parse Error"
+
+
+def test_non_exception_error_object_does_not_crash(shown):
+    # The old add_error pattern sometimes logged strings; the reporter must
+    # survive whatever error object a caller hands it.
+    message = error_report.report_error("Write failed: x", "disk full")
+
+    assert message == "Write failed: x"
+    assert len(logmod.get_error_entries()) == 1
+    assert shown[0][1] == "Write failed: x"

--- a/tests/test_file_errors.py
+++ b/tests/test_file_errors.py
@@ -6,6 +6,7 @@ Headless: the dialog call is stubbed, no Tk root is ever created.
 import pytest
 
 import hoi4cm.core.logger as logmod
+import hoi4cm.ui.error_report as error_report
 import hoi4cm.ui.file_errors as file_errors
 
 
@@ -14,7 +15,7 @@ def shown(monkeypatch):
     """Capture the messagebox call and isolate the shared error buffer."""
     calls = []
     monkeypatch.setattr(
-        file_errors.messagebox,
+        error_report.messagebox,
         "showerror",
         lambda title, message, **options: calls.append((title, message, options)),
     )
@@ -61,6 +62,17 @@ def test_parent_window_is_forwarded_when_given(shown):
     file_errors.report_write_failure(sentinel, "tree.txt", OSError("nope"))
 
     assert shown[0][2] == {"parent": sentinel}
+
+
+def test_failure_entry_carries_the_traceback(shown):
+    try:
+        raise OSError("disk full")
+    except OSError as exc:
+        file_errors.report_write_failure(None, "tree.txt", exc)
+
+    entry = logmod.get_error_entries()[0][1]
+    assert "OSError: disk full" in entry
+    assert "Traceback" in entry
 
 
 def test_custom_title_overrides_the_default(shown):

--- a/tests/test_monolith_error_reporting.py
+++ b/tests/test_monolith_error_reporting.py
@@ -1,0 +1,94 @@
+"""Integration tests: monolith error shells report instead of raising (issue #52).
+
+Drives the monolith's `_load` and `_apply_focus_code` failure paths through
+the real reporter: the dialog call is the only stub, the error buffer and
+`report_error` are the production ones. Both failure paths return before
+touching any widget state, so a bare shell stands in for the App.
+"""
+
+import pytest
+
+import hoi4_content_maker as m
+import hoi4cm.core.logger as logmod
+import hoi4cm.ui.error_report as error_report
+from hoi4cm.models import Focus, FocusDocument
+
+
+@pytest.fixture
+def shown(monkeypatch):
+    """Capture the error dialog and isolate the shared error buffer."""
+    calls = []
+    monkeypatch.setattr(
+        error_report.messagebox,
+        "showerror",
+        lambda title, message, **options: calls.append((title, message, options)),
+    )
+    orig_cb = logmod._error_callback
+    logmod.set_error_callback(None)
+    logmod.clear_errors()
+    yield calls
+    logmod._error_callback = orig_cb
+    logmod.clear_errors()
+
+
+def test_load_reports_a_corrupt_project(shown, monkeypatch):
+    monkeypatch.setattr(m.filedialog, "askopenfilename", lambda **_kw: "bad.json")
+
+    def boom(path):
+        raise ValueError(f"invalid JSON in {path}")
+
+    monkeypatch.setattr(m, "read_project", boom)
+
+    m.App._load(object())
+
+    assert len(shown) == 1
+    title, message, _options = shown[0]
+    assert title == "Load Project Error"
+    assert "invalid JSON" in message
+    entries = logmod.get_error_entries()
+    assert len(entries) == 1
+    assert "invalid JSON" in entries[0][1]
+    assert "Traceback" in entries[0][1]
+
+
+def test_load_cancel_shows_nothing(shown, monkeypatch):
+    monkeypatch.setattr(m.filedialog, "askopenfilename", lambda **_kw: "")
+
+    m.App._load(object())
+
+    assert shown == []
+    assert logmod.get_error_entries() == []
+
+
+def test_save_reports_a_write_failure(shown, monkeypatch):
+    monkeypatch.setattr(m.filedialog, "asksaveasfilename", lambda **_kw: "out.json")
+
+    def boom(path, workspace):
+        raise PermissionError("read-only folder")
+
+    monkeypatch.setattr(m, "write_project", boom)
+    shell = type("Shell", (), {"_capture_workspace": lambda self: None})()
+
+    m.App._save(shell)
+
+    assert len(shown) == 1
+    title, message, _options = shown[0]
+    assert title == "Write Failed"
+    assert "read-only folder" in message
+    entry = logmod.get_error_entries()[0][1]
+    assert "read-only folder" in entry
+    assert "Traceback" in entry
+
+
+def test_apply_focus_code_reports_a_parse_failure(shown):
+    shell = type("Shell", (), {"focuses": FocusDocument()})()
+    focus = Focus()
+
+    assert m.App._apply_focus_code(shell, focus, "not a focus block") is False
+
+    assert len(shown) == 1
+    title, message, _options = shown[0]
+    assert title == "Parse Error"
+    assert "Check Error Log for details" in message
+    entry = logmod.get_error_entries()[0][1]
+    assert "Traceback" in entry

--- a/tests/test_wizard_generators_dyn_mod.py
+++ b/tests/test_wizard_generators_dyn_mod.py
@@ -163,7 +163,7 @@ def test_build_dyn_mod_output_golden_definition_block():
         mods_raw="stability_factor = AM_stab = stab_tt",
         const="consumer_goods_factor = 0.05",
     )
-    definition = out.split("\n\n\n")[0]
+    definition = out.split("\n\n\n", maxsplit=1)[0]
     assert definition == "\n".join(
         [
             "# ============================================================",


### PR DESCRIPTION
Closes #52.
Also closes #68 (mypy PEP 758 workaround removed, see QA note below).

## What

Handled errors now reach the in-app error log instead of only flashing a dialog:

- New `report_error(msg, exc=None, *, parent=None, title=None)` in `hoi4cm.ui.error_report` writes one entry to the HOI4CM file log, records `msg` plus the exception's traceback via `add_error` (so the badge flashes and the log window shows it), then raises the dialog. Only real exceptions contribute a traceback, so the reporter itself can never raise.
- `report_write_failure` delegates to it; write failures now carry a traceback in the log too.
- Converted the synchronous dialog-only sites: `_apply_focus_code` (previously logged `str(ex)` with no traceback), drawio read, import read, extra-tree read, and the mod-not-found path; all import/export/parse failures in the decision, event, dynamic modifier, and national spirit wizards.
- `_load` now guards `read_project`, so a corrupt project JSON gets a dialog plus a log entry instead of a bare console traceback.

Left alone on purpose: the three `run_bg` `on_error` dialogs (drawio parse, load-all, export plans) already land in the log via `ui/tasks.py`'s `add_error`, and the pure user-input validation dialogs (sidebar numeric/empty ID, settings profile fields) are expected user nags, not program failures. The 144 `BLE` blind-excepts are a separate sweep, not part of this change.

## Why

The in-app error log, its badge flash, and the log window were all built and wired, but `add_error` was reached from only three places. `_apply_focus_code`'s own dialog says "Check Error Log for details", which was only true for that one path.

## How

The helper lives in `ui/` rather than `core/logger.py` as the issue sketch suggested: core is deliberately Tk-free and `core/__init__` imports `hoi4cm.ui` before it binds logger names, so a dialog-shower in core would risk the import cycle `tests/test_import_order.py` guards against.

## Tests

- `tests/test_error_report.py` — helper contract headless: dialog message/title/parent, traceback appended to the log entry only, non-exception error objects don't crash the reporter.
- `tests/test_monolith_error_reporting.py` — integration: drives `_load` (corrupt project), `_save` (failed write), and `_apply_focus_code` (parse failure) through the real reporter with only the dialog stubbed; cancel paths stay silent.
- `tests/test_file_errors.py` — write failures now carry a traceback in the log entry.

## QA / tooling note

QA of the feature found and fixed one real bug (the reporter crashed on non-exception error objects). It also cleared the remaining tooling findings:

- `native_parser = true` in `[tool.mypy]` and the eight PEP 758 `exclude` entries removed — mypy now type-checks 137 files instead of 130 (issue #68).
- Dev floors pinned to the verified versions: `mypy>=2.3.0`, `pylint>=4.0.7`, pre-commit pylint rev `v4.0.7`, so local and CI lint with the same toolchain.
- Fixed the two pylint findings in `tests/test_canvas_tk.py` and `tests/test_wizard_generators_dyn_mod.py` that older pylint reported.
