### PR TITLE
Fix export dropping quotes on scalar values with whitespace

### DIFF
--- a/src/hoi4cm/focus_tree/codec.py
+++ b/src/hoi4cm/focus_tree/codec.py
@@ -9,7 +9,7 @@ from typing import Literal
 
 from hoi4cm.models import Focus
 from hoi4cm.script.effects import render_effect
-from hoi4cm.script.syntax import serialize_block
+from hoi4cm.script.syntax import emit_scalar, serialize_block
 
 from .build import build_focuses
 from .parse import parse_focus_tree
@@ -144,7 +144,7 @@ def render_focus_body(
     inner_indent = indent + "\t"
     text = getattr(focus, "text", "").strip()
     if text:
-        out.append(f"{indent}text = {text}")
+        out.append(f"{indent}text = {emit_scalar(text)}")
 
     x, y, relative_id = _render_coordinates(
         focus, focus_name_lookup, policy=coordinate_policy
@@ -225,7 +225,7 @@ def render_focus_body(
                 out, "will_lead_to_war_with", war_target, indent, inner_indent
             )
         else:
-            out.append(f"{indent}will_lead_to_war_with = {war_target}")
+            out.append(f"{indent}will_lead_to_war_with = {emit_scalar(war_target)}")
     _emit_block(out, "complete_tooltip", getattr(focus, "complete_tooltip", ""), indent)
     _emit_block(out, "select_effect", getattr(focus, "select_effect", ""), indent)
     if not focus.cancel_if_invalid:
@@ -286,7 +286,7 @@ def render_focus_block(
     out = [
         "focus = {",
         f"{indent}id = {focus.name}",
-        f"{indent}icon = {getattr(focus, 'gfx', _DEFAULT_GFX)}",
+        f"{indent}icon = {emit_scalar(getattr(focus, 'gfx', _DEFAULT_GFX))}",
     ]
     out.extend(
         render_focus_body(

--- a/src/hoi4cm/focus_tree/export.py
+++ b/src/hoi4cm/focus_tree/export.py
@@ -7,7 +7,7 @@ writing the file.
 import re
 
 from hoi4cm.script.effects import render_effect
-from hoi4cm.script.syntax import serialize_block
+from hoi4cm.script.syntax import emit_scalar, serialize_block
 
 from .codec import render_focus_body
 from .operations import build_focus_name_lookup
@@ -90,7 +90,7 @@ def export_focus_tree(
         for f in focuses_in_tree:
             out.append(f"{block_kw} = {{")
             out.append(f"\tid = {f.name}")
-            out.append(f"\ticon = {getattr(f, 'gfx', GFX_DEFAULT)}")
+            out.append(f"\ticon = {emit_scalar(getattr(f, 'gfx', GFX_DEFAULT))}")
             write_focus_body(f, out, "\t")
             out.append("}")
             out.append("")
@@ -131,7 +131,7 @@ def export_focus_tree(
         for f in focuses_in_tree:
             out.append("\tfocus = {")
             out.append(f"\t\tid = {f.name}")
-            out.append(f"\t\ticon = {getattr(f, 'gfx', GFX_DEFAULT)}")
+            out.append(f"\t\ticon = {emit_scalar(getattr(f, 'gfx', GFX_DEFAULT))}")
             write_focus_body(f, out, "\t\t")
             out.append("\t}")
             out.append("")
@@ -215,7 +215,7 @@ def export_main_tree(
     for f in focuses_in_tree:
         out.append("\tfocus = {")
         out.append(f"\t\tid = {f.name}")
-        out.append(f"\t\ticon = {getattr(f, 'gfx', GFX_DEFAULT)}")
+        out.append(f"\t\ticon = {emit_scalar(getattr(f, 'gfx', GFX_DEFAULT))}")
         out.extend(
             render_focus_body(
                 f,

--- a/src/hoi4cm/script/__init__.py
+++ b/src/hoi4cm/script/__init__.py
@@ -2,6 +2,7 @@
 
 from .effects import render_effect
 from .syntax import (
+    emit_scalar,
     extract_block,
     extract_named_block,
     find_blocks,
@@ -16,6 +17,7 @@ from .syntax import (
 __all__ = [
     "append_scripted_loc",
     "dict_to_raw",
+    "emit_scalar",
     "extract_block",
     "extract_named_block",
     "find_blocks",

--- a/src/hoi4cm/script/syntax.py
+++ b/src/hoi4cm/script/syntax.py
@@ -6,6 +6,7 @@ import re
 from collections.abc import Mapping, Sequence
 
 __all__ = [
+    "emit_scalar",
     "extract_block",
     "extract_named_block",
     "find_blocks",
@@ -198,11 +199,24 @@ def extract_named_block(source: str, name: str) -> str | None:
     return None
 
 
+def emit_scalar(value: str) -> str:
+    """Wrap a string in double quotes if it contains bare-token-breaking chars.
+
+    Paradox script bare tokens cannot contain whitespace, ``{``, ``}``, ``=``,
+    ``"``, or ``#``. Values containing any of these characters are quoted so
+    that they survive a parse -> export -> parse round-trip intact.
+    """
+    if any(c in value for c in ' \t\n\r{}="#') or '"' in value:
+        return f'"{value}"'
+    return value
+
+
 def _scalar_to_str(value: object, *, strip_strings: bool) -> str:
     if isinstance(value, bool):
         return "yes" if value else "no"
-    if isinstance(value, str) and strip_strings:
-        return value.strip()
+    if isinstance(value, str):
+        value = value.strip() if strip_strings else value
+        return emit_scalar(value)
     return str(value)
 
 

--- a/tests/test_emit_scalar.py
+++ b/tests/test_emit_scalar.py
@@ -7,7 +7,10 @@ def test_emit_scalar_empty():
 
 def test_emit_scalar_no_special_chars():
     assert emit_scalar("hello") == "hello"
-    assert emit_scalar("GFX_goal_generic_political_pressure") == "GFX_goal_generic_political_pressure"
+    assert (
+        emit_scalar("GFX_goal_generic_political_pressure")
+        == "GFX_goal_generic_political_pressure"
+    )
     assert emit_scalar("TST_a") == "TST_a"
     assert emit_scalar("VEN") == "VEN"
     assert emit_scalar("1") == "1"

--- a/tests/test_emit_scalar.py
+++ b/tests/test_emit_scalar.py
@@ -1,0 +1,40 @@
+from hoi4cm.script.syntax import emit_scalar
+
+
+def test_emit_scalar_empty():
+    assert emit_scalar("") == ""
+
+
+def test_emit_scalar_no_special_chars():
+    assert emit_scalar("hello") == "hello"
+    assert emit_scalar("GFX_goal_generic_political_pressure") == "GFX_goal_generic_political_pressure"
+    assert emit_scalar("TST_a") == "TST_a"
+    assert emit_scalar("VEN") == "VEN"
+    assert emit_scalar("1") == "1"
+    assert emit_scalar("yes") == "yes"
+
+
+def test_emit_scalar_quotes_on_whitespace():
+    assert emit_scalar("hello world") == '"hello world"'
+    assert emit_scalar("hello\tworld") == '"hello\tworld"'
+    assert emit_scalar("hello\nworld") == '"hello\nworld"'
+    assert emit_scalar("hello\rworld") == '"hello\rworld"'
+
+
+def test_emit_scalar_quotes_on_braces_equals_hash():
+    assert emit_scalar("hello{world") == '"hello{world"'
+    assert emit_scalar("hello}world") == '"hello}world"'
+    assert emit_scalar("hello=world") == '"hello=world"'
+    assert emit_scalar("hello#world") == '"hello#world"'
+
+
+def test_emit_scalar_quotes_on_embedded_quote():
+    assert emit_scalar('hello"world') == '"hello"world"'
+
+
+def test_emit_scalar_icon_path_with_space():
+    assert emit_scalar("gfx/with a space/goal.dds") == '"gfx/with a space/goal.dds"'
+
+
+def test_emit_scalar_multiword_text():
+    assert emit_scalar("Multi word title") == '"Multi word title"'

--- a/tests/test_focus_tree_roundtrip.py
+++ b/tests/test_focus_tree_roundtrip.py
@@ -476,6 +476,35 @@ def test_fixture_export_is_idempotent(fname, tree_type):
     assert t1 == t2
 
 
+def test_multiword_scalar_values_round_trip():
+    """Quoted values containing whitespace survive parse -> export -> parse.
+
+    Regression test for #75: export previously dropped quotes on scalar
+    values, truncating any value containing whitespace on re-parse.
+    """
+    src = (
+        "focus_tree = {\n"
+        "\tid = TST_tree\n"
+        "\tfocus = {\n"
+        "\t\tid = TST_a\n"
+        "\t\tx = 0\n"
+        "\t\ty = 0\n"
+        '\t\ttext = "Multi word title"\n'
+        '\t\ticon = "gfx/with a space/goal.dds"\n'
+        "\t\tcost = 7\n"
+        "\t}\n"
+        "}\n"
+    )
+    f1, t1 = _load_and_export(src, "shared")
+    # Exported text must re-quote values containing whitespace.
+    assert 'text = "Multi word title"' in t1
+    assert 'icon = "gfx/with a space/goal.dds"' in t1
+    # Round-trip must preserve the values intact.
+    f2, _t2 = _load_and_export(t1, "shared")
+    assert f2[0].text == "Multi word title"
+    assert f2[0].gfx == "gfx/with a space/goal.dds"
+
+
 @pytest.mark.parametrize("fname,tree_type", FIXTURE_FILES)
 def test_fixture_structural_fields_survive(fname, tree_type):
     f1, t1 = _load_and_export_fixture(fname, tree_type)

--- a/tests/test_focus_tree_roundtrip.py
+++ b/tests/test_focus_tree_roundtrip.py
@@ -505,6 +505,35 @@ def test_multiword_scalar_values_round_trip():
     assert f2[0].gfx == "gfx/with a space/goal.dds"
 
 
+def test_newline_in_scalar_value_is_quoted():
+    """A scalar value containing a newline must be quoted on export.
+
+    Unquoted, a newline in a scalar value would break the file structure
+    by closing the enclosing block early and leaving the remainder as
+    stray top-level tokens. Quoting keeps the file parseable.
+    """
+    src = (
+        "focus_tree = {\n"
+        "\tid = TST_tree\n"
+        "\tfocus = {\n"
+        "\t\tid = TST_a\n"
+        "\t\tx = 0\n"
+        "\t\ty = 0\n"
+        '\t\ttext = "Line one\nLine two"\n'
+        "\t\tcost = 7\n"
+        "\t}\n"
+        "}\n"
+    )
+    f1, t1 = _load_and_export(src, "shared")
+    # The exported text must quote the value containing a newline.
+    assert 'text = "Line one' in t1
+    assert 'Line two"' in t1
+    # Round-trip must preserve the newline in the value.
+    f2, _t2 = _load_and_export(t1, "shared")
+    assert "Line one" in f2[0].text
+    assert "Line two" in f2[0].text
+
+
 @pytest.mark.parametrize("fname,tree_type", FIXTURE_FILES)
 def test_fixture_structural_fields_survive(fname, tree_type):
     f1, t1 = _load_and_export_fixture(fname, tree_type)

--- a/tests/test_script_syntax.py
+++ b/tests/test_script_syntax.py
@@ -168,7 +168,7 @@ def test_recursive_serializer_supports_bare_values_and_duplicate_keys():
     assert serialize_block(parsed, indent="", include_bare_values=True) == (
         "item = first\n"
         "item = {\n\tenabled = yes\n}\n"
-        "values = {\n\tone\n\ttwo words\n}"
+        'values = {\n\tone\n\t"two words"\n}'
     )
 
 


### PR DESCRIPTION
Fixes #75

**What**
Export was dropping quotes on scalar values containing whitespace (or other bare-token-breaking characters like `{`, `}`, `=`, `#`), causing them to be silently truncated on the next parse. For example, `text = "Multi word title"` was exported as `text = Multi word title`, which parsed back as just `Multi`.

**Why**
This violates the round-trip preservation rule in AGENTS.md. Any value containing whitespace in a scalar field (text, icon paths, etc.) was corrupted on export → import cycles.

**How**
Added `emit_scalar` helper in `syntax.py` that wraps a string in double quotes when it contains characters that bare tokens cannot hold (whitespace, `{`, `}`, `=`, `"`, `#`). Applied it in three places:
- `_scalar_to_str` — covers all generic serialization via `serialize_block`
- `codec.py` — direct emissions for `text`, `icon`, `will_lead_to_war_with`
- `export.py` — direct emissions for `icon`

Added roundtrip test for multi-word `text` and `icon` values.