### PR TITLE
Fix Idea Wizard modifier list overflow and scroll-close (issue #72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Application Modernization — Python Floor Raised to 3.14
 
 **Minimum supported Python is now 3.14, up from 3.9.**
+
 - `requires-python` in `pyproject.toml` bumped to `>=3.14`. CI's test matrix collapsed
   from `3.9`/`3.13` to `3.14` only, and the lint job moved off `3.12` to match.
 - `black` now targets `py314` and `ruff` infers the same from `requires-python`, so both
@@ -24,6 +25,7 @@
 ### Extra-tree unload removes connector lines (issue #80)
 
 **[BUG FIX] Unloading a shared or joint tree now removes its connection lines**
+
 - The focus cards disappeared correctly, but their prerequisite and mutex
   connectors remained visible at their old canvas positions for the rest of
   the session.
@@ -34,11 +36,26 @@
 ### Minimap opens and renders (issue #81)
 
 **[BUG FIX] Opening the minimap no longer raises `TclError` or leaves its toggle state inconsistent**
+
 - On a Tkinter `Canvas`, the usual widget-raising aliases resolve to the
   canvas-item `tag_raise` operation, which requires an item ID. Pressing M or
   choosing Tools -> Minimap therefore failed before the minimap could render.
 - The minimap now explicitly uses Tk's generic widget-raising implementation.
   Widget coverage verifies that it renders, hides, and reopens normally.
+
+### Idea Wizard modifier list scrolls and fits the screen (issue #72)
+
+**[BUG FIX] The Idea Wizard's modifier picker no longer overflows or closes on scroll**
+
+- The picker was a native `OptionMenu`, whose menu cannot scroll: with a
+  category holding 150+ modifiers it posted a menu taller than the screen,
+  mouse-wheel events unposted it while selecting whatever was under the
+  pointer, and off-screen entries were reachable only via keyboard.
+- It is now a `ScrollableDropdown` (`hoi4cm.ui.widgets`): a button that posts
+  a borderless popup holding a scrollable list, sized to the remaining screen
+  space and flipped above the button when there is more room up there. The
+  wheel scrolls, arrows move the highlight, Return commits, and Escape or
+  focus loss closes without selecting.
 
 ---
 
@@ -50,6 +67,7 @@ They are recorded here so they don't get "fixed" back.
 ### Code-tab apply replaces every editable field
 
 **[BEHAVIOR CHANGE] Applying the Code tab now resets fields you leave out**
+
 - The old regex patcher only rewrote the fields it recognized and left the
   rest untouched. The new apply parses the block and rewrites every editable
   field, so a field you delete from the code is reset to its parser default
@@ -58,6 +76,7 @@ They are recorded here so they don't get "fixed" back.
 ### Focus-sprite scanning honors `path_goals`
 
 **[BEHAVIOR CHANGE] Focus icons are read from your configured goals path**
+
 - Focus-sprite discovery used to hardcode `gfx/interface/goals`. It now
   honors the `path_goals` setting, so a mod that keeps focus goal icons
   somewhere else has them found.
@@ -65,6 +84,7 @@ They are recorded here so they don't get "fixed" back.
 ### Quote-aware script parsing
 
 **[BEHAVIOR CHANGE] `#` and `{ }` inside quoted strings now parse correctly**
+
 - Comments and braces inside a quoted value are no longer treated as real
   comments or braces, so a value like `"a # b { c }"` parses intact instead
   of getting truncated. Clausewitz has no string escapes, so a quoted value
@@ -74,6 +94,7 @@ They are recorded here so they don't get "fixed" back.
 ### Every mod-file write is atomic (issue #46)
 
 **[BUG FIX] A failed export no longer destroys the file it was overwriting**
+
 - Export wrote the focus `.txt` and the loc `.yml` with a plain
   `open(path, "w")`, which truncates the target before writing a byte. When an
   edit target was set, that target is your existing tracked mod file — a crash,
@@ -92,6 +113,7 @@ They are recorded here so they don't get "fixed" back.
   for an export that did not land.
 
 **[BEHAVIOR CHANGE] Exporting into a read-only folder now fails instead of overwriting**
+
 - An atomic write needs write permission on the target's *directory*, not just on
   the file, so a mod folder you can't write to is now reported as a clear error
   rather than silently accepting an in-place overwrite. Make the folder writable
@@ -104,6 +126,7 @@ They are recorded here so they don't get "fixed" back.
 ### Focus Tree — `_raw_rewards` Regex Missing `shared_focus` Blocks
 
 **[BUG FIX] `shared_focus = { }` blocks were silently skipped by the raw-block extractor**
+
 - `_load_extra_tree` (line ~17629) and `_load_extra_tree_from_path` (line ~18341)
 - The regex `r'\b(?:joint_focus|focus)\s*=\s*\{'` used a word-boundary `\b` before `focus`.
   In `shared_focus`, the preceding `_` is a word character, so `\bfocus` never matched inside it.
@@ -117,6 +140,7 @@ They are recorded here so they don't get "fixed" back.
 ### Focus Tree — Auto-Fit Viewport Missing After Import and Extra Tree Load
 
 **[BUG FIX] Loading any tree (main import or `+ Shared` / `+ Joint`) left the viewport unchanged, making focuses appear off-screen or "in the wrong position"**
+
 - `_import_txt` (line ~17472), `_load_extra_tree` (line ~17896), `_load_extra_tree_from_path` (line ~18571)
 - All three functions called `_redraw()` (throttled, preserves current zoom/pan) but not `_fit_all()`.
   The "Load All" batch dialog already called `_fit_all()` after loading; all other load paths did not.
@@ -138,6 +162,7 @@ They are recorded here so they don't get "fixed" back.
 ### Focus Tree — `tag =` → `original_tag =` (all remaining locations)
 
 **[BUG FIX] Draw.io import wizard preview code still used `tag =` instead of `original_tag =`**
+
 - Lines ~15436, ~15668, ~14904
 - The `_export()` function was already correct (`original_tag =`) but three other locations still emitted
   the wrong field: the Draw.io wizard's live preview text, the code preview pane built after import,
@@ -149,16 +174,19 @@ They are recorded here so they don't get "fixed" back.
 ### Focus Tree — Import Parser Reads Country Tag from File
 
 **[BUG FIX] Importing a `.txt` focus tree reset country tag to placeholder `"TAG"` instead of reading from file**
+
 - `_import_txt()`, around line ~15980
 - When importing an existing HOI4 focus tree file, the parser read the `focus_tree` block's `id` field
   but ignored the `country = { modifier = { original_tag = X } }` block entirely.
   The tag was inferred only from focus ID prefixes via `_detect_and_apply_tag()`, which fails for
   small trees or trees whose focus IDs don't follow the `TAG_` prefix convention.
 - Fix: after calling `parse_block()` on the `focus_tree` block, extract:
+
   ```
   block["country"]["modifier"]["original_tag"]  (preferred)
   block["country"]["modifier"]["tag"]            (backwards compat for old exports)
   ```
+
   Store the result as `self._tree_country_tag`. This value is used by `_export()` as the fallback
   tag when the tree ID doesn't match the `^TAG_` pattern.
 - Also: after `_detect_and_apply_tag()`, if the prefix was not auto-detected from focus names but
@@ -170,6 +198,7 @@ They are recorded here so they don't get "fixed" back.
 ### EFFECT_DEFS — Missing Scope Effects
 
 **[ADDED] `every_hostile_country` and `random_hostile_country` scope effects**
+
 - These country scopes iterate over / pick one of all countries currently at war with the current
   country. Commonly used in war-related focus completion rewards and event effects.
 - Both placed in the "Scopes" category alongside the existing `every_enemy_country` entry.
@@ -179,6 +208,7 @@ They are recorded here so they don't get "fixed" back.
 ### MODIFIER_DEFS — Missing Building-Specific Production Speed Modifiers
 
 **[ADDED] 18 building-specific `production_speed_X_factor` modifiers (Country category)**
+
 - `production_speed_industrial_complex_factor` — civilian factory
 - `production_speed_arms_factory_factor` — military factory
 - `production_speed_dockyard_factor`
@@ -202,6 +232,7 @@ They are recorded here so they don't get "fixed" back.
 ### MODIFIER_DEFS — Missing Resource-Specific State Modifiers
 
 **[ADDED] 6 `local_resources_X_factor` modifiers (State category)**
+
 - `local_resources_oil_factor`
 - `local_resources_steel_factor`
 - `local_resources_aluminium_factor`
@@ -218,12 +249,14 @@ They are recorded here so they don't get "fixed" back.
 ### Focus Tree Maker (`_export` and `_build_focus_code`)
 
 **[BUG FIX] `tag =` → `original_tag =` in focus_tree country block**
+
 - File line ~17655
 - The country selector block was emitting `tag = TAG`, which checks the current tag (can change
   during civil wars or puppeting). Changed to `original_tag = TAG`, which checks the permanent tag.
 - Without this fix the focus tree could load for the wrong nation in certain scenarios.
 
 **[BUG FIX] `search_filters = { FOCUS_FILTER_POLITICAL }` was silently dropped on export**
+
 - Lines ~17718–17720 (`_export`) and ~14447 (`_build_focus_code` preview)
 - The condition `if sf and sf != "FOCUS_FILTER_POLITICAL"` skipped writing the filter whenever
   it was set to the default political value. All political focuses were exported with no
@@ -231,6 +264,7 @@ They are recorded here so they don't get "fixed" back.
 - Fixed by removing the exclusion: `if sf:` now always writes the filter when set.
 
 **[BUG FIX] Focus log used wrong scope and missing "executed"**
+
 - Line ~17765 (`_export`) and ~15661 (import scaffold code path)
 - Was: `log = "[GetDateText]: [Root.GetName]: focus TAG_focus_name"`
 - Fixed to: `log = "[GetDateText]: [This.GetName]: focus TAG_focus_name executed"`
@@ -242,12 +276,14 @@ They are recorded here so they don't get "fixed" back.
 ## Session 1 — Output Correctness Fixes (Decision Maker)
 
 **[BUG FIX] `complete_effect` log — lowercase "decision" and extra " complete" suffix**
+
 - Lines ~7034 and ~7043
 - Was: `log = "[GetDateText]: [Root.GetName]: decision TAG_my_dec complete"`
 - Fixed to: `log = "[GetDateText]: [Root.GetName]: Decision TAG_my_dec"`
 - Matches the CLAUDE.md standard (capital D, no trailing word).
 
 **[BUG FIX] `remove_effect` log — said "decision … removed" instead of the effect identifier**
+
 - Line ~7053
 - Was: `log = "[GetDateText]: [Root.GetName]: decision TAG_my_dec removed"`
 - Fixed to: `log = "[GetDateText]: [Root.GetName]: remove_effect TAG_my_dec"`
@@ -258,6 +294,7 @@ They are recorded here so they don't get "fixed" back.
 ## Session 1 — Output Correctness Fixes (Event Maker)
 
 **[BUG FIX] Event wizard always emitted an empty `immediate` block**
+
 - Lines ~9632–9636
 - Even for `is_triggered_only = yes` events with no immediate effects, the wizard wrote:
   `immediate = { log = "..." }`. This adds unnecessary log I/O overhead on every trigger
@@ -266,6 +303,7 @@ They are recorded here so they don't get "fixed" back.
   the user has provided content.
 
 **[BUG FIX] Event option log was injected even when the option had no effects**
+
 - Line ~9644
 - CLAUDE.md rule: "Log only if there are actual effects in the option."
 - Was injecting a log line unconditionally into every option.
@@ -278,6 +316,7 @@ They are recorded here so they don't get "fixed" back.
 ### Effect System — `_normalize_effect_fields`
 
 **[BUG FIX] `set_variable` import stored field under wrong key `"var_name"`**
+
 - Lines ~10808–10815
 - When importing a file containing `set_variable = { TAG_my_var = 0.05 }`, the parsed dict
   was stored as `{"var_name": "TAG_my_var", "value": "0.05"}`.
@@ -286,6 +325,7 @@ They are recorded here so they don't get "fixed" back.
 - Fixed: normalized dict now uses `{"var": ..., "value": ...}`.
 
 **[BUG FIX] `add_to_variable` import stored fields under wrong keys `"variable"` / `"amount"`**
+
 - Lines ~10788–10794
 - Same class of bug. Imported `add_to_variable` effects always re-exported with the placeholder
   variable name `AM_my_stat_var` and default amount `0.05` regardless of actual content.
@@ -297,22 +337,26 @@ They are recorded here so they don't get "fixed" back.
 ### MD Additional Income Wizard
 
 **[BUG FIX] `localization_key` value in scripted_localisation block was double-quoted**
+
 - Line ~16575
 - Was generating: `localization_key = "my_tooltip_key"`
 - HOI4 scripted localisation expects bare (unquoted) keys for `localization_key`.
 - Fixed: now generates `localization_key = my_tooltip_key`.
 
 **[REMOVED] Dead empty fallback `text` block in scripted_loc output**
+
 - The block `text = { trigger = { NOT = { has_idea = X } } localization_key = "" }` was
   being appended after the main text block. An empty `localization_key` is invalid in HOI4.
 - Removed entirely. The `defined_text` block now only contains the active case.
 
 **[BUG FIX] Spirit snippet used `name = "Literal String"` instead of a loc key**
+
 - Line ~8685
 - Was: `name = "Free Trade Bonus"` (inline literal, bypasses the localisation system)
 - Fixed to: `name = {idea_id}` (bare localisation key reference, per CLAUDE.md convention)
 
 **[BUG FIX] Spirit snippet missing `allowed_civil_war = { always = yes }`**
+
 - CLAUDE.md requires this for all national ideas/spirits so the spirit persists through civil wars.
 - Added as the second field in the generated spirit block (after `name`).
 
@@ -321,6 +365,7 @@ They are recorded here so they don't get "fixed" back.
 ### Event Maker
 
 **[BUG FIX] No `WM_DELETE_WINDOW` handler — all events lost silently on window close**
+
 - The Event Maker had no close protocol and no autosave, unlike all other wizards.
 - Added `_ev_save_state()` and `_ev_load_state()` backed by a temp JSON file
   (`hoi4_cm_event_autosave.json` in the system temp directory).
@@ -332,6 +377,7 @@ They are recorded here so they don't get "fixed" back.
 ### National Spirit Wizard
 
 **[BUG FIX] `_save_raw` loc regex only matched obsolete `key:0 "value"` format**
+
 - Line ~3616
 - Was: `r'^\s*(\S+?):0\s+"(.*)"'` — required a `:0` version suffix that the wizard's own
   output no longer emits (current format is `key: "value"`).
@@ -340,6 +386,7 @@ They are recorded here so they don't get "fixed" back.
 - Fixed to: `r'^\s+(\S+?)(?::\d+)?\s+"(.*)"'` — matches both `key: "value"` and `key:0 "value"`.
 
 **[DEAD CODE] Duplicate `_edit_btn.config(...)` call on consecutive lines**
+
 - Lines ~3601–3602
 - `_edit_btn.config(text="✎ Edit", fg=TEXT_DIM, bg=BG_CARD)` appeared twice in a row with
   no code between them. The second call had no effect.
@@ -350,6 +397,7 @@ They are recorded here so they don't get "fixed" back.
 ### Dynamic Modifier Generator
 
 **[BUG FIX] `read_existing()` used `encoding="utf-8"` instead of `"utf-8-sig"`**
+
 - Line ~8192 inside `_save_file()`
 - HOI4 `.txt` files are written with BOM (`utf-8-sig`). Reading with plain `utf-8` causes the
   BOM byte sequence (`\ufeff`) to appear in the parsed string, corrupting regex matches on the
@@ -364,6 +412,7 @@ All notable changes to HOI4 Content Maker are documented here.
 ## [2.0] — 2025
 
 ### Decision Maker — New Features
+
 - Full Decision Maker wizard with three-panel layout (tree / editor / preview)
 - Live HOI4-themed preview canvas rendering decisions as they appear in-game
 - GFX icon picker with inline image grid browser
@@ -389,6 +438,7 @@ All notable changes to HOI4 Content Maker are documented here.
 - Autosave with session restore prompt on reopen
 
 ### Decision Maker — Bug Fixes
+
 - Fixed `NameError: name 'h' is not defined` in `_gen_decisions_file` (orphaned cache stub removed)
 - Fixed `AttributeError: 'bool' object has no attribute 'strip'` in generator functions — added `_s()` safe string coercion wrapper applied to all 84 field accesses
 - Fixed Apply Edits not saving: replaced fragile filedialog monkeypatch with a direct inline parser
@@ -401,6 +451,7 @@ All notable changes to HOI4 Content Maker are documented here.
 - Fixed Python 3.14 forward-reference errors in `_snap_then()` / `_on_dec_win_close`
 
 ### Focus Tree Editor
+
 - Drag-and-drop focus canvas with zoom, pan, multi-select
 - Prerequisite and mutex connection drawing
 - Per-focus properties panel with GFX browser
@@ -408,19 +459,23 @@ All notable changes to HOI4 Content Maker are documented here.
 - Export to `national_focus/*.txt` and localisation `.yml`
 
 ### National Spirit Wizard
+
 - Ideas/spirit block generator with GFX browser
 - Slot, modifier, trigger field support
 
 ### Dynamic Modifier Wizard
+
 - Dynamic modifier block generator with modifier picker
 
 ### Event Maker
+
 - Full event authoring with option builder, effect picker
 - Scripted localisation support
 - Live event preview
 - GFX background picker
 
 ### General
+
 - Single-file distribution (`hoi4_content_maker.py`) — no pip install required for core features
 - Persistent config saved to `~/.hoi4_focus_maker.json`
 - Mod folder scanner: auto-discovers sprites, focus IDs, event IDs, decision IDs, country tags

--- a/src/hoi4cm/ui/__init__.py
+++ b/src/hoi4cm/ui/__init__.py
@@ -53,7 +53,7 @@ from hoi4cm.ui.theme import (
 from hoi4cm.ui.thumbnail_grid import ThumbnailItem, VirtualThumbnailGrid
 from hoi4cm.ui.toolbar import build_toolbar_row2
 from hoi4cm.ui.tree_badges import build_tree_badges
-from hoi4cm.ui.widgets import Tooltip, _safe_after, _safe_after_idle
+from hoi4cm.ui.widgets import ScrollableDropdown, Tooltip, _safe_after, _safe_after_idle
 
 __all__ = [
     "BG_CARD",
@@ -80,6 +80,7 @@ __all__ = [
     "PURPLE",
     "RED",
     "SEL_BG",
+    "ScrollableDropdown",
     "TEAL",
     "TEXT",
     "TEXT_DIM",

--- a/src/hoi4cm/ui/widgets.py
+++ b/src/hoi4cm/ui/widgets.py
@@ -1,10 +1,14 @@
-"""Reusable Tk widgets: dark tooltip and safe ``after()`` wrappers.
+"""Reusable Tk widgets: dark tooltip, scrollable dropdown, safe ``after()``.
 
 These helpers were inlined as closures in the monolith — they're now plain
-functions here so the App and every wizard can share them.
+functions/classes here so the App and every wizard can share them.
 """
 
+import time
 import tkinter as tk
+import tkinter.font as tkfont
+
+from hoi4cm.ui.theme import BG_CARD, BORDER_G, SEL_BG, TEXT
 
 # ── Safe after() wrappers ────────────────────────────────────────
 # Guard only a destroyed widget (TclError, or AttributeError from the
@@ -44,6 +48,234 @@ def _safe_after_idle(widget, fn):
         widget.after_idle(guarded)
     except _DESTROYED_WIDGET_ERRORS:
         pass
+
+
+# ── Scrollable dropdown ─────────────────────────────────────────
+class ScrollableDropdown(tk.Frame):
+    """An OptionMenu replacement that scales to hundreds of entries.
+
+    Native Tk menus cannot scroll: a category with 150+ modifiers posts a
+    menu taller than the screen, entries below the bottom are unreachable
+    except via keyboard, and a wheel event unposts the menu while selecting
+    whatever is under the pointer (issue #72). This widget instead posts a
+    borderless popup holding a scrollable Listbox, sized to the remaining
+    screen space and flipped above the anchor when there is more room up
+    there. The wheel scrolls, arrows move the highlight, Return commits,
+    Escape or focus loss closes without selecting.
+
+    ``items`` is a list of ``(value, label)`` pairs. ``variable`` is the
+    StringVar holding the selected value; writing it from outside updates
+    the displayed label.
+    """
+
+    POPUP_MARGIN = 8  # px gap between popup and screen edges
+    ROW_PAD = 3  # extra px per listbox row
+    MIN_ROWS = 1
+    MAX_ROWS = 40
+
+    def __init__(
+        self,
+        master,
+        variable=None,
+        items=None,
+        width=26,
+        bg=BG_CARD,
+        fg=TEXT,
+        activebg=SEL_BG,
+        font=("Helvetica", 9),
+    ):
+        super().__init__(master)
+        self._items = list(items or [])
+        self._var = variable if variable is not None else tk.StringVar(master=self)
+        self._width = width
+        self._bg = bg
+        self._fg = fg
+        self._activebg = activebg
+        self._font = font
+        self._popup: tk.Toplevel | None = None
+        self._lb: tk.Listbox | None = None
+        self._closed_at = 0.0
+        self._trace_id = None
+        self.btn = tk.Button(
+            self,
+            text=self._display(self._var.get()),
+            command=self._toggle,
+            bg=bg,
+            fg=fg,
+            activebackground=activebg,
+            font=font,
+            relief="flat",
+            highlightthickness=1,
+            highlightbackground=BORDER_G,
+            anchor="w",
+            width=width,
+            cursor="hand2",
+            padx=6,
+        )
+        self.btn.pack(fill="x", expand=True)
+        self._register_trace()
+        self.bind("<Destroy>", self._on_destroy, add="+")
+
+    def _display(self, value):
+        for v, label in self._items:
+            if v == value:
+                return f"{label}  ▾"
+        return f"{value}  ▾"
+
+    def _register_trace(self):
+        if self._trace_id is None:
+            self._trace_id = self._var.trace_add("write", self._on_var_write)
+
+    def _on_var_write(self, *_):
+        if not self.winfo_exists():
+            return
+        self.btn.config(text=self._display(self._var.get()))
+
+    def _on_destroy(self, *_):
+        if self._trace_id is not None:
+            try:
+                self._var.trace_remove("write", self._trace_id)
+            except tk.TclError:
+                pass
+            self._trace_id = None
+        self._close_popup()
+
+    def _toggle(self):
+        if self._popup is not None and self._popup.winfo_exists():
+            self._close_popup()
+            return
+        # The click that landed here first moved focus off the popup and
+        # closed it via FocusOut; don't immediately reopen it.
+        if time.monotonic() - self._closed_at < 0.15:
+            return
+        self._open_popup()
+
+    def _open_popup(self):
+        self._close_popup()
+        if not self._items:
+            return
+        pop = tk.Toplevel(self)
+        self._popup = pop
+        pop.overrideredirect(True)
+        pop.attributes("-topmost", True)
+        pop.configure(bg=BORDER_G)
+        lb = tk.Listbox(
+            pop,
+            bg=self._bg,
+            fg=self._fg,
+            selectbackground=self._activebg,
+            selectforeground=TEXT,
+            font=self._font,
+            relief="flat",
+            highlightthickness=0,
+            activestyle="none",
+            exportselection=False,
+            width=self._width,
+        )
+        sb = tk.Scrollbar(pop, orient="vertical", command=lb.yview)
+        lb.configure(yscrollcommand=sb.set)
+        for _v, label in self._items:
+            lb.insert("end", label)
+        lb.pack(side="left", fill="both", expand=True)
+        sb.pack(side="right", fill="y")
+        self._lb = lb
+
+        def _wheel(e):
+            if e.delta:
+                lb.yview_scroll(int(-e.delta / 120), "units")
+            elif e.num == 4:
+                lb.yview_scroll(-1, "units")
+            elif e.num == 5:
+                lb.yview_scroll(1, "units")
+            return "break"
+
+        def _move(delta):
+            sel = lb.curselection()
+            idx = sel[0] if sel else -1 if delta > 0 else len(self._items)
+            nxt = max(0, min(len(self._items) - 1, idx + delta))
+            lb.selection_clear(0, "end")
+            lb.selection_set(nxt)
+            lb.see(nxt)
+            return "break"
+
+        lb.bind("<ButtonRelease-1>", lambda e: self._commit())
+        for ev in ("<MouseWheel>", "<Button-4>", "<Button-5>"):
+            lb.bind(ev, _wheel)
+            pop.bind(ev, _wheel)
+        lb.bind("<Up>", lambda e: _move(-1))
+        lb.bind("<Down>", lambda e: _move(1))
+        lb.bind("<Return>", lambda e: self._commit())
+        lb.bind("<KP_Enter>", lambda e: self._commit())
+        lb.bind("<Escape>", lambda e: self._close_popup())
+        pop.bind("<Escape>", lambda e: self._close_popup())
+        pop.bind("<FocusOut>", self._on_popup_focus_out)
+
+        # Size to the remaining screen space, flipping above the anchor
+        # when there is more room there than below it.
+        self.btn.update_idletasks()
+        row_h = tkfont.Font(font=self._font).metrics("linespace") + self.ROW_PAD
+        screen_h = self.winfo_screenheight()
+        anchor_y = self.btn.winfo_rooty()
+        below = screen_h - anchor_y - self.btn.winfo_height() - self.POPUP_MARGIN
+        above = anchor_y - self.POPUP_MARGIN
+        wanted = min(len(self._items), self.MAX_ROWS)
+        rows_below = min(wanted, max(self.MIN_ROWS, int(below // row_h)))
+        rows_above = min(wanted, max(self.MIN_ROWS, int(above // row_h)))
+        if rows_below >= rows_above:
+            rows, y = rows_below, anchor_y + self.btn.winfo_height()
+        else:
+            rows, y = rows_above, None
+        lb.configure(height=rows)
+        pop.update_idletasks()
+        if y is None:
+            y = max(self.POPUP_MARGIN, anchor_y - pop.winfo_reqheight())
+        x = self.btn.winfo_rootx()
+        x = max(
+            self.POPUP_MARGIN,
+            min(x, self.winfo_screenwidth() - pop.winfo_reqwidth() - self.POPUP_MARGIN),
+        )
+        pop.geometry(f"+{x}+{y}")
+
+        cur = self._var.get()
+        for i, (v, _label) in enumerate(self._items):
+            if v == cur:
+                lb.selection_set(i)
+                lb.see(i)
+                break
+        lb.focus_force()
+
+    def _commit(self):
+        if self._lb is None:
+            return
+        sel = self._lb.curselection()
+        if sel:
+            self._var.set(self._items[sel[0]][0])
+        self._close_popup()
+
+    def _close_popup(self):
+        pop = self._popup
+        self._popup = None
+        self._lb = None
+        if pop is not None:
+            try:
+                if pop.winfo_exists():
+                    pop.destroy()
+            except tk.TclError:
+                pass
+
+    def _on_popup_focus_out(self, _e):
+        pop = self._popup
+        if pop is None:
+            return
+        try:
+            focused = pop.focus_get()
+        except tk.TclError:
+            focused = None
+        if focused is None or not (
+            str(focused) == str(pop) or str(focused).startswith(str(pop) + ".")
+        ):
+            self._close_popup()
+            self._closed_at = time.monotonic()
 
 
 # ── Dark tooltip ─────────────────────────────────────────────────

--- a/src/hoi4cm/wizards/national_spirit.py
+++ b/src/hoi4cm/wizards/national_spirit.py
@@ -37,6 +37,7 @@ from hoi4cm.ui import (
     SEL_BG,
     TEXT,
     TEXT_DIM,
+    ScrollableDropdown,
     _safe_after,
     _safe_after_idle,
     report_error,
@@ -869,29 +870,13 @@ def open_national_spirit_wizard(app):
         if not items:
             return
         _mt.set(items[0][0])
-        om = tk.OptionMenu(dd_frame, _mt, *[k for k, _ in items])
-        menu = om["menu"]
-        menu.delete(0, "end")
-        for k, v in items:
-            menu.add_command(
-                label="{}  ({})".format(k, v["hint"]),
-                command=lambda val=k: _mt.set(val),
-            )
-        om.config(
-            bg=BG_CARD,
-            fg=TEXT,
-            activebackground=SEL_BG,
-            font=("Helvetica", 9),
-            relief="flat",
-            highlightthickness=1,
-            highlightbackground=BORDER_G,
-            anchor="w",
+        dd = ScrollableDropdown(
+            dd_frame,
+            variable=_mt,
+            items=[(k, "{}  ({})".format(k, v["hint"])) for k, v in items],
             width=26,
         )
-        om["menu"].config(
-            bg=BG_CARD, fg=TEXT, activebackground=SEL_BG, font=("Helvetica", 9)
-        )
-        om.pack(fill="x", expand=True)
+        dd.pack(fill="x", expand=True)
 
     _rebuild_mod_dd()
 
@@ -949,29 +934,15 @@ def open_national_spirit_wizard(app):
             ).pack(anchor="w")
             return
         _mt.set(matches[0][0])
-        om = tk.OptionMenu(dd_frame, _mt, *[k for k, _ in matches])
-        menu2 = om["menu"]
-        menu2.delete(0, "end")
-        for k, v in matches:
-            menu2.add_command(
-                label="[{}]  {}  ({})".format(v["cat"], k, v["hint"]),
-                command=lambda val=k: _mt.set(val),
-            )
-        om.config(
-            bg=BG_CARD,
-            fg=TEXT,
-            activebackground=SEL_BG,
-            font=("Helvetica", 9),
-            relief="flat",
-            highlightthickness=1,
-            highlightbackground=BORDER_G,
-            anchor="w",
+        dd = ScrollableDropdown(
+            dd_frame,
+            variable=_mt,
+            items=[
+                (k, "[{}]  {}  ({})".format(v["cat"], k, v["hint"])) for k, v in matches
+            ],
             width=30,
         )
-        om["menu"].config(
-            bg=BG_CARD, fg=TEXT, activebackground=SEL_BG, font=("Helvetica", 9)
-        )
-        om.pack(fill="x", expand=True)
+        dd.pack(fill="x", expand=True)
 
     _sv.trace_add("write", _filter_mod_dd)
 

--- a/tests/test_scrollable_dropdown.py
+++ b/tests/test_scrollable_dropdown.py
@@ -1,0 +1,177 @@
+"""ScrollableDropdown — issue #72.
+
+The Idea Wizard's modifier picker used to be a native tk.OptionMenu: with a
+category holding 150+ entries the menu was taller than the screen, wheel
+events unposted it while selecting whatever was under the pointer, and
+off-screen entries were reachable only via keyboard. The dropdown now posts
+a scrollable Listbox popup sized to the screen.
+"""
+
+import tkinter as tk
+
+from hoi4cm.ui import ScrollableDropdown
+from hoi4cm.wizards.national_spirit import open_national_spirit_wizard
+
+ITEMS = [(f"mod_{i}", f"mod_{i}  (float)") for i in range(120)]
+
+
+def _dropdowns(root):
+    found = []
+
+    def _walk(w):
+        if isinstance(w, ScrollableDropdown):
+            found.append(w)
+        for child in w.winfo_children():
+            _walk(child)
+
+    _walk(root)
+    return found
+
+
+def _make(tk_root, items=None, value="mod_0"):
+    var = tk.StringVar(value=value)
+    dd = ScrollableDropdown(tk_root, variable=var, items=items or ITEMS)
+    dd.pack()
+    tk_root.update_idletasks()
+    return dd, var
+
+
+def _open(dd):
+    dd.btn.invoke()
+    dd.update_idletasks()
+    assert dd._popup is not None and dd._popup.winfo_exists()
+    assert dd._lb is not None
+    return dd._popup, dd._lb
+
+
+def test_button_shows_label_for_current_value(tk_root):
+    dd, var = _make(tk_root, value="mod_3")
+    assert dd.btn.cget("text") == "mod_3  (float)  ▾"
+    var.set("mod_7")
+    assert dd.btn.cget("text") == "mod_7  (float)  ▾"
+
+
+def test_open_popup_lists_every_item_in_a_capped_listbox(tk_root):
+    dd, _var = _make(tk_root)
+    popup, lb = _open(dd)
+    assert lb.size() == len(ITEMS)
+    assert lb.cget("height") <= ScrollableDropdown.MAX_ROWS
+    assert lb.cget("height") < len(ITEMS)
+    popup.destroy()
+
+
+def test_popup_geometry_stays_on_screen(tk_root):
+    dd, _var = _make(tk_root)
+    popup, lb = _open(dd)
+    popup.update_idletasks()
+    x = popup.winfo_rootx()
+    y = popup.winfo_rooty()
+    assert x >= 0
+    assert y >= 0
+    assert x + popup.winfo_width() <= dd.winfo_screenwidth()
+    assert y + popup.winfo_height() <= dd.winfo_screenheight()
+    popup.destroy()
+
+
+def test_wheel_scrolls_without_committing_or_closing(tk_root):
+    dd, var = _make(tk_root)
+    popup, lb = _open(dd)
+    start = var.get()
+
+    lb.event_generate("<MouseWheel>", delta=-120)
+    dd.update_idletasks()
+
+    assert popup.winfo_exists()  # must not close on scroll (issue #72)
+    assert var.get() == start  # and must not commit the highlighted entry
+    assert lb.yview()[1] > 0.0
+    popup.destroy()
+
+
+def test_arrow_keys_move_highlight_without_committing(tk_root):
+    dd, var = _make(tk_root)
+    popup, lb = _open(dd)
+
+    lb.selection_clear(0, "end")
+    lb.selection_set(0)
+    lb.event_generate("<Down>")
+    dd.update_idletasks()
+
+    assert popup.winfo_exists()
+    assert var.get() == "mod_0"
+    assert lb.curselection() == (1,)
+    popup.destroy()
+
+
+def test_return_commits_highlighted_entry_and_closes(tk_root):
+    dd, var = _make(tk_root)
+    popup, lb = _open(dd)
+
+    lb.selection_clear(0, "end")
+    lb.selection_set(4)
+    lb.event_generate("<Return>")
+    dd.update_idletasks()
+
+    assert var.get() == "mod_4"
+    assert not popup.winfo_exists()
+
+
+def test_escape_closes_without_committing(tk_root):
+    dd, var = _make(tk_root)
+    popup, lb = _open(dd)
+    start = var.get()
+
+    lb.event_generate("<Escape>")
+    dd.update_idletasks()
+
+    assert var.get() == start
+    assert not popup.winfo_exists()
+
+
+def test_click_release_commits_clicked_entry(tk_root):
+    dd, var = _make(tk_root)
+    popup, lb = _open(dd)
+
+    lb.selection_clear(0, "end")
+    lb.selection_set(9)  # the class binding does this on press
+    lb.event_generate("<ButtonRelease-1>")
+    dd.update_idletasks()
+
+    assert var.get() == "mod_9"
+    assert not popup.winfo_exists()
+
+
+def test_destroy_removes_trace_from_shared_variable(tk_root):
+    """The wizard rebuilds the dropdown on every search keystroke; a stale
+    trace on the surviving StringVar must not outlive the widget."""
+    dd, var = _make(tk_root)
+    dd.destroy()
+    var.set("mod_42")  # must not raise on the destroyed widget
+
+
+def test_destroy_closes_popup(tk_root):
+    dd, _var = _make(tk_root)
+    popup, _lb = _open(dd)
+    dd.destroy()
+    assert not popup.winfo_exists()
+
+
+def test_wizard_uses_scrollable_dropdown_for_modifiers(tk_root):
+    """Regression test for issue #72: the Idea Wizard's modifier picker must
+    be a ScrollableDropdown, and its popup must survive a wheel scroll."""
+    open_national_spirit_wizard(tk_root)
+    try:
+        dropdowns = _dropdowns(tk_root)
+        assert dropdowns, "idea wizard has no ScrollableDropdown"
+        dd = dropdowns[0]
+        dd.btn.invoke()
+        dd.update_idletasks()
+        assert dd._popup is not None and dd._popup.winfo_exists()
+        assert dd._lb is not None
+        dd._lb.event_generate("<MouseWheel>", delta=-120)
+        dd.update_idletasks()
+        assert dd._popup.winfo_exists()
+        dd._close_popup()
+    finally:
+        for w in tk_root.winfo_children():
+            if isinstance(w, tk.Toplevel):
+                w.destroy()


### PR DESCRIPTION
Closes #72

## What

The Idea Wizard's modifier picker was a native `tk.OptionMenu`. Native Tk menus cannot scroll and have no height cap, and the Air and Army categories hold 53 and 169 modifiers respectively. On anything but the tallest displays this produced all three reported symptoms:

- the menu posted taller than the screen, so entries below the bottom were unreachable except via keyboard,
- a mouse-wheel event unposted the menu while selecting the entry under the pointer,
- arrow keys could highlight entries that were never visible on screen.

## Why

The reporter (Linux, 3440x1440) cannot browse a category unfiltered: scrolling closes the picker, and half of every large category is off-screen.

## How

New `ScrollableDropdown` in `hoi4cm.ui.widgets`: a flat button that posts a borderless popup holding a scrollable `Listbox`, sized to the remaining screen space and flipped above the button when there is more room up there. The wheel scrolls (and does not commit), arrows move the highlight, Return commits, and Escape or focus loss closes without selecting. A trace-removal guard lets the wizard keep rebuilding the widget on every search keystroke without leaking callbacks on the shared StringVar.

The Idea Wizard's two rebuild paths (category pick and search pick) now use it, with the same `key (hint)` and `[cat] key (hint)` labels the old menus showed. Unit tests cover the widget plus a regression test that opens the wizard, scrolls the popup, and asserts it stays open.

Note: CHANGELOG.md also picked up markdownlint blank-line normalization from the editor's formatter; the only content change is the issue #72 entry.