### PR TITLE
Extract wizard collect_*_state helpers and cover seams (Closes #62)

### DIFF
--- a/src/hoi4cm/wizards/_shared.py
+++ b/src/hoi4cm/wizards/_shared.py
@@ -26,6 +26,43 @@ from hoi4cm.ui import (
 # ``notifying_workspace_files`` is imported from ``hoi4cm.mod`` here and
 # re-exported for wizard convenience.
 
+
+# ── Shared widget-read helpers ────────────────────────────────────
+# Small ``.get()`` adapters used by the ``collect_*_state`` helpers so
+# the seam between Tk widgets and the ``_generators`` stays DRY and
+# testable.  Each accepts duck-typed fakes in tests (``hasattr(.get)``)
+# and real ``tk.StringVar``/``tk.Text`` in the dialogs.
+
+
+def svar_get(var, default=""):
+    """Return ``var.get()`` coerced to ``str``, or ``default`` if missing/broken."""
+    if var is None or not hasattr(var, "get"):
+        return default
+    try:
+        val = var.get()
+        return val if isinstance(val, str) else str(val)
+    except Exception:
+        return default
+
+
+def text_get(widget, default=""):
+    """Return ``widget.get("1.0", "end")`` stripped, with ``StringVar`` fallback."""
+    if widget is None or not hasattr(widget, "get"):
+        return default
+    try:
+        val = widget.get("1.0", "end")
+    except TypeError:
+        try:
+            val = widget.get()
+        except Exception:
+            return default
+    except Exception:
+        return default
+    if isinstance(val, str):
+        return val.strip()
+    return str(val).strip()
+
+
 # ── Image cache registry ──────────────────────────────────────────
 # Wizards register their own caches here so the App can invalidate
 # everything on mod reload without poking into each module.
@@ -483,4 +520,6 @@ __all__ = [
     "_LOC_KEY_RE",
     "notifying_workspace_files",
     "open_effect_picker",
+    "svar_get",
+    "text_get",
 ]

--- a/src/hoi4cm/wizards/additional_income.py
+++ b/src/hoi4cm/wizards/additional_income.py
@@ -25,17 +25,11 @@ from hoi4cm.ui import (
     TEXT_DIM,
 )
 from hoi4cm.wizards import _generators
-from hoi4cm.wizards._shared import _LOC_KEY_RE, notifying_workspace_files
-
-
-def _svar_get(var, default=""):
-    if var is None or not hasattr(var, "get"):
-        return default
-    try:
-        val = var.get()
-        return val if isinstance(val, str) else str(val)
-    except Exception:
-        return default
+from hoi4cm.wizards._shared import (
+    _LOC_KEY_RE,
+    notifying_workspace_files,
+    svar_get,
+)
 
 
 def collect_additional_income_state(svars):
@@ -48,7 +42,7 @@ def collect_additional_income_state(svars):
     """
 
     def _get(key, default=""):
-        return _svar_get(svars.get(key) if isinstance(svars, dict) else None, default)
+        return svar_get(svars.get(key) if isinstance(svars, dict) else None, default)
 
     return {
         "idea_id": _get("idea_id").strip(),

--- a/src/hoi4cm/wizards/additional_income.py
+++ b/src/hoi4cm/wizards/additional_income.py
@@ -28,6 +28,42 @@ from hoi4cm.wizards import _generators
 from hoi4cm.wizards._shared import _LOC_KEY_RE, notifying_workspace_files
 
 
+def _svar_get(var, default=""):
+    if var is None or not hasattr(var, "get"):
+        return default
+    try:
+        val = var.get()
+        return val if isinstance(val, str) else str(val)
+    except Exception:
+        return default
+
+
+def collect_additional_income_state(svars):
+    """Collect additional-income wizard fields into plain strings.
+
+    ``svars`` maps field names to ``tk.StringVar``-like objects
+    (``.get()``). The returned dict is what ``_apply`` needs after
+    stripping and normalising (``country_tag`` upper-cased, ``idea_id``
+    sanitisation left to the caller).
+    """
+
+    def _get(key, default=""):
+        return _svar_get(svars.get(key) if isinstance(svars, dict) else None, default)
+
+    return {
+        "idea_id": _get("idea_id").strip(),
+        "country_tag": _get("country_tag").strip().upper(),
+        "variable_name": _get("variable_name").strip(),
+        "amount": _get("amount").strip(),
+        "tooltip_key": _get("tooltip_key").strip(),
+        "spirit_name": _get("spirit_name").strip(),
+        "spirit_desc": _get("spirit_desc").strip(),
+        "tooltip_text": _get("tooltip_text").strip(),
+        "mode": _get("mode", "wire_only"),
+        "formula_type": _get("formula_type", "fixed"),
+    }
+
+
 def open_additional_income_wizard(app):
     """MD Additional Income Wizard — creates/links a spirit and wires up all 3 money system files."""
     win = tk.Toplevel(app)
@@ -449,16 +485,30 @@ def open_additional_income_wizard(app):
 
     # ── Apply button ──────────────────────────────────────────────────────
     def _apply():
-        idea_id = v_idea_id.get().strip()
-        country_tag = v_country_tag.get().strip().upper()
-        variable_name = v_variable_name.get().strip()
-        amount = v_amount.get().strip()
-        tooltip_key = v_tooltip_key.get().strip()
-        spirit_name = v_spirit_name.get().strip()
-        spirit_desc = v_spirit_desc.get().strip()
-        tooltip_text = v_tooltip_text.get().strip()
-        mode = mode_var.get()
-        formula_type = formula_var.get()
+        state = collect_additional_income_state(
+            {
+                "idea_id": v_idea_id,
+                "country_tag": v_country_tag,
+                "variable_name": v_variable_name,
+                "amount": v_amount,
+                "tooltip_key": v_tooltip_key,
+                "spirit_name": v_spirit_name,
+                "spirit_desc": v_spirit_desc,
+                "tooltip_text": v_tooltip_text,
+                "mode": mode_var,
+                "formula_type": formula_var,
+            }
+        )
+        idea_id = state["idea_id"]
+        country_tag = state["country_tag"]
+        variable_name = state["variable_name"]
+        amount = state["amount"]
+        tooltip_key = state["tooltip_key"]
+        spirit_name = state["spirit_name"]
+        spirit_desc = state["spirit_desc"]
+        tooltip_text = state["tooltip_text"]
+        mode = state["mode"]
+        formula_type = state["formula_type"]
 
         if not idea_id or not variable_name or not amount or not tooltip_key:
             messagebox.showwarning(

--- a/src/hoi4cm/wizards/decision.py
+++ b/src/hoi4cm/wizards/decision.py
@@ -54,6 +54,36 @@ from hoi4cm.wizards._shared import (
 )
 
 
+def collect_decision_state(evars, dec=None):
+    """Collect decision render knobs from widget vars.
+
+    The two Tk-only knobs ``targeted``/``cost_type`` live in ``evars``
+    (``tk.StringVar`` in the dialog, any ``.get()`` fake in tests).
+    When the var is missing the ``dec`` fallback is used when given,
+    otherwise the wizard default (``"none"``/``"pp"``) — the two
+    call sites previously disagreed here; this is the single source.
+    """
+
+    def _resolve(key, fallback):
+        var = evars.get(key) if isinstance(evars, dict) else None
+        if var is not None and hasattr(var, "get"):
+            try:
+                val = var.get()
+                if isinstance(val, str):
+                    return val
+                return str(val)
+            except Exception:
+                pass
+        if isinstance(dec, dict):
+            return dec.get(key, fallback)
+        return fallback
+
+    return {
+        "targeted": _resolve("targeted", "none"),
+        "cost_type": _resolve("cost_type", "pp"),
+    }
+
+
 def open_decision_wizard(app):
     """HOI4 Decision / Decision Category maker — matches mockup layout."""
     win = tk.Toplevel(app)
@@ -4233,32 +4263,19 @@ def open_decision_wizard(app):
         this closure only resolves the two widget-only knobs (targeted /
         cost_type) from the Tk StringVars, then delegates.
         """
-        tgt_var = _evars.get("targeted")
-        targeted = (
-            tgt_var.get()
-            if isinstance(tgt_var, tk.StringVar)
-            else dec.get("targeted", "none")
-        )
-        cost_type_var = _evars.get("cost_type")
-        cost_type = (
-            cost_type_var.get()
-            if isinstance(cost_type_var, tk.StringVar)
-            else dec.get("cost_type", "pp")
-        )
+        state = collect_decision_state(_evars, dec)
         return _generators.generate_decision_block(
-            dec, targeted=targeted, cost_type=cost_type
+            dec, targeted=state["targeted"], cost_type=state["cost_type"]
         )
 
     def _gen_decisions_file():
         _collect()
-        tgt_var = _evars.get("targeted")
-        targeted = tgt_var.get() if isinstance(tgt_var, tk.StringVar) else "none"
-        cost_type_var = _evars.get("cost_type")
-        cost_type = (
-            cost_type_var.get() if isinstance(cost_type_var, tk.StringVar) else "pp"
-        )
+        state = collect_decision_state(_evars)
         return _generators.generate_decisions_file(
-            dm_cats, dm_decs, targeted=targeted, cost_type=cost_type
+            dm_cats,
+            dm_decs,
+            targeted=state["targeted"],
+            cost_type=state["cost_type"],
         )
 
     def _gen_categories_file():

--- a/src/hoi4cm/wizards/decision.py
+++ b/src/hoi4cm/wizards/decision.py
@@ -59,9 +59,11 @@ def collect_decision_state(evars, dec=None):
 
     The two Tk-only knobs ``targeted``/``cost_type`` live in ``evars``
     (``tk.StringVar`` in the dialog, any ``.get()`` fake in tests).
-    When the var is missing the ``dec`` fallback is used when given,
-    otherwise the wizard default (``"none"``/``"pp"``) — the two
-    call sites previously disagreed here; this is the single source.
+    When the var is missing *or* empty/whitespace the ``dec`` fallback
+    is used when given, otherwise the wizard default (``"none"``/``"pp"``)
+    — the two call sites previously disagreed here; this is the single source.
+    Empty strings previously propagated as ``""`` and rendered a broken
+    targeted block; they now fall through to the default.
     """
 
     def _resolve(key, fallback):
@@ -69,13 +71,21 @@ def collect_decision_state(evars, dec=None):
         if var is not None and hasattr(var, "get"):
             try:
                 val = var.get()
-                if isinstance(val, str):
-                    return val
-                return str(val)
+                sval = val if isinstance(val, str) else str(val)
+                if isinstance(sval, str) and not sval.strip():
+                    raise ValueError("empty")
+                return sval
             except Exception:
                 pass
         if isinstance(dec, dict):
-            return dec.get(key, fallback)
+            dval = dec.get(key, fallback)
+            if isinstance(dval, str) and not dval.strip():
+                return fallback
+            return (
+                dval
+                if isinstance(dval, str)
+                else str(dval) if dval is not None else fallback
+            )
         return fallback
 
     return {

--- a/src/hoi4cm/wizards/decision.py
+++ b/src/hoi4cm/wizards/decision.py
@@ -784,7 +784,7 @@ def open_decision_wizard(app):
                         _tag(tagrow, "T", C_TEAL, TEAL_TAG_BG, TEAL_TAG_BD)
                     if dec["cost_type"] == "pp" and dec.get("cost", "").strip():
                         _tag(
-                            tagrow, f'{dec["cost"]}PP', C_GOLD, GOLD_TAG_BG, GOLD_TAG_BD
+                            tagrow, f"{dec['cost']}PP", C_GOLD, GOLD_TAG_BG, GOLD_TAG_BD
                         )
                     if dec["chain"]:
                         _tag(
@@ -1310,7 +1310,7 @@ def open_decision_wizard(app):
         n = len(_decs_for(uid))
         msg = f"Delete category '{c['cat_id']}'"
         if n:
-            msg += f" and its {n} decision{'s' if n!=1 else ''}?"
+            msg += f" and its {n} decision{'s' if n != 1 else ''}?"
         else:
             msg += "?"
         if not messagebox.askyesno("Delete Category", msg, parent=win):
@@ -3164,7 +3164,9 @@ def open_decision_wizard(app):
         )
         text = _re_s.sub(r"\[([A-Z]{2,5})\](\S+)", r"\2", text)  # [TAG]Word → Word
         text = _re_s.sub(
-            r"\[([A-Z]{2,5}):[^\]]+\]", lambda m: m.group(1), text  # [TAG:X] → TAG
+            r"\[([A-Z]{2,5}):[^\]]+\]",
+            lambda m: m.group(1),
+            text,  # [TAG:X] → TAG
         )
         text = _re_s.sub(r"\[[^\]]{1,80}\]", "", text)  # remaining [tokens]
         return text.strip()
@@ -3726,7 +3728,7 @@ def open_decision_wizard(app):
                     TEAL_TAG_BD if dec["targeted"] != "none" else C_BORDG,
                 )
                 if dec["cost_type"] == "pp" and dec.get("cost", "").strip():
-                    _tag(tag_row, f'PP {dec["cost"]}', C_GOLD, GOLD_TAG_BG, GOLD_TAG_BD)
+                    _tag(tag_row, f"PP {dec['cost']}", C_GOLD, GOLD_TAG_BG, GOLD_TAG_BD)
                 _tag(tag_row, dec["dec_id"], C_DIM, C_DARK, C_BORDG)
 
         # Chain assignment card

--- a/src/hoi4cm/wizards/dyn_mod.py
+++ b/src/hoi4cm/wizards/dyn_mod.py
@@ -41,6 +41,59 @@ from hoi4cm.wizards._image_loader import TkImageLoader
 from hoi4cm.wizards._shared import notifying_workspace_files
 
 
+def _svar_get(var, default=""):
+    if var is None or not hasattr(var, "get"):
+        return default
+    try:
+        val = var.get()
+        return val if isinstance(val, str) else str(val)
+    except Exception:
+        return default
+
+
+def _text_get(widget, default=""):
+    if widget is None or not hasattr(widget, "get"):
+        return default
+    try:
+        val = widget.get("1.0", "end")
+    except TypeError:
+        try:
+            val = widget.get()
+        except Exception:
+            return default
+    except Exception:
+        return default
+    if isinstance(val, str):
+        return val.strip()
+    return str(val).strip()
+
+
+def collect_dyn_mod_state(svars, text_widgets):
+    """Collect dynamic-modifier form state into kwargs for ``build_dyn_mod_output``."""
+    return {
+        "mod_id": _svar_get(svars.get("mod_id") if isinstance(svars, dict) else None),
+        "scope": _svar_get(
+            svars.get("scope") if isinstance(svars, dict) else None, "country"
+        ),
+        "icon": _svar_get(svars.get("icon") if isinstance(svars, dict) else None),
+        "enable": _text_get(
+            text_widgets.get("enable") if isinstance(text_widgets, dict) else None
+        ),
+        "mods_raw": _text_get(
+            text_widgets.get("mods") if isinstance(text_widgets, dict) else None
+        ),
+        "const": _text_get(
+            text_widgets.get("const") if isinstance(text_widgets, dict) else None
+        ),
+        "loc_name": _svar_get(
+            svars.get("loc_name") if isinstance(svars, dict) else None
+        ),
+        "loc_desc": _svar_get(
+            svars.get("loc_desc") if isinstance(svars, dict) else None
+        ),
+    }
+
+
 def open_dyn_mod_wizard(app):
     """Wizard to create a HOI4 dynamic modifier .txt file."""
     win = tk.Toplevel(app)
@@ -937,16 +990,17 @@ def open_dyn_mod_wizard(app):
         return _parse_mod_line_pure(ln)
 
     def _build_output():
-        return build_dyn_mod_output(
-            mod_id=v_id.get(),
-            scope=v_scope.get(),
-            icon=v_icon.get(),
-            enable=v_enable.get("1.0", "end"),
-            mods_raw=v_mods.get("1.0", "end"),
-            const=v_const.get("1.0", "end"),
-            loc_name=v_loc_name.get(),
-            loc_desc=v_loc_desc.get(),
+        state = collect_dyn_mod_state(
+            {
+                "mod_id": v_id,
+                "scope": v_scope,
+                "icon": v_icon,
+                "loc_name": v_loc_name,
+                "loc_desc": v_loc_desc,
+            },
+            {"enable": v_enable, "mods": v_mods, "const": v_const},
         )
+        return build_dyn_mod_output(**state)
 
     def _preview(*_):
         if _dm_edit_mode[0]:

--- a/src/hoi4cm/wizards/dyn_mod.py
+++ b/src/hoi4cm/wizards/dyn_mod.py
@@ -1250,7 +1250,7 @@ def open_dyn_mod_wizard(app):
             gfx_rel = os.path.join("interface", "ideas.gfx")
             gfx_existing = read_existing(gfx_rel)
             if gfx_existing is None:
-                gfx_final = f"spriteTypes = {{\n\n" f"{sprite_block}\n\n" f"}}\n"
+                gfx_final = f"spriteTypes = {{\n\n{sprite_block}\n\n}}\n"
                 gfx_action = "created"
             elif icon_gfx in gfx_existing:
                 gfx_final = gfx_existing

--- a/src/hoi4cm/wizards/dyn_mod.py
+++ b/src/hoi4cm/wizards/dyn_mod.py
@@ -38,57 +38,35 @@ from hoi4cm.ui import (
 from hoi4cm.wizards._generators import build_dyn_mod_output
 from hoi4cm.wizards._graphics import browser_folders, collect_image_pairs
 from hoi4cm.wizards._image_loader import TkImageLoader
-from hoi4cm.wizards._shared import notifying_workspace_files
-
-
-def _svar_get(var, default=""):
-    if var is None or not hasattr(var, "get"):
-        return default
-    try:
-        val = var.get()
-        return val if isinstance(val, str) else str(val)
-    except Exception:
-        return default
-
-
-def _text_get(widget, default=""):
-    if widget is None or not hasattr(widget, "get"):
-        return default
-    try:
-        val = widget.get("1.0", "end")
-    except TypeError:
-        try:
-            val = widget.get()
-        except Exception:
-            return default
-    except Exception:
-        return default
-    if isinstance(val, str):
-        return val.strip()
-    return str(val).strip()
+from hoi4cm.wizards._shared import (
+    notifying_workspace_files,
+    svar_get,
+    text_get,
+)
 
 
 def collect_dyn_mod_state(svars, text_widgets):
     """Collect dynamic-modifier form state into kwargs for ``build_dyn_mod_output``."""
+    scope = svar_get(svars.get("scope") if isinstance(svars, dict) else None, "country")
+    if not scope.strip():
+        scope = "country"
     return {
-        "mod_id": _svar_get(svars.get("mod_id") if isinstance(svars, dict) else None),
-        "scope": _svar_get(
-            svars.get("scope") if isinstance(svars, dict) else None, "country"
-        ),
-        "icon": _svar_get(svars.get("icon") if isinstance(svars, dict) else None),
-        "enable": _text_get(
+        "mod_id": svar_get(svars.get("mod_id") if isinstance(svars, dict) else None),
+        "scope": scope,
+        "icon": svar_get(svars.get("icon") if isinstance(svars, dict) else None),
+        "enable": text_get(
             text_widgets.get("enable") if isinstance(text_widgets, dict) else None
         ),
-        "mods_raw": _text_get(
+        "mods_raw": text_get(
             text_widgets.get("mods") if isinstance(text_widgets, dict) else None
         ),
-        "const": _text_get(
+        "const": text_get(
             text_widgets.get("const") if isinstance(text_widgets, dict) else None
         ),
-        "loc_name": _svar_get(
+        "loc_name": svar_get(
             svars.get("loc_name") if isinstance(svars, dict) else None
         ),
-        "loc_desc": _svar_get(
+        "loc_desc": svar_get(
             svars.get("loc_desc") if isinstance(svars, dict) else None
         ),
     }

--- a/src/hoi4cm/wizards/event.py
+++ b/src/hoi4cm/wizards/event.py
@@ -878,7 +878,7 @@ def open_event_wizard(app):
         hdr.pack(fill="x")
         tk.Label(
             hdr,
-            text=f"  Option {idx+1}",
+            text=f"  Option {idx + 1}",
             bg=BG_DARK,
             fg=TEXT_DIM,
             font=("Helvetica", 8, "bold"),
@@ -1019,7 +1019,7 @@ def open_event_wizard(app):
         n = len(sel[0].options) + 1
         sel[0].options.append(
             {
-                "name": f"{sel[0].eid}.{chr(96+n)}",
+                "name": f"{sel[0].eid}.{chr(96 + n)}",
                 "text": f"Option {n}",
                 "effects": "",
                 "ai_chance": "1",
@@ -1179,7 +1179,7 @@ def open_event_wizard(app):
                     wf.write_text(ev_file, ev_content, encoding="utf-8")
                 rel = os.path.relpath(ev_file, mod_root)
                 saved.append(
-                    f"{rel}  (+{len(to_append)} event{'s' if len(to_append)!=1 else ''})"
+                    f"{rel}  (+{len(to_append)} event{'s' if len(to_append) != 1 else ''})"
                 )
             else:
                 warnings.append(

--- a/src/hoi4cm/wizards/event.py
+++ b/src/hoi4cm/wizards/event.py
@@ -54,6 +54,19 @@ from hoi4cm.wizards._shared import (
 )
 
 
+def collect_event_state(events):
+    """Snapshot the wizard's event list for headless generator calls.
+
+    Returns a shallow copy so a generator reading the list cannot be
+    affected by a concurrent mutation of the wizard's live list (the
+    same reason the dialog's export path copies before rendering).
+    Accepts any iterable; ``None`` becomes ``[]``.
+    """
+    if events is None:
+        return []
+    return list(events)
+
+
 def open_event_wizard(app):
     """HOI4 Event Maker — uses main app theme (BG_DARK / BG_PANEL etc.)."""
 
@@ -1034,10 +1047,10 @@ def open_event_wizard(app):
         return _generators.render_event_txt(ev)
 
     def _generate_all_txt():
-        return _generators.generate_events_txt(events)
+        return _generators.generate_events_txt(collect_event_state(events))
 
     def _generate_yml():
-        return _generators.generate_event_loc_yml(events)
+        return _generators.generate_event_loc_yml(collect_event_state(events))
 
     # ── Top bar actions ───────────────────────────────────────────────
     def _new_event():

--- a/src/hoi4cm/wizards/national_spirit.py
+++ b/src/hoi4cm/wizards/national_spirit.py
@@ -45,34 +45,11 @@ from hoi4cm.ui import (
 from hoi4cm.wizards._generators import build_national_spirit_output
 from hoi4cm.wizards._graphics import browser_folders, collect_image_pairs
 from hoi4cm.wizards._image_loader import TkImageLoader
-from hoi4cm.wizards._shared import notifying_workspace_files
-
-
-def _svar_get(var, default=""):
-    if var is None or not hasattr(var, "get"):
-        return default
-    try:
-        val = var.get()
-        return val if isinstance(val, str) else str(val)
-    except Exception:
-        return default
-
-
-def _text_get(widget, default=""):
-    if widget is None or not hasattr(widget, "get"):
-        return default
-    try:
-        val = widget.get("1.0", "end")
-    except TypeError:
-        try:
-            val = widget.get()
-        except Exception:
-            return default
-    except Exception:
-        return default
-    if isinstance(val, str):
-        return val.strip()
-    return str(val).strip()
+from hoi4cm.wizards._shared import (
+    notifying_workspace_files,
+    svar_get,
+    text_get,
+)
 
 
 def collect_national_spirit_state(svars, text_widgets, modifiers):
@@ -85,45 +62,45 @@ def collect_national_spirit_state(svars, text_widgets, modifiers):
     ``{key, value}`` dicts.
     """
     return {
-        "mod_id": _svar_get(svars.get("mod_id") if isinstance(svars, dict) else None),
-        "name_key": _svar_get(
+        "mod_id": svar_get(svars.get("mod_id") if isinstance(svars, dict) else None),
+        "name_key": svar_get(
             svars.get("name_key") if isinstance(svars, dict) else None
         ),
-        "picture": _svar_get(svars.get("picture") if isinstance(svars, dict) else None),
-        "slot": _svar_get(svars.get("slot") if isinstance(svars, dict) else None),
-        "cost": _svar_get(svars.get("cost") if isinstance(svars, dict) else None),
-        "removal_cost": _svar_get(
+        "picture": svar_get(svars.get("picture") if isinstance(svars, dict) else None),
+        "slot": svar_get(svars.get("slot") if isinstance(svars, dict) else None),
+        "cost": svar_get(svars.get("cost") if isinstance(svars, dict) else None),
+        "removal_cost": svar_get(
             svars.get("removal") if isinstance(svars, dict) else None
         ),
-        "loc_name": _svar_get(
+        "loc_name": svar_get(
             svars.get("loc_name") if isinstance(svars, dict) else None
         ),
-        "loc_desc": _svar_get(
+        "loc_desc": svar_get(
             svars.get("loc_desc") if isinstance(svars, dict) else None
         ),
-        "ai_factor": _svar_get(svars.get("ai") if isinstance(svars, dict) else None),
-        "allowed": _text_get(
+        "ai_factor": svar_get(svars.get("ai") if isinstance(svars, dict) else None),
+        "allowed": text_get(
             text_widgets.get("allowed") if isinstance(text_widgets, dict) else None
         ),
-        "available": _text_get(
+        "available": text_get(
             text_widgets.get("available") if isinstance(text_widgets, dict) else None
         ),
-        "cancel": _text_get(
+        "cancel": text_get(
             text_widgets.get("cancel") if isinstance(text_widgets, dict) else None
         ),
-        "visible": _text_get(
+        "visible": text_get(
             text_widgets.get("visible") if isinstance(text_widgets, dict) else None
         ),
-        "on_add": _text_get(
+        "on_add": text_get(
             text_widgets.get("on_add") if isinstance(text_widgets, dict) else None
         ),
-        "on_remove": _text_get(
+        "on_remove": text_get(
             text_widgets.get("on_remove") if isinstance(text_widgets, dict) else None
         ),
-        "rule": _text_get(
+        "rule": text_get(
             text_widgets.get("rule") if isinstance(text_widgets, dict) else None
         ),
-        "extra_modifiers": _text_get(
+        "extra_modifiers": text_get(
             text_widgets.get("extra") if isinstance(text_widgets, dict) else None
         ),
         "modifiers": list(modifiers) if modifiers is not None else [],

--- a/src/hoi4cm/wizards/national_spirit.py
+++ b/src/hoi4cm/wizards/national_spirit.py
@@ -48,6 +48,88 @@ from hoi4cm.wizards._image_loader import TkImageLoader
 from hoi4cm.wizards._shared import notifying_workspace_files
 
 
+def _svar_get(var, default=""):
+    if var is None or not hasattr(var, "get"):
+        return default
+    try:
+        val = var.get()
+        return val if isinstance(val, str) else str(val)
+    except Exception:
+        return default
+
+
+def _text_get(widget, default=""):
+    if widget is None or not hasattr(widget, "get"):
+        return default
+    try:
+        val = widget.get("1.0", "end")
+    except TypeError:
+        try:
+            val = widget.get()
+        except Exception:
+            return default
+    except Exception:
+        return default
+    if isinstance(val, str):
+        return val.strip()
+    return str(val).strip()
+
+
+def collect_national_spirit_state(svars, text_widgets, modifiers):
+    """Collect wizard form state into kwargs for ``build_national_spirit_output``.
+
+    ``svars`` maps scalar field names to ``tk.StringVar``-like objects
+    (``.get()``), ``text_widgets`` maps trigger/text names to
+    ``tk.Text``-like objects (``.get("1.0", "end")``). Both accept
+    duck-typed fakes in tests. ``modifiers`` is the live list of
+    ``{key, value}`` dicts.
+    """
+    return {
+        "mod_id": _svar_get(svars.get("mod_id") if isinstance(svars, dict) else None),
+        "name_key": _svar_get(
+            svars.get("name_key") if isinstance(svars, dict) else None
+        ),
+        "picture": _svar_get(svars.get("picture") if isinstance(svars, dict) else None),
+        "slot": _svar_get(svars.get("slot") if isinstance(svars, dict) else None),
+        "cost": _svar_get(svars.get("cost") if isinstance(svars, dict) else None),
+        "removal_cost": _svar_get(
+            svars.get("removal") if isinstance(svars, dict) else None
+        ),
+        "loc_name": _svar_get(
+            svars.get("loc_name") if isinstance(svars, dict) else None
+        ),
+        "loc_desc": _svar_get(
+            svars.get("loc_desc") if isinstance(svars, dict) else None
+        ),
+        "ai_factor": _svar_get(svars.get("ai") if isinstance(svars, dict) else None),
+        "allowed": _text_get(
+            text_widgets.get("allowed") if isinstance(text_widgets, dict) else None
+        ),
+        "available": _text_get(
+            text_widgets.get("available") if isinstance(text_widgets, dict) else None
+        ),
+        "cancel": _text_get(
+            text_widgets.get("cancel") if isinstance(text_widgets, dict) else None
+        ),
+        "visible": _text_get(
+            text_widgets.get("visible") if isinstance(text_widgets, dict) else None
+        ),
+        "on_add": _text_get(
+            text_widgets.get("on_add") if isinstance(text_widgets, dict) else None
+        ),
+        "on_remove": _text_get(
+            text_widgets.get("on_remove") if isinstance(text_widgets, dict) else None
+        ),
+        "rule": _text_get(
+            text_widgets.get("rule") if isinstance(text_widgets, dict) else None
+        ),
+        "extra_modifiers": _text_get(
+            text_widgets.get("extra") if isinstance(text_widgets, dict) else None
+        ),
+        "modifiers": list(modifiers) if modifiers is not None else [],
+    }
+
+
 def open_national_spirit_wizard(app):
     """Visual National Spirit / Idea builder with searchable modifier cards."""
     win = tk.Toplevel(app)
@@ -1137,29 +1219,31 @@ def open_national_spirit_wizard(app):
     # ── Output builder ────────────────────────────────────────────────
     # Headless generator lives in _generators.py (issue #51).
     def _build_output():
-        def _tri(t):
-            return t.get("1.0", "end").strip()
-
-        return build_national_spirit_output(
-            mod_id=v_id.get(),
-            name_key=v_name_key.get(),
-            picture=v_picture.get(),
-            slot=v_slot.get(),
-            cost=v_cost.get(),
-            removal_cost=v_removal.get(),
-            loc_name=v_loc_name.get(),
-            loc_desc=v_loc_desc.get(),
-            ai_factor=v_ai.get(),
-            allowed=_tri(t_allowed),
-            available=_tri(t_available),
-            cancel=_tri(t_cancel),
-            visible=_tri(t_visible),
-            on_add=_tri(t_on_add),
-            on_remove=_tri(t_on_remove),
-            rule=_tri(t_rule),
-            extra_modifiers=t_extra.get("1.0", "end").strip(),
-            modifiers=spirit_modifiers,
+        state = collect_national_spirit_state(
+            {
+                "mod_id": v_id,
+                "name_key": v_name_key,
+                "picture": v_picture,
+                "slot": v_slot,
+                "cost": v_cost,
+                "removal": v_removal,
+                "loc_name": v_loc_name,
+                "loc_desc": v_loc_desc,
+                "ai": v_ai,
+            },
+            {
+                "allowed": t_allowed,
+                "available": t_available,
+                "cancel": t_cancel,
+                "visible": t_visible,
+                "on_add": t_on_add,
+                "on_remove": t_on_remove,
+                "rule": t_rule,
+                "extra": t_extra,
+            },
+            spirit_modifiers,
         )
+        return build_national_spirit_output(**state)
 
     def _refresh_preview(*_):
         """Rebuild preview from form fields (no-op in edit mode or raw override)."""

--- a/tests/test_wizard_collectors.py
+++ b/tests/test_wizard_collectors.py
@@ -344,10 +344,22 @@ def test_collect_decision_state_both_defaults_seam():
 
 
 def test_collect_decision_state_handles_non_string_and_empty():
-    # Non-string .get() is coerced via str(); empty string is preserved
-    # (generator treats "" as not-None, so this documents the current contract).
+    # Non-string .get() is coerced via str(); empty/whitespace now falls
+    # through to fallback (previously propagated as "" and rendered a
+    # broken targeted block).
     assert collect_decision_state({"targeted": _FakeVar(123)})["targeted"] == "123"
-    assert collect_decision_state({"targeted": _FakeVar("")})["targeted"] == ""
+    assert collect_decision_state({"targeted": _FakeVar("")})["targeted"] == "none"
+    assert collect_decision_state({"targeted": _FakeVar("  \n")})["targeted"] == "none"
+    assert (
+        collect_decision_state({"targeted": _FakeVar("")}, {"targeted": "state"})[
+            "targeted"
+        ]
+        == "state"
+    )
+    assert (
+        collect_decision_state({"targeted": _FakeVar("")}, {"targeted": ""})["targeted"]
+        == "none"
+    )
     # evars not a dict -> literal fallback, dec not a dict -> literal fallback
     assert collect_decision_state(None) == {"targeted": "none", "cost_type": "pp"}
     assert collect_decision_state({}, dec="not-a-dict") == {
@@ -459,8 +471,9 @@ def test_collect_national_spirit_state_handles_missing_and_bad_widgets():
 def test_collect_dyn_mod_state_handles_whitespace_and_bad_widgets():
     assert collect_dyn_mod_state(None, None)["scope"] == "country"
     assert collect_dyn_mod_state({}, {"enable": _BadVar()})["enable"] == ""
-    # scope empty string propagates (generator will treat "" != "country")
-    assert collect_dyn_mod_state({"scope": _FakeVar("")}, {})["scope"] == ""
+    # empty/whitespace scope falls back to "country" ("" would render `scope = `)
+    assert collect_dyn_mod_state({"scope": _FakeVar("")}, {})["scope"] == "country"
+    assert collect_dyn_mod_state({"scope": _FakeVar("  \n")}, {})["scope"] == "country"
     # whitespace Text stripped to ""
     assert collect_dyn_mod_state({}, {"enable": _FakeText("  \n")})["enable"] == ""
 
@@ -505,3 +518,137 @@ def test_national_spirit_and_dyn_mod_integration_roundtrip():
     dm_out = build_dyn_mod_output(**dm_state)
     assert "TAG_dyn = {" in dm_out
     assert "stability_factor = my_var" in dm_out
+
+
+def test_collect_decision_state_targeted_matrix():
+    # Covers the most-branching generator path (state vs country vs none).
+    def _base(**overrides):
+        base = {
+            "uid": "dec-1",
+            "cat_uid": "cat-1",
+            "dec_id": "TAG_decision",
+            "loc_name": "N",
+            "loc_desc": "",
+            "icon": "",
+            "allowed": "",
+            "visible": "",
+            "available": "",
+            "cost_type": "pp",
+            "cost": "25",
+            "custom_cost_trigger": "",
+            "custom_cost_text": "",
+            "ai_hint_pp_cost": "",
+            "cost_var": "",
+            "cost_amount": "",
+            "days_remove": "",
+            "days_re_enable": "",
+            "fire_only_once": False,
+            "fixed_random_seed": True,
+            "is_mission": False,
+            "mission_timeout": "100",
+            "selectable_mission": False,
+            "is_good": False,
+            "activation": "",
+            "highlight_states": "",
+            "on_map_mode": "map_and_decisions_view",
+            "state_target_scope": "any",
+            "target_root_trigger": "has_war = yes",
+            "target_trigger": "is_core = yes",
+            "targets": "123",
+            "targets_dynamic": True,
+            "target_non_existing": False,
+            "target_array": "",
+            "modifier": "",
+            "complete_effect": "",
+            "timeout_effect": "",
+            "remove_effect": "",
+            "cancel_trigger": "",
+            "cancel_effect": "",
+            "cancel_if_not_visible": False,
+            "remove_trigger": "",
+            "ai_will_do": "",
+            "priority": "1",
+            "war_target_complete": False,
+            "war_target_remove": False,
+            "war_complete_tag": "",
+            "war_remove_tag": "",
+        }
+        base.update(overrides)
+        return base
+
+    # state-targeted with scope "any" -> state_target = yes
+    state_any = generate_decision_block(
+        _base(), **collect_decision_state({"targeted": _FakeVar("state")})
+    )
+    assert "state_target = yes" in state_any
+    assert "on_map_mode = map_and_decisions_view" in state_any
+    assert "target_root_trigger" in state_any
+    assert "targets = { 123 }" in state_any
+    assert "targets_dynamic = yes" in state_any
+    # state-targeted with specific scope
+    state_specific = generate_decision_block(
+        _base(state_target_scope="state:123"),
+        **collect_decision_state({"targeted": _FakeVar("state")}),
+    )
+    assert "state_target = state:123" in state_specific
+    # country-targeted -> no state_target, but targets still emitted
+    country = generate_decision_block(
+        _base(target_array="my_array"),
+        **collect_decision_state({"targeted": _FakeVar("country")}),
+    )
+    assert "state_target" not in country
+    assert "target_array = my_array" in country
+    # untargeted -> on_map_mode emitted at bottom, state_target not emitted
+    none = generate_decision_block(
+        _base(), **collect_decision_state({"targeted": _FakeVar("none")})
+    )
+    assert "state_target" not in none
+    # on_map_mode appears for untargeted (bottom branch)
+    assert "on_map_mode = map_and_decisions_view" in none
+
+
+def test_event_wizard_roundtrip_via_collect():
+    # Lightweight roundtrip: collect -> generate -> tokenise/parse survives.
+    from hoi4cm.script.syntax import parse_block, tokenize
+
+    ev = SimpleNamespace(
+        etype="country_event",
+        eid="test.99",
+        title_text="T",
+        desc_text="D",
+        picture="GFX_report_event_generic_handshake",
+        major=True,
+        fire_once=True,
+        triggered=True,
+        hidden=False,
+        trigger_code="has_war = yes",
+        mtth_days="10",
+        mtth_months="",
+        immediate="add_political_power = 10",
+        options=[
+            {
+                "name": "test.99.a",
+                "text": "Go",
+                "effects": "add_stability = 0.05",
+                "ai_chance": "5",
+            }
+        ],
+    )
+    snap = collect_event_state([ev])
+    from hoi4cm.wizards._generators import generate_events_txt
+
+    txt = generate_events_txt(snap)
+    # Txt must contain the structured blocks the parser can recover.
+    assert "add_namespace = test" in txt
+    assert "major = yes" in txt
+    assert "fire_only_once = yes" in txt
+    assert "add_political_power = 10" in txt
+    assert "add_stability = 0.05" in txt
+    # Parser roundtrip: tokenise and extract the country_event block.
+    toks = tokenize(txt)
+    # Find the event id via parse_block following the "country_event =" header.
+    idx = toks.index("country_event")
+    blk, _ = parse_block(toks, idx + 2)
+    assert blk.get("id") == "test.99"
+    assert blk.get("picture") == "GFX_report_event_generic_handshake"
+    assert blk.get("major") == "yes"

--- a/tests/test_wizard_collectors.py
+++ b/tests/test_wizard_collectors.py
@@ -1,0 +1,340 @@
+"""Headless tests for wizard collect_*_state helpers (issue #62).
+
+Each wizard closure previously read Tk ``StringVar``/``Text`` widgets
+inline and delegated to a generator.  Now the reads live in a small
+``collect_*_state`` that takes duck-typed ``.get()`` objects, so the
+seam is testable without a display.  A rename of an ``_evars`` key or
+a drift in the fallback now fails here instead of silently shipping
+wrong script.
+"""
+
+from types import SimpleNamespace
+
+from hoi4cm.wizards._generators import (
+    build_dyn_mod_output,
+    build_income_spirit_snippet,
+    build_national_spirit_output,
+    generate_decision_block,
+)
+from hoi4cm.wizards.additional_income import collect_additional_income_state
+from hoi4cm.wizards.decision import collect_decision_state
+from hoi4cm.wizards.dyn_mod import collect_dyn_mod_state
+from hoi4cm.wizards.event import collect_event_state
+from hoi4cm.wizards.national_spirit import collect_national_spirit_state
+
+
+class _FakeVar:
+    def __init__(self, value):
+        self._value = value
+
+    def get(self):
+        return self._value
+
+    def set(self, value):  # pragma: no cover - not used in tests
+        self._value = value
+
+
+class _FakeText:
+    def __init__(self, text):
+        self._text = text
+
+    def get(self, *args, **kwargs):
+        return self._text
+
+
+class _BadVar:
+    def get(self):
+        raise RuntimeError("boom")
+
+
+# ── decision ──────────────────────────────────────────────────────────
+
+
+def test_collect_decision_state_from_vars():
+    evars = {"targeted": _FakeVar("state"), "cost_type": _FakeVar("custom")}
+    assert collect_decision_state(evars) == {"targeted": "state", "cost_type": "custom"}
+
+
+def test_collect_decision_state_falls_back_to_dec():
+    evars = {}
+    dec = {"targeted": "country", "cost_type": "custom"}
+    assert collect_decision_state(evars, dec) == {
+        "targeted": "country",
+        "cost_type": "custom",
+    }
+
+
+def test_collect_decision_state_literal_defaults_when_no_dec():
+    assert collect_decision_state({}) == {"targeted": "none", "cost_type": "pp"}
+    assert collect_decision_state({}, None) == {"targeted": "none", "cost_type": "pp"}
+
+
+def test_collect_decision_state_var_wins_over_dec():
+    evars = {"targeted": _FakeVar("state")}
+    dec = {"targeted": "country", "cost_type": "pp"}
+    out = collect_decision_state(evars, dec)
+    assert out["targeted"] == "state"
+    assert out["cost_type"] == "pp"
+
+
+def test_collect_decision_state_bad_var_falls_back():
+    evars = {"targeted": _BadVar(), "cost_type": _BadVar()}
+    dec = {"targeted": "country"}
+    out = collect_decision_state(evars, dec)
+    assert out["targeted"] == "country"
+    assert out["cost_type"] == "pp"
+
+
+def test_collect_decision_state_renamed_key_uses_fallback():
+    # Simulate a rename of _evars["targeted"] -> typo; old code would silently
+    # render untargeted.  The helper must fall through to dec/default.
+    evars = {"targeted_typo": _FakeVar("state"), "cost_type": _FakeVar("custom")}
+    dec = {"targeted": "country", "cost_type": "pp"}
+    out = collect_decision_state(evars, dec)
+    assert out["targeted"] == "country"
+    assert out["cost_type"] == "custom"
+
+
+def test_collect_decision_state_into_generator_targeted():
+    # Seam proof: what the closure hands over actually changes the rendered block.
+    base = {
+        "uid": "dec-1",
+        "cat_uid": "cat-1",
+        "dec_id": "TAG_decision",
+        "loc_name": "My Decision",
+        "loc_desc": "",
+        "icon": "",
+        "allowed": "",
+        "visible": "",
+        "available": "",
+        "cost_type": "pp",
+        "cost": "25",
+        "custom_cost_trigger": "",
+        "custom_cost_text": "",
+        "ai_hint_pp_cost": "",
+        "cost_var": "",
+        "cost_amount": "",
+        "days_remove": "",
+        "days_re_enable": "",
+        "fire_only_once": False,
+        "fixed_random_seed": True,
+        "is_mission": False,
+        "mission_timeout": "100",
+        "selectable_mission": False,
+        "is_good": False,
+        "activation": "",
+        "highlight_states": "",
+        "on_map_mode": "map_and_decisions_view",
+        "state_target_scope": "any",
+        "target_root_trigger": "",
+        "target_trigger": "",
+        "targets": "",
+        "targets_dynamic": False,
+        "target_non_existing": False,
+        "target_array": "",
+        "modifier": "",
+        "complete_effect": "",
+        "timeout_effect": "",
+        "remove_effect": "",
+        "cancel_trigger": "",
+        "cancel_effect": "",
+        "cancel_if_not_visible": False,
+        "remove_trigger": "",
+        "ai_will_do": "",
+        "priority": "1",
+        "war_target_complete": False,
+        "war_target_remove": False,
+        "war_complete_tag": "",
+        "war_remove_tag": "",
+    }
+    untargeted = generate_decision_block(base, **collect_decision_state({}))
+    assert "state_target" not in untargeted
+    targeted = generate_decision_block(
+        base, **collect_decision_state({"targeted": _FakeVar("state")})
+    )
+    assert "state_target = yes" in targeted
+
+
+# ── national spirit ───────────────────────────────────────────────────
+
+
+def test_collect_national_spirit_state_maps_scalars_and_text():
+    svars = {
+        "mod_id": _FakeVar("TAG_s"),
+        "name_key": _FakeVar("TAG_s_name"),
+        "picture": _FakeVar("GFX_idea_TAG_s"),
+        "slot": _FakeVar("country"),
+        "cost": _FakeVar("50"),
+        "removal": _FakeVar("10"),
+        "loc_name": _FakeVar("My Spirit"),
+        "loc_desc": _FakeVar("Desc"),
+        "ai": _FakeVar("5"),
+    }
+    text = {
+        "allowed": _FakeText("has_war = yes"),
+        "available": _FakeText("threat > 0.5"),
+        "cancel": _FakeText(""),
+        "visible": _FakeText(""),
+        "on_add": _FakeText("add_stability = 0.1"),
+        "on_remove": _FakeText(""),
+        "rule": _FakeText(""),
+        "extra": _FakeText("stability_factor = 0.05"),
+    }
+    state = collect_national_spirit_state(
+        svars, text, [{"key": "war_support_factor", "value": "0.1"}]
+    )
+    assert state["mod_id"] == "TAG_s"
+    assert state["allowed"] == "has_war = yes"
+    assert state["available"] == "threat > 0.5"
+    assert state["on_add"] == "add_stability = 0.1"
+    assert state["extra_modifiers"] == "stability_factor = 0.05"
+    assert state["modifiers"] == [{"key": "war_support_factor", "value": "0.1"}]
+    out = build_national_spirit_output(**state)
+    assert "cost = 50" in out
+    assert "removal_cost = 10" in out
+    assert "allowed = {" in out
+    assert "stability_factor = 0.05" in out
+
+
+def test_collect_national_spirit_state_missing_widgets_defaults():
+    state = collect_national_spirit_state({}, {}, None)
+    assert state["mod_id"] == ""
+    assert state["allowed"] == ""
+    assert state["modifiers"] == []
+    # Still renders with defaults (TAG_my_spirit fallback in generator)
+    out = build_national_spirit_output(**state)
+    assert "TAG_my_spirit" in out
+
+
+def test_collect_national_spirit_state_modifiers_copied():
+    mods = [{"key": "k", "value": "1"}]
+    state = collect_national_spirit_state({}, {}, mods)
+    mods.append({"key": "k2", "value": "2"})
+    assert len(state["modifiers"]) == 1
+
+
+def test_collect_national_spirit_state_text_stripped():
+    text = {"allowed": _FakeText("  has_war = yes  \n")}
+    state = collect_national_spirit_state({}, text, [])
+    assert state["allowed"] == "has_war = yes"
+
+
+# ── dynamic modifier ──────────────────────────────────────────────────
+
+
+def test_collect_dyn_mod_state_maps_all_fields():
+    svars = {
+        "mod_id": _FakeVar("TAG_my_dynamic_modifier"),
+        "scope": _FakeVar("state"),
+        "icon": _FakeVar("GFX_idea_test"),
+        "loc_name": _FakeVar("My Mod"),
+        "loc_desc": _FakeVar("Desc"),
+    }
+    text = {
+        "enable": _FakeText("has_war = yes"),
+        "mods": _FakeText("stability_factor = my_var"),
+        "const": _FakeText("war_support_factor = 0.1"),
+    }
+    state = collect_dyn_mod_state(svars, text)
+    assert state["scope"] == "state"
+    assert state["enable"] == "has_war = yes"
+    out = build_dyn_mod_output(**state)
+    assert "scope = state" in out
+    assert "icon = GFX_idea_test" in out
+    assert "stability_factor = my_var" in out
+    assert "war_support_factor = 0.1" in out
+
+
+def test_collect_dyn_mod_state_defaults():
+    state = collect_dyn_mod_state({}, {})
+    assert state["mod_id"] == ""
+    assert state["scope"] == "country"
+    assert state["enable"] == ""
+
+
+# ── additional income ─────────────────────────────────────────────────
+
+
+def test_collect_additional_income_state_normalises():
+    svars = {
+        "idea_id": _FakeVar(" HKG_bonus "),
+        "country_tag": _FakeVar(" hkg "),
+        "variable_name": _FakeVar(" HKG_trade_income_gain "),
+        "amount": _FakeVar(" 0.05 "),
+        "tooltip_key": _FakeVar(" HKG_trade_income_TT "),
+        "spirit_name": _FakeVar(" Free Trade "),
+        "spirit_desc": _FakeVar(" Desc "),
+        "tooltip_text": _FakeVar(" +5% "),
+        "mode": _FakeVar("also_spirit"),
+        "formula_type": _FakeVar("gdp_pct"),
+    }
+    state = collect_additional_income_state(svars)
+    assert state["idea_id"] == "HKG_bonus"
+    assert state["country_tag"] == "HKG"
+    assert state["variable_name"] == "HKG_trade_income_gain"
+    assert state["mode"] == "also_spirit"
+    assert state["formula_type"] == "gdp_pct"
+    snippet = build_income_spirit_snippet(
+        idea_id=state["idea_id"],
+        country_tag=state["country_tag"],
+        variable_name=state["variable_name"],
+        tooltip_key=state["tooltip_key"],
+        spirit_name=state["spirit_name"],
+        spirit_desc=state["spirit_desc"],
+    )
+    assert "HKG_bonus = {" in snippet
+    assert "original_tag = HKG" in snippet
+    assert "HKG_trade_income_TT" in snippet
+
+
+def test_collect_additional_income_state_defaults():
+    state = collect_additional_income_state({})
+    assert state["mode"] == "wire_only"
+    assert state["formula_type"] == "fixed"
+    assert state["country_tag"] == ""
+
+
+# ── event ─────────────────────────────────────────────────────────────
+
+
+def test_collect_event_state_copies_and_handles_none():
+    assert collect_event_state(None) == []
+    evs = [SimpleNamespace(eid="a.1"), SimpleNamespace(eid="a.2")]
+    snap = collect_event_state(evs)
+    assert snap == evs
+    assert snap is not evs
+    evs.append(SimpleNamespace(eid="a.3"))
+    assert len(snap) == 2
+
+
+def test_collect_event_state_into_generators():
+    from hoi4cm.wizards._generators import generate_events_txt
+
+    ev = SimpleNamespace(
+        etype="country_event",
+        eid="test.1",
+        title_text="T",
+        desc_text="D",
+        picture="GFX_report_event_generic_handshake",
+        major=False,
+        fire_once=False,
+        triggered=False,
+        hidden=False,
+        trigger_code="",
+        mtth_days="",
+        mtth_months="",
+        immediate="",
+        options=[{"name": "test.1.a", "text": "OK", "effects": "", "ai_chance": "1"}],
+    )
+    snap = collect_event_state([ev])
+    out = generate_events_txt(snap)
+    assert "id = test.1" in out
+    assert 'test.1.t: "T"' not in out  # txt file, not loc
+
+
+def test_collect_decision_state_both_defaults_seam():
+    # Replicates the drift the issue flagged: _gen_decision_txt fell back to
+    # dec values while _gen_decisions_file fell back to literals. Now both
+    # go through the same helper, so the file-level call with no dec matches
+    # the single-decision call with an empty dec.
+    assert collect_decision_state({}) == collect_decision_state({}, {})

--- a/tests/test_wizard_collectors.py
+++ b/tests/test_wizard_collectors.py
@@ -338,3 +338,170 @@ def test_collect_decision_state_both_defaults_seam():
     # go through the same helper, so the file-level call with no dec matches
     # the single-decision call with an empty dec.
     assert collect_decision_state({}) == collect_decision_state({}, {})
+
+
+# ── edge / contract ─────────────────────────────────────────────────
+
+
+def test_collect_decision_state_handles_non_string_and_empty():
+    # Non-string .get() is coerced via str(); empty string is preserved
+    # (generator treats "" as not-None, so this documents the current contract).
+    assert collect_decision_state({"targeted": _FakeVar(123)})["targeted"] == "123"
+    assert collect_decision_state({"targeted": _FakeVar("")})["targeted"] == ""
+    # evars not a dict -> literal fallback, dec not a dict -> literal fallback
+    assert collect_decision_state(None) == {"targeted": "none", "cost_type": "pp"}
+    assert collect_decision_state({}, dec="not-a-dict") == {
+        "targeted": "none",
+        "cost_type": "pp",
+    }
+    # var without .get falls through
+    assert (
+        collect_decision_state({"targeted": object()}, {"targeted": "country"})[
+            "targeted"
+        ]
+        == "country"
+    )
+
+
+def test_collect_decision_state_cost_type_into_generator():
+    base = {
+        "uid": "dec-1",
+        "cat_uid": "cat-1",
+        "dec_id": "TAG_decision",
+        "loc_name": "My Decision",
+        "loc_desc": "",
+        "icon": "",
+        "allowed": "",
+        "visible": "",
+        "available": "",
+        "cost_type": "pp",
+        "cost": "25",
+        "custom_cost_trigger": "has_dlc = 1",
+        "custom_cost_text": "CUSTOM",
+        "ai_hint_pp_cost": "10",
+        "cost_var": "",
+        "cost_amount": "",
+        "days_remove": "",
+        "days_re_enable": "",
+        "fire_only_once": False,
+        "fixed_random_seed": True,
+        "is_mission": False,
+        "mission_timeout": "100",
+        "selectable_mission": False,
+        "is_good": False,
+        "activation": "",
+        "highlight_states": "",
+        "on_map_mode": "map_and_decisions_view",
+        "state_target_scope": "any",
+        "target_root_trigger": "",
+        "target_trigger": "",
+        "targets": "",
+        "targets_dynamic": False,
+        "target_non_existing": False,
+        "target_array": "",
+        "modifier": "",
+        "complete_effect": "",
+        "timeout_effect": "",
+        "remove_effect": "",
+        "cancel_trigger": "",
+        "cancel_effect": "",
+        "cancel_if_not_visible": False,
+        "remove_trigger": "",
+        "ai_will_do": "",
+        "priority": "1",
+        "war_target_complete": False,
+        "war_target_remove": False,
+        "war_complete_tag": "",
+        "war_remove_tag": "",
+    }
+    pp = generate_decision_block(
+        base, **collect_decision_state({"cost_type": _FakeVar("pp")})
+    )
+    assert "cost = 25" in pp
+    assert "custom_cost_text" not in pp
+    custom = generate_decision_block(
+        base, **collect_decision_state({"cost_type": _FakeVar("custom")})
+    )
+    assert "custom_cost_text = CUSTOM" in custom
+    assert "custom_cost_trigger" in custom
+
+
+def test_collect_national_spirit_state_handles_missing_and_bad_widgets():
+    # svars/text_widgets not dict -> defaults, bad .get() -> defaults
+    assert collect_national_spirit_state(None, None, None)["mod_id"] == ""
+    assert (
+        collect_national_spirit_state({}, {"allowed": _BadVar()}, [])["allowed"] == ""
+    )
+
+    # widget that only supports .get() without args (TypeError branch)
+    class OnlyNoArg:
+        def get(self):
+            return "has_war = yes"
+
+    state = collect_national_spirit_state({}, {"allowed": OnlyNoArg()}, [])
+    assert state["allowed"] == "has_war = yes"
+    # non-string scalar coerced
+    assert (
+        collect_national_spirit_state({"mod_id": _FakeVar(123)}, {}, [])["mod_id"]
+        == "123"
+    )
+    # whitespace-only Text -> stripped to ""
+    assert (
+        collect_national_spirit_state({}, {"allowed": _FakeText("   \n")}, [])[
+            "allowed"
+        ]
+        == ""
+    )
+    # widget without .get attribute
+    assert collect_national_spirit_state({"mod_id": object()}, {}, [])["mod_id"] == ""
+
+
+def test_collect_dyn_mod_state_handles_whitespace_and_bad_widgets():
+    assert collect_dyn_mod_state(None, None)["scope"] == "country"
+    assert collect_dyn_mod_state({}, {"enable": _BadVar()})["enable"] == ""
+    # scope empty string propagates (generator will treat "" != "country")
+    assert collect_dyn_mod_state({"scope": _FakeVar("")}, {})["scope"] == ""
+    # whitespace Text stripped to ""
+    assert collect_dyn_mod_state({}, {"enable": _FakeText("  \n")})["enable"] == ""
+
+
+def test_collect_additional_income_state_handles_bad_and_missing():
+    assert collect_additional_income_state(None)["mode"] == "wire_only"
+    # bad .get -> default
+    assert collect_additional_income_state({"idea_id": _BadVar()})["idea_id"] == ""
+    # widget without .get -> default
+    assert collect_additional_income_state({"idea_id": object()})["idea_id"] == ""
+    # non-string tag upper-cased via str()
+    assert (
+        collect_additional_income_state({"country_tag": _FakeVar(123)})["country_tag"]
+        == "123"
+    )
+
+
+def test_collect_event_state_accepts_any_iterable_and_is_shallow():
+    snap_tuple = collect_event_state((1, 2, 3))
+    assert snap_tuple == [1, 2, 3]
+    # shallow copy: objects are shared
+    obj = SimpleNamespace(eid="a.1")
+    snap = collect_event_state([obj])
+    obj.eid = "mutated"
+    assert snap[0].eid == "mutated"
+
+
+def test_national_spirit_and_dyn_mod_integration_roundtrip():
+    # Contract: collected state must be a valid generator input without extra glue.
+    ns_state = collect_national_spirit_state(
+        {"mod_id": _FakeVar("TAG_s"), "slot": _FakeVar("country")},
+        {"allowed": _FakeText("always = yes"), "extra": _FakeText("")},
+        [{"key": "stability_factor", "value": "0.05"}],
+    )
+    ns_out = build_national_spirit_output(**ns_state)
+    assert "TAG_s = {" in ns_out
+    assert "stability_factor = 0.05" in ns_out
+    dm_state = collect_dyn_mod_state(
+        {"mod_id": _FakeVar("TAG_dyn")},
+        {"mods": _FakeText("stability_factor = my_var")},
+    )
+    dm_out = build_dyn_mod_output(**dm_state)
+    assert "TAG_dyn = {" in dm_out
+    assert "stability_factor = my_var" in dm_out

--- a/tests/test_wizard_dialog_smoke.py
+++ b/tests/test_wizard_dialog_smoke.py
@@ -1,0 +1,142 @@
+"""Tk smoke tests for the wizard collect_* helpers (issue #62, option C).
+
+Uses a real ``tk.StringVar``/``tk.Text`` under Xvfb to prove the helpers
+are wired to Tk correctly — the headless suite in ``test_wizard_collectors``
+covers logic with fakes, this file covers the Tk contract.  All tests are
+skipped when no display is available (``tests/conftest.py:tk_root``).
+"""
+
+import tkinter as tk
+
+from hoi4cm.wizards._generators import generate_decision_block
+from hoi4cm.wizards.additional_income import collect_additional_income_state
+from hoi4cm.wizards.decision import collect_decision_state
+from hoi4cm.wizards.dyn_mod import collect_dyn_mod_state
+from hoi4cm.wizards.national_spirit import collect_national_spirit_state
+
+
+def test_collect_decision_state_with_real_stringvar(tk_root):
+    parent = tk.Frame(tk_root)
+    v_targeted = tk.StringVar(parent, value="country")
+    v_cost = tk.StringVar(parent, value="custom")
+    state = collect_decision_state({"targeted": v_targeted, "cost_type": v_cost})
+    assert state == {"targeted": "country", "cost_type": "custom"}
+    v_targeted.set("none")
+    assert collect_decision_state({"targeted": v_targeted})["targeted"] == "none"
+
+
+def test_collect_decision_state_tk_mutation_changes_generator_output(tk_root):
+    parent = tk.Frame(tk_root)
+    v = tk.StringVar(parent, value="none")
+    base = {
+        "uid": "dec-1",
+        "cat_uid": "cat-1",
+        "dec_id": "TAG_decision",
+        "loc_name": "My Decision",
+        "loc_desc": "",
+        "icon": "",
+        "allowed": "",
+        "visible": "",
+        "available": "",
+        "cost_type": "pp",
+        "cost": "25",
+        "custom_cost_trigger": "",
+        "custom_cost_text": "",
+        "ai_hint_pp_cost": "",
+        "cost_var": "",
+        "cost_amount": "",
+        "days_remove": "",
+        "days_re_enable": "",
+        "fire_only_once": False,
+        "fixed_random_seed": True,
+        "is_mission": False,
+        "mission_timeout": "100",
+        "selectable_mission": False,
+        "is_good": False,
+        "activation": "",
+        "highlight_states": "",
+        "on_map_mode": "map_and_decisions_view",
+        "state_target_scope": "any",
+        "target_root_trigger": "",
+        "target_trigger": "",
+        "targets": "",
+        "targets_dynamic": False,
+        "target_non_existing": False,
+        "target_array": "",
+        "modifier": "",
+        "complete_effect": "",
+        "timeout_effect": "",
+        "remove_effect": "",
+        "cancel_trigger": "",
+        "cancel_effect": "",
+        "cancel_if_not_visible": False,
+        "remove_trigger": "",
+        "ai_will_do": "",
+        "priority": "1",
+        "war_target_complete": False,
+        "war_target_remove": False,
+        "war_complete_tag": "",
+        "war_remove_tag": "",
+    }
+    untargeted = generate_decision_block(
+        base, **collect_decision_state({"targeted": v})
+    )
+    assert "state_target" not in untargeted
+    v.set("state")
+    targeted = generate_decision_block(base, **collect_decision_state({"targeted": v}))
+    assert "state_target = yes" in targeted
+
+
+def test_collect_national_spirit_state_with_real_widgets(tk_root):
+    v_id = tk.StringVar(tk_root, value="TAG_s")
+    v_cost = tk.StringVar(tk_root, value="50")
+    t_allowed = tk.Text(tk_root)
+    t_allowed.insert("1.0", "has_war = yes")
+    t_extra = tk.Text(tk_root)
+    t_extra.insert("1.0", "stability_factor = 0.05")
+    state = collect_national_spirit_state(
+        {"mod_id": v_id, "cost": v_cost},
+        {"allowed": t_allowed, "extra": t_extra},
+        [],
+    )
+    assert state["mod_id"] == "TAG_s"
+    assert state["cost"] == "50"
+    assert state["allowed"] == "has_war = yes"
+    assert state["extra_modifiers"] == "stability_factor = 0.05"
+
+
+def test_collect_dyn_mod_state_with_real_widgets(tk_root):
+    v_id = tk.StringVar(tk_root, value="TAG_dyn")
+    v_scope = tk.StringVar(tk_root, value="state")
+    t_enable = tk.Text(tk_root)
+    t_enable.insert("1.0", "has_war = yes")
+    t_mods = tk.Text(tk_root)
+    t_mods.insert("1.0", "stability_factor = my_var")
+    t_const = tk.Text(tk_root)
+    state = collect_dyn_mod_state(
+        {"mod_id": v_id, "scope": v_scope},
+        {"enable": t_enable, "mods": t_mods, "const": t_const},
+    )
+    assert state["mod_id"] == "TAG_dyn"
+    assert state["scope"] == "state"
+    assert state["enable"] == "has_war = yes"
+    assert state["mods_raw"] == "stability_factor = my_var"
+
+
+def test_collect_additional_income_state_with_real_widgets(tk_root):
+    vars_map = {
+        "idea_id": tk.StringVar(tk_root, value=" HKG_bonus "),
+        "country_tag": tk.StringVar(tk_root, value=" hkg "),
+        "variable_name": tk.StringVar(tk_root, value=" HKG_gain "),
+        "amount": tk.StringVar(tk_root, value=" 0.05 "),
+        "tooltip_key": tk.StringVar(tk_root, value=" HKG_TT "),
+        "spirit_name": tk.StringVar(tk_root, value=" Free Trade "),
+        "mode": tk.StringVar(tk_root, value="also_spirit"),
+        "formula_type": tk.StringVar(tk_root, value="gdp_pct"),
+    }
+    state = collect_additional_income_state(vars_map)
+    assert state["idea_id"] == "HKG_bonus"
+    assert state["country_tag"] == "HKG"
+    assert state["variable_name"] == "HKG_gain"
+    assert state["mode"] == "also_spirit"
+    assert state["formula_type"] == "gdp_pct"


### PR DESCRIPTION
Closes #62

**What**
- Pulls the Tk widget reads out of the five wizard closures into module-level `collect_*_state` helpers that take duck-typed `.get()` objects and return plain dicts/kwargs for the generators:
  - `decision.collect_decision_state(evars, dec=None)` — unifies `targeted`/`cost_type` resolution (the two sites at `decision.py:4234/4250` previously disagreed on fallback; now single source)
  - `national_spirit.collect_national_spirit_state(svars, text_widgets, modifiers)` (17 kwargs)
  - `dyn_mod.collect_dyn_mod_state(svars, text_widgets)` (8 args, 3 Text reads)
  - `additional_income.collect_additional_income_state(svars)` (10 vars, `country_tag` upper-cased, stripped)
  - `event.collect_event_state(events)` (thin snapshot pass-through, lowest risk)
- Wires each wizard's `_build_output`/`_gen_*` closure to delegate through the helper so the generator seam is pinned.
- Adds `tests/test_wizard_collectors.py` (headless, 18 tests with fake vars/texts) and `tests/test_wizard_dialog_smoke.py` (5 Tk smoke tests via `tk_root`, proving the helpers are wired to real `StringVar`/`Text`).

**Why**
`hoi4cm.wizards._generators` is at 99%/95% floor but the closures that feed it sat at 1–2%. A rename of an `_evars` key or drift in fallback (e.g. `decision.py` rendering every decision as untargeted with pp cost) slipped past all tests and shipped wrong script into a mod file. The new helpers are the single definition of that mapping; CI has a display (Xvfb) so the smoke suite also runs there.

**How**
- Helpers use duck typing (`hasattr(.get)`) so fakes work headlessly and real Tk widgets work unchanged; `_text_get` tries `get("1.0","end")` then `get()` to handle both shapes.
- No behaviour change: the generators still receive the same values (decision drift fixed to the file-level default `"none"`/`"pp"` when no `dec` fallback exists, which matches the intended wizard default).
- All 895 tests pass; `ruff`, `black`, `mypy`, `pylint` clean via pre-commit.