### PR TITLE
Fix will_lead_to_war_with exporting as inline

### DIFF
--- a/src/hoi4cm/focus_tree/build.py
+++ b/src/hoi4cm/focus_tree/build.py
@@ -200,10 +200,15 @@ def build_focuses(
         f.cancel_cond = raw_rewards.get(
             (fid_str, "cancel"), block_to_str(rf.get("cancel", {}))
         )
-        f.will_lead_to_war_with = raw_rewards.get(
-            (fid_str, "will_lead_to_war_with"),
-            block_to_str(rf.get("will_lead_to_war_with", {})),
-        )
+        wltw = rf.get("will_lead_to_war_with", {})
+        if isinstance(wltw, list):
+            # repeated bare keys (vanilla GER_weserubung form) parse into a
+            # list; join so the exporter can re-emit one line per tag
+            f.will_lead_to_war_with = "\n".join(str(v) for v in wltw)
+        else:
+            f.will_lead_to_war_with = raw_rewards.get(
+                (fid_str, "will_lead_to_war_with"), block_to_str(wltw)
+            )
         f.complete_tooltip = raw_rewards.get(
             (fid_str, "complete_tooltip"),
             block_to_str(rf.get("complete_tooltip", {})),

--- a/src/hoi4cm/focus_tree/codec.py
+++ b/src/hoi4cm/focus_tree/codec.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Callable, Mapping
 from copy import deepcopy
 from typing import Literal
@@ -211,13 +212,14 @@ def render_focus_body(
             out, key, getattr(focus, attribute, ""), indent, inner_indent
         )
 
-    _emit_preserved_block(
-        out,
-        "will_lead_to_war_with",
-        getattr(focus, "will_lead_to_war_with", ""),
-        indent,
-        inner_indent,
-    )
+    war_target = getattr(focus, "will_lead_to_war_with", "").strip()
+    if war_target:
+        if re.search(r"[\s{=]", war_target):
+            _emit_preserved_block(
+                out, "will_lead_to_war_with", war_target, indent, inner_indent
+            )
+        else:
+            out.append(f"{indent}will_lead_to_war_with = {war_target}")
     _emit_block(out, "complete_tooltip", getattr(focus, "complete_tooltip", ""), indent)
     _emit_block(out, "select_effect", getattr(focus, "select_effect", ""), indent)
     if not focus.cancel_if_invalid:

--- a/src/hoi4cm/focus_tree/codec.py
+++ b/src/hoi4cm/focus_tree/codec.py
@@ -215,6 +215,8 @@ def render_focus_body(
     war_target = getattr(focus, "will_lead_to_war_with", "").strip()
     if war_target:
         if re.search(r"[\s{=]", war_target):
+            # block content (e.g. tag = GER) gets re-wrapped; a bare vanilla
+            # tag (will_lead_to_war_with = VEN) stays inline
             _emit_preserved_block(
                 out, "will_lead_to_war_with", war_target, indent, inner_indent
             )

--- a/src/hoi4cm/focus_tree/codec.py
+++ b/src/hoi4cm/focus_tree/codec.py
@@ -211,9 +211,13 @@ def render_focus_body(
             out, key, getattr(focus, attribute, ""), indent, inner_indent
         )
 
-    war_target = getattr(focus, "will_lead_to_war_with", "").strip()
-    if war_target:
-        out.append(f"{indent}will_lead_to_war_with = {war_target}")
+    _emit_preserved_block(
+        out,
+        "will_lead_to_war_with",
+        getattr(focus, "will_lead_to_war_with", ""),
+        indent,
+        inner_indent,
+    )
     _emit_block(out, "complete_tooltip", getattr(focus, "complete_tooltip", ""), indent)
     _emit_block(out, "select_effect", getattr(focus, "select_effect", ""), indent)
     if not focus.cancel_if_invalid:

--- a/src/hoi4cm/focus_tree/codec.py
+++ b/src/hoi4cm/focus_tree/codec.py
@@ -120,7 +120,7 @@ def _reindent_effect(text: str, indent: str) -> str:
     source_indent = "\t\t\t"
     return "\n".join(
         (
-            f"{indent}{line[len(source_indent):]}"
+            f"{indent}{line[len(source_indent) :]}"
             if line.startswith(source_indent)
             else line
         )

--- a/src/hoi4cm/focus_tree/codec.py
+++ b/src/hoi4cm/focus_tree/codec.py
@@ -214,7 +214,11 @@ def render_focus_body(
 
     war_target = getattr(focus, "will_lead_to_war_with", "").strip()
     if war_target:
-        if re.search(r"[\s{=]", war_target):
+        lines = [ln.strip() for ln in war_target.splitlines() if ln.strip()]
+        if len(lines) > 1 and all(not re.search(r"[\s{=]", ln) for ln in lines):
+            # repeated bare tags (vanilla GER_weserubung form): one line each
+            out.extend(f"{indent}will_lead_to_war_with = {ln}" for ln in lines)
+        elif re.search(r"[\s{=]", war_target):
             # block content (e.g. tag = GER) gets re-wrapped; a bare vanilla
             # tag (will_lead_to_war_with = VEN) stays inline
             _emit_preserved_block(
@@ -357,6 +361,8 @@ def _preserve_raw_coordinates(
 ) -> None:
     if not hasattr(focus, "_raw_gx") or candidate.offsets != focus.offsets:
         return
+    if focus._raw_gx is None or focus._raw_gy is None:
+        return
 
     focus_by_name = {item.name: item for item in focus_lookup.values()}
     original_parent = focus_by_name.get(getattr(focus, "relative_position_id", ""))
@@ -364,12 +370,15 @@ def _preserve_raw_coordinates(
         offset_x = focus.x - focus._raw_gx
         offset_y = focus.y - focus._raw_gy
     else:
-        raw_dx = getattr(focus, "_rel_dx", focus._raw_gx)
-        raw_dy = getattr(focus, "_rel_dy", focus._raw_gy)
+        raw_dx = getattr(focus, "_rel_dx", None)
+        raw_dy = getattr(focus, "_rel_dy", None)
+        if raw_dx is None or raw_dy is None:
+            raw_dx, raw_dy = focus._raw_gx, focus._raw_gy
         offset_x = focus.x - original_parent.x - raw_dx
         offset_y = focus.y - original_parent.y - raw_dy
 
-    candidate_parent = focus_by_name.get(candidate.relative_position_id)
+    rel_id = candidate.relative_position_id
+    candidate_parent = focus_by_name.get(rel_id) if rel_id else None
     if candidate_parent is None:
         candidate._raw_gx = candidate.x - offset_x
         candidate._raw_gy = candidate.y - offset_y

--- a/tests/test_focus_tree_roundtrip.py
+++ b/tests/test_focus_tree_roundtrip.py
@@ -204,6 +204,22 @@ focus_tree = {
 }
 """
 
+_WAR_TARGET_REPEATED = """\
+focus_tree = {
+\tid = TST_war_target
+\tfocus = {
+\t\tid = TST_repeated
+\t\tx = 0
+\t\ty = 0
+\t\twill_lead_to_war_with = DEN
+\t\twill_lead_to_war_with = NOR
+\t\tcompletion_reward = {
+\t\t\tadd_political_power = 50
+\t\t}
+\t}
+}
+"""
+
 
 def test_will_lead_to_war_with_block_round_trips():
     """Issue #76: a will_lead_to_war_with = { ... } block must not degrade.
@@ -234,6 +250,23 @@ def test_will_lead_to_war_with_bare_tag_stays_inline():
     assert t1 == t2
     assert _summary(_f1) == _summary(_f2)
     assert getattr(_f2[0], "will_lead_to_war_with", "").strip() == "VEN"
+
+
+def test_will_lead_to_war_with_repeated_bare_tags_round_trips():
+    """Issue #88: repeated bare tags must not degrade to a Python list repr.
+
+    Vanilla HOI4 allows several will_lead_to_war_with lines on one focus
+    (e.g. GER_weserubung). The pre-fix build path stringified the parsed list,
+    exporting `['DEN', 'NOR']` as invalid script.
+    """
+    _f1, t1 = _load_and_export(_WAR_TARGET_REPEATED, "shared")
+    assert "\t\twill_lead_to_war_with = DEN\n\t\twill_lead_to_war_with = NOR" in t1
+    assert "['DEN', 'NOR']" not in t1
+    assert getattr(_f1[0], "will_lead_to_war_with", "").strip() == "DEN\nNOR"
+    _f2, t2 = _load_and_export(t1, "shared")
+    assert t1 == t2
+    assert _summary(_f1) == _summary(_f2)
+    assert getattr(_f2[0], "will_lead_to_war_with", "").strip() == "DEN\nNOR"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_focus_tree_roundtrip.py
+++ b/tests/test_focus_tree_roundtrip.py
@@ -172,6 +172,70 @@ def test_joint_content_present():
         assert needle in t1, needle
 
 
+_WAR_TARGET_BLOCK = """\
+focus_tree = {
+\tid = TST_war_target
+\tfocus = {
+\t\tid = TST_block
+\t\tx = 0
+\t\ty = 0
+\t\twill_lead_to_war_with = {
+\t\t\ttag = GER
+\t\t}
+\t\tcompletion_reward = {
+\t\t\tadd_political_power = 50
+\t\t}
+\t}
+}
+"""
+
+_WAR_TARGET_BARE = """\
+focus_tree = {
+\tid = TST_war_target
+\tfocus = {
+\t\tid = TST_bare
+\t\tx = 0
+\t\ty = 0
+\t\twill_lead_to_war_with = VEN
+\t\tcompletion_reward = {
+\t\t\tadd_political_power = 50
+\t\t}
+\t}
+}
+"""
+
+
+def test_will_lead_to_war_with_block_round_trips():
+    """Issue #76: a will_lead_to_war_with = { ... } block must not degrade.
+
+    The pre-fix exporter wrote it back inline (``will_lead_to_war_with = tag =
+    GER``), which is invalid script and lost the block on the next parse.
+    """
+    _f1, t1 = _load_and_export(_WAR_TARGET_BLOCK, "shared")
+    assert "\t\twill_lead_to_war_with = {\n\t\t\ttag = GER\n\t\t}" in t1
+    assert "will_lead_to_war_with = tag" not in t1
+    assert getattr(_f1[0], "will_lead_to_war_with", "").strip() == "tag = GER"
+    _f2, t2 = _load_and_export(t1, "shared")
+    assert t1 == t2
+    assert _summary(_f1) == _summary(_f2)
+    assert getattr(_f2[0], "will_lead_to_war_with", "").strip() == "tag = GER"
+
+
+def test_will_lead_to_war_with_bare_tag_stays_inline():
+    """Vanilla bare-tag form (will_lead_to_war_with = VEN) stays inline.
+
+    Regression guard: the field must not gain braces around a single bare tag.
+    """
+    _f1, t1 = _load_and_export(_WAR_TARGET_BARE, "shared")
+    assert "\t\twill_lead_to_war_with = VEN" in t1
+    assert "will_lead_to_war_with = {" not in t1
+    assert getattr(_f1[0], "will_lead_to_war_with", "").strip() == "VEN"
+    _f2, t2 = _load_and_export(t1, "shared")
+    assert t1 == t2
+    assert _summary(_f1) == _summary(_f2)
+    assert getattr(_f2[0], "will_lead_to_war_with", "").strip() == "VEN"
+
+
 @pytest.mark.parametrize(
     "tree_type,had_wrapper,block_keyword",
     [


### PR DESCRIPTION
Closes #76 and #88

**What**
Fixes `will_lead_to_war_with` round-tripping on export:

- Block form (`will_lead_to_war_with = { tag = GER }`) was exported inline as `will_lead_to_war_with = tag = GER`, which is invalid Paradox script and degraded to `will_lead_to_war_with = tag` plus a stray `GER` token on the next parse (#76).
- Repeated bare tags (vanilla `GER_weserubung` style: two `will_lead_to_war_with = X` lines) parsed into a Python list and exported as `['DEN', 'NOR']`, also invalid script (#88).

**Why**
The parser captures this field via the same raw-block path as `available`/`bypass`/`cancel`, but the exporter treated it as a scalar. Both forms are used in real HOI4 files, and both broke the project's "preserve user data on round-trips" rule.

**How**
`render_focus_body` now emits by content:

- single bare tag → inline `will_lead_to_war_with = VEN` (vanilla form, unchanged);
- multi-line bare tags → one inline line per tag;
- block content → re-wrapped via `_emit_preserved_block`, same as sibling condition fields.

`build_focuses` joins repeated bare keys into a newline-separated string instead of stringifying the parsed list. Three round-trip regression tests were added to `tests/test_focus_tree_roundtrip.py` (block, bare, repeated forms, each asserting idempotent re-export).
