### PR TITLE
Rebuild Validate Tree as real testable validator

### DIFF
--- a/hoi4_content_maker.py
+++ b/hoi4_content_maker.py
@@ -810,9 +810,7 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
         try:
             sprites = self._validation_sprites()
             loc_keys = self._validation_loc_keys()
-            issues = validate_document(
-                self.focuses, sprites=sprites, loc_keys=loc_keys
-            )
+            issues = validate_document(self.focuses, sprites=sprites, loc_keys=loc_keys)
         except Exception:
             return
         self._validation_issues = issues
@@ -5707,10 +5705,20 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
         for iid in tree.get_children():
             tree.delete(iid)
         for idx, it in enumerate(shown):
-            sev_icon = "🔴" if it.severity == "error" else "🟡" if it.severity == "warning" else "🔵"
+            sev_icon = (
+                "🔴"
+                if it.severity == "error"
+                else "🟡"
+                if it.severity == "warning"
+                else "🔵"
+            )
             focus_txt = it.focus_name or "—"
             tree.insert(
-                "", "end", iid=str(idx), values=(sev_icon, focus_txt, it.message, it.code), tags=(str(idx),)
+                "",
+                "end",
+                iid=str(idx),
+                values=(sev_icon, focus_txt, it.message, it.code),
+                tags=(str(idx),),
             )
         # store mapping for click handler
         win._val_shown = shown  # type: ignore[attr-defined]
@@ -5746,32 +5754,99 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
         win.protocol("WM_DELETE_WINDOW", _on_close)
         hdr = tk.Frame(win, bg="#080c12")
         hdr.pack(fill="x")
-        hdr_lbl = tk.Label(hdr, text="", bg="#080c12", fg="#fbbf24", font=("Helvetica", 11, "bold"), pady=8)
+        hdr_lbl = tk.Label(
+            hdr,
+            text="",
+            bg="#080c12",
+            fg="#fbbf24",
+            font=("Helvetica", 11, "bold"),
+            pady=8,
+        )
         hdr_lbl.pack(side="left", padx=8)
         win._val_hdr_lbl = hdr_lbl  # type: ignore[attr-defined]
-        tk.Button(hdr, text="✕", command=_on_close, bg="#080c12", fg=TEXT_DIM, relief="flat", cursor="hand2", padx=10).pack(side="right")
+        tk.Button(
+            hdr,
+            text="✕",
+            command=_on_close,
+            bg="#080c12",
+            fg=TEXT_DIM,
+            relief="flat",
+            cursor="hand2",
+            padx=10,
+        ).pack(side="right")
         tk.Frame(win, bg=BORDER_G, height=1).pack(fill="x")
         # filter row
         filt_var = tk.StringVar(value="all")
         win._val_filter_var = filt_var  # type: ignore[attr-defined]
         filt_row = tk.Frame(win, bg=BG_DARK)
         filt_row.pack(fill="x", padx=8, pady=6)
-        tk.Label(filt_row, text=tr("validation.filter", "Filter:"), bg=BG_DARK, fg=TEXT_DIM, font=("Helvetica", 9)).pack(side="left")
-        for val, label in (("all", tr("validation.filter_all", "All")), ("error", tr("validation.filter_errors", "Errors")), ("warning", tr("validation.filter_warnings", "Warnings"))):
-            tk.Radiobutton(filt_row, text=label, variable=filt_var, value=val, bg=BG_DARK, fg=TEXT, selectcolor="#1e293b", activebackground=BG_DARK, command=lambda: self._refresh_validation_dialog(win)).pack(side="left", padx=6)
+        tk.Label(
+            filt_row,
+            text=tr("validation.filter", "Filter:"),
+            bg=BG_DARK,
+            fg=TEXT_DIM,
+            font=("Helvetica", 9),
+        ).pack(side="left")
+        for val, label in (
+            ("all", tr("validation.filter_all", "All")),
+            ("error", tr("validation.filter_errors", "Errors")),
+            ("warning", tr("validation.filter_warnings", "Warnings")),
+        ):
+            tk.Radiobutton(
+                filt_row,
+                text=label,
+                variable=filt_var,
+                value=val,
+                bg=BG_DARK,
+                fg=TEXT,
+                selectcolor="#1e293b",
+                activebackground=BG_DARK,
+                command=lambda: self._refresh_validation_dialog(win),
+            ).pack(side="left", padx=6)
+
         def _copy_filtered():
             shown = getattr(win, "_val_shown", [])
             if not shown:
                 return
-            text = "\n".join(f"{it.severity.upper()}: {it.message} [{it.code}]" for it in shown)
+            text = "\n".join(
+                f"{it.severity.upper()}: {it.message} [{it.code}]" for it in shown
+            )
             try:
                 self.clipboard_clear()
                 self.clipboard_append(text)
-                self._hint(tr("validation.copied", "Copied {count} issues", count=len(shown)))
+                self._hint(
+                    tr("validation.copied", "Copied {count} issues", count=len(shown))
+                )
             except Exception:
                 pass
-        tk.Button(filt_row, text=tr("validation.copy", "Copy"), command=_copy_filtered, bg=BG_CARD, fg=TEXT, relief="flat", padx=10, pady=2, cursor="hand2", font=("Helvetica", 9)).pack(side="right", padx=4)
-        tk.Button(filt_row, text=tr("validation.revalidate", "Re-validate"), command=lambda: (self._run_validation(), self._refresh_validation_dialog(win)), bg=BG_CARD, fg=TEXT, relief="flat", padx=10, pady=2, cursor="hand2", font=("Helvetica", 9)).pack(side="right")
+
+        tk.Button(
+            filt_row,
+            text=tr("validation.copy", "Copy"),
+            command=_copy_filtered,
+            bg=BG_CARD,
+            fg=TEXT,
+            relief="flat",
+            padx=10,
+            pady=2,
+            cursor="hand2",
+            font=("Helvetica", 9),
+        ).pack(side="right", padx=4)
+        tk.Button(
+            filt_row,
+            text=tr("validation.revalidate", "Re-validate"),
+            command=lambda: (
+                self._run_validation(),
+                self._refresh_validation_dialog(win),
+            ),
+            bg=BG_CARD,
+            fg=TEXT,
+            relief="flat",
+            padx=10,
+            pady=2,
+            cursor="hand2",
+            font=("Helvetica", 9),
+        ).pack(side="right")
         frm = tk.Frame(win, bg=BG_DARK)
         frm.pack(fill="both", expand=True, padx=8, pady=(0, 8))
         # Treeview with scrollbar
@@ -5780,12 +5855,31 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
         style = ttk.Style()
         try:
             style.theme_use("clam")
-            style.configure("Val.Treeview", background="#050810", foreground=TEXT, fieldbackground="#050810", borderwidth=0, highlightthickness=0, rowheight=22)
-            style.configure("Val.Treeview.Heading", background="#1e293b", foreground=TEXT, relief="flat")
+            style.configure(
+                "Val.Treeview",
+                background="#050810",
+                foreground=TEXT,
+                fieldbackground="#050810",
+                borderwidth=0,
+                highlightthickness=0,
+                rowheight=22,
+            )
+            style.configure(
+                "Val.Treeview.Heading",
+                background="#1e293b",
+                foreground=TEXT,
+                relief="flat",
+            )
             style.map("Val.Treeview", background=[("selected", "#1e2d4a")])
         except Exception:
             pass
-        tree = ttk.Treeview(frm, columns=("sev", "focus", "message", "code"), show="headings", style="Val.Treeview", yscrollcommand=sb.set)
+        tree = ttk.Treeview(
+            frm,
+            columns=("sev", "focus", "message", "code"),
+            show="headings",
+            style="Val.Treeview",
+            yscrollcommand=sb.set,
+        )
         win._val_tree = tree  # type: ignore[attr-defined]
         tree.heading("sev", text="")
         tree.heading("focus", text=tr("validation.col_focus", "Focus"))
@@ -5797,8 +5891,19 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
         tree.column("code", width=120, minwidth=80, anchor="w")
         sb.config(command=tree.yview)
         tree.pack(fill="both", expand=True)
-        hint = tk.Label(win, text=tr("validation.hint", "Click a row to select the focus on the canvas. Double-click to center."), bg=BG_DARK, fg=TEXT_DIM, font=("Helvetica", 8), anchor="w")
+        hint = tk.Label(
+            win,
+            text=tr(
+                "validation.hint",
+                "Click a row to select the focus on the canvas. Double-click to center.",
+            ),
+            bg=BG_DARK,
+            fg=TEXT_DIM,
+            font=("Helvetica", 8),
+            anchor="w",
+        )
         hint.pack(fill="x", padx=8, pady=(0, 6))
+
         def _select_focus(event=None):
             sel = tree.selection()
             if not sel:
@@ -5813,6 +5918,7 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
                 if it.focus_id is not None and it.focus_id in self.focuses:
                     self._select(self.focuses[it.focus_id])
                     self._hint(f"Selected {it.focus_name}: {it.code}")
+
         def _center_focus(event=None):
             sel = tree.selection()
             if not sel:
@@ -5826,11 +5932,24 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
                 it = shown[idx]
                 if it.focus_id is not None and it.focus_id in self.focuses:
                     self._center_on_focus(it.focus_id)
+
         tree.bind("<<TreeviewSelect>>", _select_focus)
         tree.bind("<Double-Button-1>", _center_focus)
         self._refresh_validation_dialog(win)
         if not issues:
-            tree.insert("", "end", values=("", "", tr("validation.all_prereqs_valid", "All prerequisite chains are valid."), ""))
+            tree.insert(
+                "",
+                "end",
+                values=(
+                    "",
+                    "",
+                    tr(
+                        "validation.all_prereqs_valid",
+                        "All prerequisite chains are valid.",
+                    ),
+                    "",
+                ),
+            )
 
     def _export(
         self, *, focuses_in_tree=None, focus_name_lookup=None, show_dialog=True

--- a/hoi4_content_maker.py
+++ b/hoi4_content_maker.py
@@ -781,7 +781,9 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
     def _validation_sprites(self):
         if MOD.loaded and getattr(MOD, "sprites", None):
             try:
-                return dict(MOD.sprites)
+                # return mapping view directly; validate_document only does `in` checks
+                # caller must not mutate
+                return MOD.sprites
             except Exception:
                 return None
         return None
@@ -813,11 +815,24 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
             issues = validate_document(self.focuses, sprites=sprites, loc_keys=loc_keys)
         except Exception:
             return
-        self._validation_issues = issues
         try:
-            self._validation_worst = worst_severity_per_focus(issues)
+            worst = worst_severity_per_focus(issues)
         except Exception:
-            self._validation_worst = {}
+            worst = {}
+        prev_issues = getattr(self, "_validation_issues", None)
+        prev_worst = getattr(self, "_validation_worst", None)
+        changed = issues != prev_issues or worst != prev_worst
+        self._validation_issues = issues
+        self._validation_worst = worst
+        if not changed:
+            # still refresh dialog if open but avoid redraw churn
+            win = getattr(self, "_validation_win", None)
+            if win is not None and win.winfo_exists():
+                try:
+                    self._refresh_validation_dialog(win)
+                except Exception:
+                    pass
+            return
         # refresh UI surfaces that depend on validation
         try:
             self._redraw()
@@ -850,18 +865,39 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
             pass
 
     def _redraw(self, *args, **kwargs):
-        super()._redraw(*args, **kwargs)  # type: ignore[misc]
+        # only validation-relevant redraws should re-queue validation
+        channels = kwargs.get("channels", args[0] if args else None)
+        should_schedule = True
         try:
-            self._schedule_validation()
+            from hoi4cm.ui.canvas_scheduler import RedrawChannel
+
+            if channels is not None:
+                should_schedule = bool(channels & RedrawChannel.SCENE)
         except Exception:
-            pass
+            should_schedule = True
+        super()._redraw(*args, **kwargs)  # type: ignore[misc]
+        if should_schedule:
+            try:
+                self._schedule_validation()
+            except Exception:
+                pass
 
     def _redraw_now(self, *args, **kwargs):
-        super()._redraw_now(*args, **kwargs)  # type: ignore[misc]
+        channels = kwargs.get("channels", args[0] if args else None)
+        should_schedule = True
         try:
-            self._schedule_validation()
+            from hoi4cm.ui.canvas_scheduler import RedrawChannel
+
+            if channels is not None:
+                should_schedule = bool(channels & RedrawChannel.SCENE)
         except Exception:
-            pass
+            should_schedule = True
+        super()._redraw_now(*args, **kwargs)  # type: ignore[misc]
+        if should_schedule:
+            try:
+                self._schedule_validation()
+            except Exception:
+                pass
 
     def _refresh_tree_meta_panel(self):
         """Refresh the shared_focus / joint_focus read-only display in the sidebar."""
@@ -5369,11 +5405,9 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
         if not hasattr(self, "_focus_list"):
             return
         worst = getattr(self, "_validation_worst", {})
-        # Rebuild the item tuple only when the document structure changes;
-        # search keystrokes just re-filter the cached tuple.
-        self._focus_list_items = self._focus_list_cache.get(
-            self.focuses,
-            lambda: (
+
+        def _build_items():
+            return (
                 FocusListItem(
                     f.id,
                     f.name,
@@ -5384,10 +5418,13 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
                     validation_severity=worst.get(f.id),
                 )
                 for f in self.focuses.values()
-            ),
-        )
+            )
+
+        # Rebuild the item tuple only when the document structure changes;
+        # search keystrokes just re-filter the cached tuple.
+        self._focus_list_items = self._focus_list_cache.get(self.focuses, _build_items)
         # patch cached items if validation changed without document revision bump
-        if worst and self._focus_list_items:
+        if self._focus_list_items:
             needs_patch = any(
                 item.validation_severity != worst.get(item.key)
                 for item in self._focus_list_items
@@ -5395,21 +5432,7 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
             if needs_patch:
                 self._focus_list_cache.invalidate()
                 self._focus_list_items = self._focus_list_cache.get(
-                    self.focuses,
-                    lambda: (
-                        FocusListItem(
-                            f.id,
-                            f.name,
-                            has_effects=bool(f.effects),
-                            has_broken_prerequisite=any(
-                                pid not in self.focuses
-                                for group in f.prereqs
-                                for pid in group
-                            ),
-                            validation_severity=worst.get(f.id),
-                        )
-                        for f in self.focuses.values()
-                    ),
+                    self.focuses, _build_items
                 )
         query = self._lp_search_var.get() if hasattr(self, "_lp_search_var") else ""
         placeholder = tr("common.search_placeholder", "Search...")

--- a/hoi4_content_maker.py
+++ b/hoi4_content_maker.py
@@ -96,6 +96,11 @@ from hoi4cm.core import (
     tr,
 )
 from hoi4cm.editor import read_project, write_project
+from hoi4cm.focus_tree.validate import (
+    collect_loc_keys_from_text,
+    validate_document,
+    worst_severity_per_focus,
+)
 from hoi4cm.mod import MOD, detect_loc_file
 from hoi4cm.mod.workspace_files import WorkspaceFiles
 from hoi4cm.models import (
@@ -211,7 +216,7 @@ def _apply_tk_dpi_scaling(root):
         log.warning(f"Tk DPI scaling setup skipped: {e}")
 
 
-class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):
+class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[misc]
     CANVAS_MIN_SIZE = 10
     CANVAS_EXPAND_STEP = 5
 
@@ -257,9 +262,14 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):
         self._grid_item = None
         self._grid_key = None
         self._sash_x = 0
+        self._validation_issues = []
+        self._validation_worst = {}
+        self._validation_job = None
+        self._validation_win = None
         self.protocol("WM_DELETE_WINDOW", self._on_app_close)
         self._build_ui()
         self._redraw()
+        self._schedule_validation()
 
     def _on_app_close(self):
         if not self._lifecycle.begin_close():
@@ -766,6 +776,94 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):
 
     def _hint(self, t):
         self._hint_lbl.config(text=t)
+
+    # ── VALIDATION (background + dialog) ───────────────────────────
+    def _validation_sprites(self):
+        if MOD.loaded and getattr(MOD, "sprites", None):
+            try:
+                return dict(MOD.sprites)
+            except Exception:
+                return None
+        return None
+
+    def _validation_loc_keys(self):
+        path = getattr(MOD, "edit_loc_file", "")
+        if path and os.path.isfile(path):
+            try:
+                text = read_file(path)
+                keys = collect_loc_keys_from_text(text)
+                return keys
+            except Exception:
+                return None
+        return None
+
+    def _schedule_validation(self):
+        if getattr(self, "_validation_job", None):
+            return
+        try:
+            self._validation_job = self.after(150, self._run_validation)
+        except Exception:
+            self._run_validation()
+
+    def _run_validation(self):
+        self._validation_job = None
+        try:
+            sprites = self._validation_sprites()
+            loc_keys = self._validation_loc_keys()
+            issues = validate_document(
+                self.focuses, sprites=sprites, loc_keys=loc_keys
+            )
+        except Exception:
+            return
+        self._validation_issues = issues
+        try:
+            self._validation_worst = worst_severity_per_focus(issues)
+        except Exception:
+            self._validation_worst = {}
+        # refresh UI surfaces that depend on validation
+        try:
+            self._redraw()
+        except Exception:
+            pass
+        try:
+            self._invalidate_focus_list_structure()
+        except Exception:
+            pass
+        # if validation dialog is open, refresh its contents
+        win = getattr(self, "_validation_win", None)
+        if win is not None and win.winfo_exists():
+            try:
+                self._refresh_validation_dialog(win)
+            except Exception:
+                pass
+
+    def _center_on_focus(self, fid):
+        f = self.focuses.get(fid)
+        if f is None:
+            return
+        try:
+            cw = self.cv.winfo_width() or 800
+            ch = self.cv.winfo_height() or 600
+            self.offset[0] = cw / 2 - f.x * 96 * self.zoom
+            self.offset[1] = ch / 2 - f.y * 130 * self.zoom
+            self._redraw()
+            self._select(f)
+        except Exception:
+            pass
+
+    def _redraw(self, *args, **kwargs):
+        super()._redraw(*args, **kwargs)  # type: ignore[misc]
+        try:
+            self._schedule_validation()
+        except Exception:
+            pass
+
+    def _redraw_now(self, *args, **kwargs):
+        super()._redraw_now(*args, **kwargs)  # type: ignore[misc]
+        try:
+            self._schedule_validation()
+        except Exception:
+            pass
 
     def _refresh_tree_meta_panel(self):
         """Refresh the shared_focus / joint_focus read-only display in the sidebar."""
@@ -5272,6 +5370,7 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):
         self._lp_search_job = None
         if not hasattr(self, "_focus_list"):
             return
+        worst = getattr(self, "_validation_worst", {})
         # Rebuild the item tuple only when the document structure changes;
         # search keystrokes just re-filter the cached tuple.
         self._focus_list_items = self._focus_list_cache.get(
@@ -5284,10 +5383,36 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):
                     has_broken_prerequisite=any(
                         pid not in self.focuses for group in f.prereqs for pid in group
                     ),
+                    validation_severity=worst.get(f.id),
                 )
                 for f in self.focuses.values()
             ),
         )
+        # patch cached items if validation changed without document revision bump
+        if worst and self._focus_list_items:
+            needs_patch = any(
+                item.validation_severity != worst.get(item.key)
+                for item in self._focus_list_items
+            )
+            if needs_patch:
+                self._focus_list_cache.invalidate()
+                self._focus_list_items = self._focus_list_cache.get(
+                    self.focuses,
+                    lambda: (
+                        FocusListItem(
+                            f.id,
+                            f.name,
+                            has_effects=bool(f.effects),
+                            has_broken_prerequisite=any(
+                                pid not in self.focuses
+                                for group in f.prereqs
+                                for pid in group
+                            ),
+                            validation_severity=worst.get(f.id),
+                        )
+                        for f in self.focuses.values()
+                    ),
+                )
         query = self._lp_search_var.get() if hasattr(self, "_lp_search_var") else ""
         placeholder = tr("common.search_placeholder", "Search...")
         selected_id = self.selected.id if self.selected else None
@@ -5546,111 +5671,166 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):
         self._redraw()
 
     # ─────────────────── VALIDATE TREE ───────────────────────────
-    def _validate_tree(self):
-        """Check tree for common errors and report them."""
-        issues = []
-        for f in self.focuses.values():
-            # Broken prereqs (prereqs store Focus IDs = ints)
-            for grp in f.prereqs:
-                for pid in grp:
-                    if pid not in self.focuses:
-                        issues.append(f"[{f.name}]  broken prereq → id:{pid}")
-            # Broken mutex (mutex stores Focus IDs = ints)
-            for mid in f.mutex:
-                if mid not in self.focuses:
-                    issues.append(f"[{f.name}]  broken mutex → id:{mid}")
-            # No effects
-            if not f.effects:
-                issues.append(f"[{f.name}]  no effects in completion_reward")
-            # Missing GFX
-            gfx = getattr(f, "gfx", "")
-            if not gfx or gfx == "GFX_goal_generic_political_pressure":
-                issues.append(f"[{f.name}]  using default/missing icon GFX")
+    def _refresh_validation_dialog(self, win):
+        filt = getattr(win, "_val_filter_var", None)
+        tree = getattr(win, "_val_tree", None)
+        hdr_lbl = getattr(win, "_val_hdr_lbl", None)
+        if filt is None or tree is None:
+            return
+        issues = getattr(self, "_validation_issues", [])
+        mode = filt.get()
+        if mode == "error":
+            shown = [it for it in issues if it.severity == "error"]
+        elif mode == "warning":
+            shown = [it for it in issues if it.severity == "warning"]
+        else:
+            shown = list(issues)
+        if hdr_lbl is not None:
+            err = sum(1 for it in issues if it.severity == "error")
+            warn = sum(1 for it in issues if it.severity == "warning")
+            if not issues:
+                hdr_lbl.config(
+                    text=tr("validation.clean", "  Tree looks clean!"),
+                    fg="#22c55e",
+                )
+            else:
+                hdr_lbl.config(
+                    text=tr(
+                        "validation.issues_found",
+                        "  {count} issues — {err} errors, {warn} warnings",
+                        count=len(issues),
+                        err=err,
+                        warn=warn,
+                    ),
+                    fg="#fbbf24" if err else "#f59e0b",
+                )
+        for iid in tree.get_children():
+            tree.delete(iid)
+        for idx, it in enumerate(shown):
+            sev_icon = "🔴" if it.severity == "error" else "🟡" if it.severity == "warning" else "🔵"
+            focus_txt = it.focus_name or "—"
+            tree.insert(
+                "", "end", iid=str(idx), values=(sev_icon, focus_txt, it.message, it.code), tags=(str(idx),)
+            )
+        # store mapping for click handler
+        win._val_shown = shown  # type: ignore[attr-defined]
 
+    def _validate_tree(self):
+        """Validate tree via pure validator and show filterable dialog."""
+        from tkinter import ttk
+
+        try:
+            sprites = self._validation_sprites()
+            loc_keys = self._validation_loc_keys()
+            issues = validate_document(self.focuses, sprites=sprites, loc_keys=loc_keys)
+            self._validation_issues = issues
+            self._validation_worst = worst_severity_per_focus(issues)
+            self._redraw()
+            self._invalidate_focus_list_structure()
+        except Exception:
+            issues = getattr(self, "_validation_issues", [])
         win = tk.Toplevel(self)
         win.title(tr("validation.title", "Tree Validation"))
         win.configure(bg=BG_DARK)
-        win.geometry("640x440")
+        win.geometry("820x460")
         win.resizable(True, True)
+        self._validation_win = win
 
+        def _on_close():
+            self._validation_win = None
+            try:
+                win.destroy()
+            except Exception:
+                pass
+
+        win.protocol("WM_DELETE_WINDOW", _on_close)
         hdr = tk.Frame(win, bg="#080c12")
         hdr.pack(fill="x")
-        if issues:
-            tk.Label(
-                hdr,
-                text=tr(
-                    "validation.issues_found",
-                    "  {count} issues found",
-                    count=len(issues),
-                ),
-                bg="#080c12",
-                fg="#fbbf24",
-                font=("Helvetica", 11, "bold"),
-                pady=8,
-            ).pack(side="left", padx=8)
-        else:
-            tk.Label(
-                hdr,
-                text=tr("validation.clean", "  Tree looks clean!"),
-                bg="#080c12",
-                fg="#22c55e",
-                font=("Helvetica", 11, "bold"),
-                pady=8,
-            ).pack(side="left", padx=8)
-        tk.Button(
-            hdr,
-            text="✕",
-            command=win.destroy,
-            bg="#080c12",
-            fg=TEXT_DIM,
-            relief="flat",
-            cursor="hand2",
-            padx=10,
-        ).pack(side="right")
+        hdr_lbl = tk.Label(hdr, text="", bg="#080c12", fg="#fbbf24", font=("Helvetica", 11, "bold"), pady=8)
+        hdr_lbl.pack(side="left", padx=8)
+        win._val_hdr_lbl = hdr_lbl  # type: ignore[attr-defined]
+        tk.Button(hdr, text="✕", command=_on_close, bg="#080c12", fg=TEXT_DIM, relief="flat", cursor="hand2", padx=10).pack(side="right")
         tk.Frame(win, bg=BORDER_G, height=1).pack(fill="x")
-
+        # filter row
+        filt_var = tk.StringVar(value="all")
+        win._val_filter_var = filt_var  # type: ignore[attr-defined]
+        filt_row = tk.Frame(win, bg=BG_DARK)
+        filt_row.pack(fill="x", padx=8, pady=6)
+        tk.Label(filt_row, text=tr("validation.filter", "Filter:"), bg=BG_DARK, fg=TEXT_DIM, font=("Helvetica", 9)).pack(side="left")
+        for val, label in (("all", tr("validation.filter_all", "All")), ("error", tr("validation.filter_errors", "Errors")), ("warning", tr("validation.filter_warnings", "Warnings"))):
+            tk.Radiobutton(filt_row, text=label, variable=filt_var, value=val, bg=BG_DARK, fg=TEXT, selectcolor="#1e293b", activebackground=BG_DARK, command=lambda: self._refresh_validation_dialog(win)).pack(side="left", padx=6)
+        def _copy_filtered():
+            shown = getattr(win, "_val_shown", [])
+            if not shown:
+                return
+            text = "\n".join(f"{it.severity.upper()}: {it.message} [{it.code}]" for it in shown)
+            try:
+                self.clipboard_clear()
+                self.clipboard_append(text)
+                self._hint(tr("validation.copied", "Copied {count} issues", count=len(shown)))
+            except Exception:
+                pass
+        tk.Button(filt_row, text=tr("validation.copy", "Copy"), command=_copy_filtered, bg=BG_CARD, fg=TEXT, relief="flat", padx=10, pady=2, cursor="hand2", font=("Helvetica", 9)).pack(side="right", padx=4)
+        tk.Button(filt_row, text=tr("validation.revalidate", "Re-validate"), command=lambda: (self._run_validation(), self._refresh_validation_dialog(win)), bg=BG_CARD, fg=TEXT, relief="flat", padx=10, pady=2, cursor="hand2", font=("Helvetica", 9)).pack(side="right")
         frm = tk.Frame(win, bg=BG_DARK)
-        frm.pack(fill="both", expand=True)
+        frm.pack(fill="both", expand=True, padx=8, pady=(0, 8))
+        # Treeview with scrollbar
         sb = tk.Scrollbar(frm)
         sb.pack(side="right", fill="y")
-        txt = tk.Text(
-            frm,
-            bg="#050810",
-            fg=TEXT,
-            font=("Courier", 10),
-            relief="flat",
-            yscrollcommand=sb.set,
-            wrap="word",
-            highlightthickness=0,
-        )
-        sb.config(command=txt.yview)
-        txt.pack(fill="both", expand=True, padx=8, pady=8)
-        if issues:
-            for issue in issues:
-                if "broken" in issue:
-                    txt.insert("end", "  🔴  " + issue + "\n")
-                elif "no effects" in issue:
-                    txt.insert("end", "  🟡  " + issue + "\n")
-                else:
-                    txt.insert("end", "  🔵  " + issue + "\n")
-        else:
-            txt.insert(
-                "end",
-                "\n"
-                + tr(
-                    "validation.all_prereqs_valid",
-                    "  All prerequisite chains are valid.",
-                )
-                + "\n"
-                + tr("validation.all_mutex_valid", "  All mutex references resolve.")
-                + "\n"
-                + tr(
-                    "validation.all_effects_present",
-                    "  All focuses have completion_reward effects.",
-                )
-                + "\n",
-            )
-        txt.config(state="disabled")
+        style = ttk.Style()
+        try:
+            style.theme_use("clam")
+            style.configure("Val.Treeview", background="#050810", foreground=TEXT, fieldbackground="#050810", borderwidth=0, highlightthickness=0, rowheight=22)
+            style.configure("Val.Treeview.Heading", background="#1e293b", foreground=TEXT, relief="flat")
+            style.map("Val.Treeview", background=[("selected", "#1e2d4a")])
+        except Exception:
+            pass
+        tree = ttk.Treeview(frm, columns=("sev", "focus", "message", "code"), show="headings", style="Val.Treeview", yscrollcommand=sb.set)
+        win._val_tree = tree  # type: ignore[attr-defined]
+        tree.heading("sev", text="")
+        tree.heading("focus", text=tr("validation.col_focus", "Focus"))
+        tree.heading("message", text=tr("validation.col_message", "Message"))
+        tree.heading("code", text=tr("validation.col_code", "Code"))
+        tree.column("sev", width=40, minwidth=30, stretch=False, anchor="center")
+        tree.column("focus", width=160, minwidth=100, anchor="w")
+        tree.column("message", width=420, minwidth=200, anchor="w")
+        tree.column("code", width=120, minwidth=80, anchor="w")
+        sb.config(command=tree.yview)
+        tree.pack(fill="both", expand=True)
+        hint = tk.Label(win, text=tr("validation.hint", "Click a row to select the focus on the canvas. Double-click to center."), bg=BG_DARK, fg=TEXT_DIM, font=("Helvetica", 8), anchor="w")
+        hint.pack(fill="x", padx=8, pady=(0, 6))
+        def _select_focus(event=None):
+            sel = tree.selection()
+            if not sel:
+                return
+            try:
+                idx = int(sel[0])
+            except Exception:
+                return
+            shown = getattr(win, "_val_shown", [])
+            if 0 <= idx < len(shown):
+                it = shown[idx]
+                if it.focus_id is not None and it.focus_id in self.focuses:
+                    self._select(self.focuses[it.focus_id])
+                    self._hint(f"Selected {it.focus_name}: {it.code}")
+        def _center_focus(event=None):
+            sel = tree.selection()
+            if not sel:
+                return
+            try:
+                idx = int(sel[0])
+            except Exception:
+                return
+            shown = getattr(win, "_val_shown", [])
+            if 0 <= idx < len(shown):
+                it = shown[idx]
+                if it.focus_id is not None and it.focus_id in self.focuses:
+                    self._center_on_focus(it.focus_id)
+        tree.bind("<<TreeviewSelect>>", _select_focus)
+        tree.bind("<Double-Button-1>", _center_focus)
+        self._refresh_validation_dialog(win)
+        if not issues:
+            tree.insert("", "end", values=("", "", tr("validation.all_prereqs_valid", "All prerequisite chains are valid."), ""))
 
     def _export(
         self, *, focuses_in_tree=None, focus_name_lookup=None, show_dialog=True

--- a/src/hoi4cm/focus_tree/__init__.py
+++ b/src/hoi4cm/focus_tree/__init__.py
@@ -28,6 +28,13 @@ from .operations import (
     group_focuses_by_tree,
 )
 from .parse import EmptyFocusTreeError, ParsedFocusTree, parse_focus_tree
+from .validate import (
+    Issue,
+    Severity,
+    collect_loc_keys_from_text,
+    validate_document,
+    worst_severity_per_focus,
+)
 
 __all__ = [
     "parse_focus_tree",
@@ -53,4 +60,9 @@ __all__ = [
     "parse_drawio_graph",
     "drawio_to_focus_data",
     "build_drawio_focuses",
+    "Issue",
+    "Severity",
+    "collect_loc_keys_from_text",
+    "validate_document",
+    "worst_severity_per_focus",
 ]

--- a/src/hoi4cm/focus_tree/validate.py
+++ b/src/hoi4cm/focus_tree/validate.py
@@ -1,0 +1,309 @@
+"""Pure validator for focus trees.
+
+Headless: no Tk, no MOD globals. The caller supplies sprites/loc sets.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Literal
+
+from hoi4cm.models import Focus
+
+Severity = Literal["error", "warning", "info"]
+DEFAULT_GFX = "GFX_goal_generic_political_pressure"
+_KEY_RE = re.compile(r"\s+(\S+?)(?::\d+)?\s*[=:]?\s*\"")
+
+SEVERITY_RANK = {"error": 0, "warning": 1, "info": 2}
+
+
+@dataclass(frozen=True)
+class Issue:
+    severity: Severity
+    code: str
+    focus_id: int | None
+    focus_name: str | None
+    message: str
+    field: str | None = None
+
+    def sort_key(self):
+        return (SEVERITY_RANK.get(self.severity, 99), self.focus_name or "", self.code)
+
+
+def _extract_loc_keys(text: str) -> set[str]:
+    keys: set[str] = set()
+    for line in text.splitlines():
+        m = _KEY_RE.match(line)
+        if m:
+            keys.add(m.group(1))
+    return keys
+
+
+def collect_loc_keys_from_text(text: str | None) -> set[str] | None:
+    if text is None:
+        return None
+    return _extract_loc_keys(text)
+
+
+def validate_document(
+    doc: Mapping[int, Focus],
+    *,
+    sprites: Mapping[str, str] | None = None,
+    loc_keys: set[str] | None = None,
+    include_default_icon_warning: bool = True,
+) -> list[Issue]:
+    """Validate a focus document.
+
+    doc: FocusDocument or plain mapping id->Focus.
+    sprites: MOD.sprites dict (gfx_name -> path) or None to skip GFX check.
+    loc_keys: set of localisation keys present in the .yml or None to skip.
+    """
+    issues: list[Issue] = []
+    if not doc:
+        return issues
+
+    id_set = set(doc.keys())
+    # name -> list of ids
+    name_to_ids: dict[str, list[int]] = defaultdict(list)
+    for fid, focus in doc.items():
+        name_to_ids[focus.name].append(fid)
+
+    # duplicate names (game IDs)
+    for name, ids in name_to_ids.items():
+        if len(ids) > 1:
+            issues.append(
+                Issue(
+                    "error",
+                    "duplicate_name",
+                    ids[0],
+                    name,
+                    (
+                        f"duplicate focus name '{name}' used by "
+                        f"{len(ids)} focuses (ids {sorted(ids)})"
+                    ),
+                    field="name",
+                )
+            )
+
+    # occupied positions
+    occupied: dict[tuple[int, int], set[int]] | None = getattr(
+        doc, "occupied_positions", None
+    )
+    if occupied is None:
+        occupied = defaultdict(set)
+        for fid, focus in doc.items():
+            occupied[(focus.x, focus.y)].add(fid)
+        occupied = dict(occupied)
+
+    for (x, y), occupants in occupied.items():
+        if len(occupants) > 1:
+            sorted_ids = sorted(occupants)
+            names = [doc[i].name for i in sorted_ids]
+            issues.append(
+                Issue(
+                    "error",
+                    "position_collision",
+                    sorted_ids[0],
+                    doc[sorted_ids[0]].name,
+                    (
+                        f"position collision at x={x} y={y}: "
+                        f"{', '.join(names)} (ids {sorted_ids}) share the same cell"
+                    ),
+                    field="x",
+                )
+            )
+
+    # name lookup for relative_position_id
+    name_to_one_id = {name: ids[0] for name, ids in name_to_ids.items()}
+
+    for fid, focus in doc.items():
+        # broken prereqs
+        for grp_idx, grp in enumerate(getattr(focus, "prereqs", [])):
+            for pid in grp:
+                if pid not in id_set:
+                    issues.append(
+                        Issue(
+                            "error",
+                            "broken_prereq",
+                            fid,
+                            focus.name,
+                            (
+                                f"[{focus.name}] broken prereq "
+                                f"→ id:{pid} (group {grp_idx})"
+                            ),
+                            field="prereqs",
+                        )
+                    )
+        # broken mutex
+        for mid in getattr(focus, "mutex", []):
+            if mid not in id_set:
+                issues.append(
+                    Issue(
+                        "error",
+                        "broken_mutex",
+                        fid,
+                        focus.name,
+                        f"[{focus.name}] broken mutex → id:{mid}",
+                        field="mutex",
+                    )
+                )
+        # relative_position_id
+        rel = getattr(focus, "relative_position_id", None)
+        if rel:
+            if rel not in name_to_one_id:
+                issues.append(
+                    Issue(
+                        "error",
+                        "relative_position_unresolved",
+                        fid,
+                        focus.name,
+                        (
+                            f"[{focus.name}] relative_position_id "
+                            f"'{rel}' does not match any focus"
+                        ),
+                        field="relative_position_id",
+                    )
+                )
+        # empty effects
+        if not getattr(focus, "effects", []):
+            issues.append(
+                Issue(
+                    "warning",
+                    "empty_effects",
+                    fid,
+                    focus.name,
+                    f"[{focus.name}] no effects in completion_reward",
+                    field="effects",
+                )
+            )
+        # default/missing icon
+        gfx = getattr(focus, "gfx", "")
+        if include_default_icon_warning and (not gfx or gfx == DEFAULT_GFX):
+            issues.append(
+                Issue(
+                    "warning",
+                    "default_icon",
+                    fid,
+                    focus.name,
+                    f"[{focus.name}] using default/missing icon GFX",
+                    field="gfx",
+                )
+            )
+        # GFX not in sprites
+        if sprites is not None and gfx and gfx not in sprites:
+            # don't double-report default as missing if already warned; still
+            # worth surfacing for custom GFX. If include_default_icon_warning,
+            # default already emitted above; skip duplicate missing for default.
+            if gfx != DEFAULT_GFX or not include_default_icon_warning:
+                issues.append(
+                    Issue(
+                        "warning",
+                        "gfx_missing",
+                        fid,
+                        focus.name,
+                        f"[{focus.name}] icon '{gfx}' not found in loaded sprites",
+                        field="gfx",
+                    )
+                )
+        # missing loc keys
+        if loc_keys is not None:
+            if focus.name not in loc_keys:
+                issues.append(
+                    Issue(
+                        "warning",
+                        "loc_missing",
+                        fid,
+                        focus.name,
+                        f"[{focus.name}] missing localisation key '{focus.name}'",
+                        field="name",
+                    )
+                )
+            desc_key = f"{focus.name}_desc"
+            if desc_key not in loc_keys:
+                issues.append(
+                    Issue(
+                        "warning",
+                        "loc_missing_desc",
+                        fid,
+                        focus.name,
+                        f"[{focus.name}] missing localisation key '{desc_key}'",
+                        field="desc",
+                    )
+                )
+
+    # prerequisite cycles
+    # build adjacency: child -> parents that exist
+    adjacency: dict[int, list[int]] = {}
+    for fid, focus in doc.items():
+        parents: list[int] = []
+        for grp in getattr(focus, "prereqs", []):
+            for pid in grp:
+                if pid in id_set:
+                    parents.append(pid)
+        adjacency[fid] = parents
+
+    # DFS cycle detection
+    visited: dict[int, int] = {}  # 0 unvisited, 1 visiting, 2 done
+    stack: list[int] = []
+    cycles_reported: set[tuple[int, ...]] = set()
+
+    def dfs(node: int):
+        visited[node] = 1
+        stack.append(node)
+        for parent in adjacency.get(node, []):
+            state = visited.get(parent, 0)
+            if state == 1:
+                # found cycle
+                idx = stack.index(parent)
+                cycle = tuple(stack[idx:] + [parent])
+                # normalize to sorted tuple for dedup
+                key = tuple(sorted(cycle))
+                if key not in cycles_reported:
+                    cycles_reported.add(key)
+                    names = " → ".join(doc[c].name for c in stack[idx:] + [parent])
+                    issues.append(
+                        Issue(
+                            "error",
+                            "prereq_cycle",
+                            node,
+                            doc[node].name,
+                            f"prerequisite cycle: {names}",
+                            field="prereqs",
+                        )
+                    )
+            elif state == 0:
+                dfs(parent)
+        stack.pop()
+        visited[node] = 2
+
+    for nid in list(id_set):
+        if visited.get(nid, 0) == 0:
+            dfs(nid)
+
+    issues.sort(key=lambda issue: issue.sort_key())
+    return issues
+
+
+def worst_severity_per_focus(issues: list[Issue]) -> dict[int, Severity]:
+    """Return worst severity per focus_id among issues that have a focus_id."""
+    worst: dict[int, Severity] = {}
+    for issue in issues:
+        if issue.focus_id is None:
+            continue
+        cur = worst.get(issue.focus_id)
+        if cur is None or SEVERITY_RANK[issue.severity] < SEVERITY_RANK[cur]:
+            worst[issue.focus_id] = issue.severity
+    return worst
+
+
+__all__ = [
+    "DEFAULT_GFX",
+    "Issue",
+    "Severity",
+    "collect_loc_keys_from_text",
+    "validate_document",
+    "worst_severity_per_focus",
+]

--- a/src/hoi4cm/ui/canvas.py
+++ b/src/hoi4cm/ui/canvas.py
@@ -1304,7 +1304,7 @@ class CanvasMixin:
         offs = getattr(f, "offsets", [])
         if offs:
             off_strs = [
-                f"x={o['x']} y={o['y']} [{o.get('trigger','').strip()[:30]}]"
+                f"x={o['x']} y={o['y']} [{o.get('trigger', '').strip()[:30]}]"
                 for o in offs
             ]
             base += f"  •  Offsets: {'; '.join(off_strs)}"

--- a/src/hoi4cm/ui/canvas.py
+++ b/src/hoi4cm/ui/canvas.py
@@ -8,6 +8,7 @@ lines out of ``hoi4_content_maker.py``.
 
 import math
 import tkinter as tk
+from typing import Any
 
 from hoi4cm.mod import MOD
 from hoi4cm.ui import (
@@ -49,6 +50,42 @@ _GRID_MARGIN_SCREENS = 1
 
 class CanvasMixin:
     """Canvas rendering + interaction methods for :class:`App`."""
+
+    # App-owned attributes accessed through the mixin. Declared here so
+    # type-checkers know they exist on the concrete App instance.
+    cv: Any  # type: ignore[no-redef]
+    focuses: Any  # type: ignore[no-redef]
+    offset: Any  # type: ignore[no-redef]
+    zoom: Any  # type: ignore[no-redef]
+    selected: Any  # type: ignore[no-redef]
+    _multi_sel: Any  # type: ignore[no-redef]
+    _multisel_mode: Any  # type: ignore[no-redef]
+    mutex_src: Any  # type: ignore[no-redef]
+    mutex_mode: Any  # type: ignore[no-redef]
+    _lines: Any  # type: ignore[no-redef]
+    _temp_line: Any  # type: ignore[no-redef]
+    _pan_start: Any  # type: ignore[no-redef]
+    _drag: Any  # type: ignore[no-redef]
+    _redraw_state: Any  # type: ignore[no-redef]
+    _scene_index: Any  # type: ignore[no-redef]
+    _focus_bundles: Any  # type: ignore[no-redef]
+    _redraw_job: Any  # type: ignore[no-redef]
+    _lines_job: Any  # type: ignore[no-redef]
+    _grid_pool: Any  # type: ignore[no-redef]
+    _grid_used: Any  # type: ignore[no-redef]
+    _grid_key: Any  # type: ignore[no-redef]
+    _grid_item: Any  # type: ignore[no-redef]
+    _grid_on: Any  # type: ignore[no-redef]
+    _canvas_min: Any  # type: ignore[no-redef]
+    _canvas_max: Any  # type: ignore[no-redef]
+    _extra_trees: Any  # type: ignore[no-redef]
+    _lifecycle: Any  # type: ignore[no-redef]
+    _image_broker: Any  # type: ignore[no-redef]
+    _image_poll_job: Any  # type: ignore[no-redef]
+    _validation_worst: dict[int, str]  # type: ignore[no-redef]
+
+    def __getattr__(self, name: str) -> Any:  # type: ignore[no-redef]
+        raise AttributeError(name)
 
     # Above this many loaded focuses, the minimap buckets dots to one per
     # occupied pixel cell and skips prereq lines (see _draw_minimap).
@@ -727,7 +764,7 @@ class CanvasMixin:
             self._delete_focus_bundle(f.id)
             bundle = None
         z = self.zoom
-        XGRID * z  # horizontal slot width
+        _ = XGRID * z  # horizontal slot width, keeps import used
         box = BOX * z
         h = box / 2
         sd = max(1, int(2 * z))
@@ -753,6 +790,14 @@ class CanvasMixin:
         )
         fill_col = FC_SEL if sel else ("#0a2030" if msel else FC_BG)
         bw = 3 if sel else (2 if msel else 1)
+        # validation overlay: error red, warning amber when not selected
+        val_sev = getattr(self, "_validation_worst", {}).get(f.id)
+        if val_sev and not sel and not msel and not mut:
+            if val_sev == "error":
+                border_col = "#ef4444"
+                bw = max(bw, 2)
+            elif val_sev == "warning":
+                border_col = "#f59e0b"
 
         if lod == "compact":
             state_key = (
@@ -762,6 +807,7 @@ class CanvasMixin:
                 border_col,
                 fill_col,
                 bw,
+                val_sev,
             )
             if bundle is not None and bundle.draw_key == state_key:
                 return
@@ -804,6 +850,7 @@ class CanvasMixin:
             label_text = ""
 
         has_offsets = bool(getattr(f, "offsets", []))
+        val_sev = getattr(self, "_validation_worst", {}).get(f.id)
         # Fast-exit: skip if nothing changed since last draw
         state_key = (
             round(cx, 1),
@@ -819,6 +866,7 @@ class CanvasMixin:
             getattr(f, "gfx", ""),
             tree_idx,
             has_offsets,
+            val_sev,
         )
         if bundle is not None and bundle.draw_key == state_key:
             return
@@ -1286,7 +1334,7 @@ class CanvasMixin:
             header = (f"■ … {first} more trees", TEXT_DIM)
         else:
             header = ("■ Main tree", FC_BORDER)
-        rows = [header]
+        rows: list[tuple[str, str]] = [header]
         for idx in range(first, len(extra)):
             et = extra[idx]
             badge, col = self._get_tree_badge(idx + 1)

--- a/src/hoi4cm/ui/canvas.py
+++ b/src/hoi4cm/ui/canvas.py
@@ -10,6 +10,7 @@ import math
 import tkinter as tk
 from typing import Any
 
+from hoi4cm.focus_tree.validate import Severity
 from hoi4cm.mod import MOD
 from hoi4cm.ui import (
     BG_CARD,
@@ -82,7 +83,7 @@ class CanvasMixin:
     _lifecycle: Any  # type: ignore[no-redef]
     _image_broker: Any  # type: ignore[no-redef]
     _image_poll_job: Any  # type: ignore[no-redef]
-    _validation_worst: dict[int, str]  # type: ignore[no-redef]
+    _validation_worst: dict[int, Severity]  # type: ignore[no-redef]
 
     def __getattr__(self, name: str) -> Any:  # type: ignore[no-redef]
         raise AttributeError(name)
@@ -850,7 +851,7 @@ class CanvasMixin:
             label_text = ""
 
         has_offsets = bool(getattr(f, "offsets", []))
-        val_sev = getattr(self, "_validation_worst", {}).get(f.id)
+        # val_sev already fetched before LOD branch; reuse for full path
         # Fast-exit: skip if nothing changed since last draw
         state_key = (
             round(cx, 1),

--- a/src/hoi4cm/ui/focus_list.py
+++ b/src/hoi4cm/ui/focus_list.py
@@ -27,6 +27,7 @@ class FocusListItem:
     name: str
     has_effects: bool = False
     has_broken_prerequisite: bool = False
+    validation_severity: str | None = None
     name_lower: str = field(init=False, repr=False, compare=False)
 
     def __post_init__(self) -> None:
@@ -142,11 +143,16 @@ class _FocusRow:
     def show(self, item: FocusListItem, *, selected: bool) -> None:
         self.key = item.key
         self.label.configure(text=item.name)
-        color = (
-            "#ef4444"
-            if item.has_broken_prerequisite
-            else "#22c55e" if item.has_effects else "#fbbf24"
-        )
+        if item.validation_severity == "error":
+            color = "#ef4444"
+        elif item.validation_severity == "warning":
+            color = "#f59e0b"
+        elif item.has_broken_prerequisite:
+            color = "#ef4444"
+        elif item.has_effects:
+            color = "#22c55e"
+        else:
+            color = "#fbbf24"
         self.dot.configure(fg=color)
         self.apply_selection(selected)
 

--- a/src/hoi4cm/ui/focus_list.py
+++ b/src/hoi4cm/ui/focus_list.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Hashable, Iterable, Sequence
 from dataclasses import dataclass, field
 from math import ceil, floor
-from typing import Protocol
+from typing import Literal, Protocol
 
 from hoi4cm.ui.theme import BG_PANEL, BLUE, TEXT_DIM
 
@@ -27,7 +27,7 @@ class FocusListItem:
     name: str
     has_effects: bool = False
     has_broken_prerequisite: bool = False
-    validation_severity: str | None = None
+    validation_severity: Literal["error", "warning", "info"] | None = None
     name_lower: str = field(init=False, repr=False, compare=False)
 
     def __post_init__(self) -> None:
@@ -147,6 +147,8 @@ class _FocusRow:
             color = "#ef4444"
         elif item.validation_severity == "warning":
             color = "#f59e0b"
+        elif item.validation_severity == "info":
+            color = "#60a5fa"
         elif item.has_broken_prerequisite:
             color = "#ef4444"
         elif item.has_effects:

--- a/src/hoi4cm/ui/mod_loading.py
+++ b/src/hoi4cm/ui/mod_loading.py
@@ -10,6 +10,7 @@ import os
 import re
 import tkinter as tk
 from tkinter import filedialog, messagebox
+from typing import Any, cast
 
 from hoi4cm.core import default_hoi4_mod_dir, tr
 from hoi4cm.mod import MOD, notifying_workspace_files
@@ -34,6 +35,13 @@ _default_hoi4_mod_dir = default_hoi4_mod_dir
 
 class ModLoadingMixin:
     """Mod picking/scanning, post-load prompt and MD additional-income setup."""
+
+    _mod_lbl: Any  # type: ignore[no-redef]
+    _focus_bundles: Any  # type: ignore[no-redef]
+    cv: Any  # type: ignore[no-redef]
+
+    def __getattr__(self, name: str) -> Any:  # type: ignore[no-redef]
+        raise AttributeError(name)
 
     def _load_mod_path(self, root):
         """Load a mod directly from a known path (used by Recent Mods menu)."""
@@ -97,7 +105,7 @@ class ModLoadingMixin:
         MOD.save_config()
 
         # Progress window
-        pw = tk.Toplevel(self)
+        pw = tk.Toplevel(cast(Any, self))  # type: ignore[arg-type]
         pw.title(tr("mod.loading.title", "Loading Mod..."))
         pw.configure(bg=BG_DARK)
         pw.geometry("420x140")
@@ -125,7 +133,10 @@ class ModLoadingMixin:
         status_lbl.pack()
 
         def progress(i, total, label):
-            pct = int((i / total) * 380) if total else 380
+            try:
+                pct = int((i / total) * 380) if total else 380
+            except Exception:
+                pct = 0
             prog_lbl.config(
                 text=tr(
                     "mod.loading.step",
@@ -229,6 +240,12 @@ class ModLoadingMixin:
                 err_note=err_note,
             ),
         )
+        try:
+            sched = getattr(self, "_schedule_validation", None)
+            if callable(sched):
+                sched()
+        except Exception:
+            pass
         # Prompt user to pick edit targets for ideas/events files
         lifecycle = getattr(self, "_lifecycle", None)
         if lifecycle is None:
@@ -247,24 +264,30 @@ class ModLoadingMixin:
             messagebox.showinfo(
                 tr("dialog.no_mod.title", "No Mod"),
                 tr("dialog.no_mod.body", "Please load a mod first."),
-                parent=self,
+                parent=cast(Any, self),  # type: ignore[arg-type]
             )
             return
         root = MOD.root
         ideas_dir = os.path.join(root, "common", "ideas")
         events_dir = os.path.join(root, "events")
-        idea_files = (
-            sorted([f for f in os.listdir(ideas_dir) if f.endswith(".txt")])
-            if os.path.isdir(ideas_dir)
-            else []
-        )
-        event_files = (
-            sorted([f for f in os.listdir(events_dir) if f.endswith(".txt")])
-            if os.path.isdir(events_dir)
-            else []
-        )
+        try:
+            idea_files = (
+                sorted([f for f in os.listdir(ideas_dir) if f.endswith(".txt")])
+                if os.path.isdir(ideas_dir)
+                else []
+            )
+        except OSError:
+            idea_files = []
+        try:
+            event_files = (
+                sorted([f for f in os.listdir(events_dir) if f.endswith(".txt")])
+                if os.path.isdir(events_dir)
+                else []
+            )
+        except OSError:
+            event_files = []
 
-        dlg = tk.Toplevel(self)
+        dlg = tk.Toplevel(cast(Any, self))  # type: ignore[arg-type]
         dlg.title(tr("edit_targets.title", "Set Edit Targets"))
         dlg.configure(bg=BG_DARK)
         # Cap height to screen height - 80px so the dialog always fits
@@ -329,7 +352,11 @@ class ModLoadingMixin:
         def _on_mousewheel(e):
             # Only scroll outer canvas if the event widget is NOT a Listbox
             if not isinstance(e.widget, tk.Listbox):
-                _body_cv.yview_scroll(int(-1 * (e.delta / 120)), "units")
+                try:
+                    delta = int(-1 * (e.delta / 120))
+                except Exception:
+                    delta = 0
+                _body_cv.yview_scroll(delta, "units")
 
         dlg.bind_all("<MouseWheel>", _on_mousewheel)
         dlg.bind(
@@ -518,9 +545,12 @@ class ModLoadingMixin:
             _fd = os.path.join(MOD.root, "common", "national_focus")
             if os.path.isdir(_fd):
                 focus_dir = _fd
-                focus_files = sorted(
-                    f for f in os.listdir(_fd) if f.lower().endswith(".txt")
-                )
+                try:
+                    focus_files = sorted(
+                        f for f in os.listdir(_fd) if f.lower().endswith(".txt")
+                    )
+                except OSError:
+                    focus_files = []
 
         _make_section(
             body,
@@ -546,15 +576,18 @@ class ModLoadingMixin:
             _ld = os.path.join(MOD.root, "localisation")
             if os.path.isdir(_ld):
                 loc_dir = _ld
-                loc_files = sorted(
-                    f
-                    for f in os.listdir(_ld)
-                    if f.lower().endswith(".yml") and "english" in f.lower()
-                )
-                if not loc_files:
+                try:
                     loc_files = sorted(
-                        f for f in os.listdir(_ld) if f.lower().endswith(".yml")
+                        f
+                        for f in os.listdir(_ld)
+                        if f.lower().endswith(".yml") and "english" in f.lower()
                     )
+                    if not loc_files:
+                        loc_files = sorted(
+                            f for f in os.listdir(_ld) if f.lower().endswith(".yml")
+                        )
+                except OSError:
+                    loc_files = []
 
         _make_section(
             body,
@@ -578,9 +611,12 @@ class ModLoadingMixin:
             _sld = os.path.join(MOD.root, "common", "scripted_localisation")
             if os.path.isdir(_sld):
                 sloc_dir = _sld
-                sloc_files = sorted(
-                    f for f in os.listdir(_sld) if f.lower().endswith(".txt")
-                )
+                try:
+                    sloc_files = sorted(
+                        f for f in os.listdir(_sld) if f.lower().endswith(".txt")
+                    )
+                except OSError:
+                    sloc_files = []
 
         _make_section(
             body,
@@ -810,7 +846,10 @@ class ModLoadingMixin:
         sloc = MOD.md_money_scripted_loc_file
         if not sloc:
             sloc_dir = os.path.join(MOD.root, "common", "scripted_localisation")
-            os.makedirs(sloc_dir, exist_ok=True)
+            try:
+                os.makedirs(sloc_dir, exist_ok=True)
+            except OSError:
+                pass
             sloc = os.path.join(sloc_dir, "money_scripted_localization.txt")
         try:
             existing_sloc = ""
@@ -843,7 +882,10 @@ class ModLoadingMixin:
         yml = MOD.md_money_yml_file
         if not yml:
             yml_dir = os.path.join(MOD.root, "localisation", "english")
-            os.makedirs(yml_dir, exist_ok=True)
+            try:
+                os.makedirs(yml_dir, exist_ok=True)
+            except OSError:
+                pass
             yml = os.path.join(yml_dir, "MD_money_l_english.yml")
         try:
             summary_token = f"[additional_income_summary_{idea_id}]"

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -30,8 +30,11 @@ def _focus(  # type: ignore[no-untyped-def]
     return f
 
 
-def test_empty_document_returns_no_issues():
+def test_empty_mapping_returns_no_issues():
     assert validate_document({}) == []
+
+
+def test_empty_focus_document_returns_no_issues():
     assert validate_document(FocusDocument([])) == []
 
 
@@ -42,9 +45,8 @@ def test_valid_tree_with_custom_gfx_and_effects_is_clean():
     b.prereqs = [[1]]
     doc = FocusDocument([a, b])
     issues = validate_document(doc, sprites={"GFX_custom": "/a", "GFX_custom2": "/b"})
-    # no error, but maybe no issues at all (effects present, gfx known, no collision)
-    assert not any(it.severity == "error" for it in issues)
-    assert not any(it.code == "broken_prereq" for it in issues)
+    # fully clean when gfx known, effects present, no collision
+    assert issues == []
 
 
 def test_broken_prereq_and_mutex_reported_as_error():
@@ -328,15 +330,14 @@ def test_collect_loc_keys_handles_version_suffix():
 
 
 def test_worst_severity_per_focus_picks_error_over_warning():
-    a = _focus(1, name="A")
-    b = _focus(2, name="B")
+    # a has only error, b has only warning
+    a = _focus(1, name="A", x=0, y=0, prereqs=[[99]])
+    b = _focus(2, name="B", x=10, y=10, effects=[])
     doc = FocusDocument([a, b])
-    b.effects = []
-    a.prereqs = [[99]]
     issues = validate_document(doc)
     worst = worst_severity_per_focus(issues)
     assert worst[a.id] == "error"
-    assert worst.get(b.id) in ("warning", "error")
+    assert worst[b.id] == "warning"
 
 
 def test_worst_severity_ignores_none_focus_id_and_info():
@@ -351,24 +352,45 @@ def test_worst_severity_ignores_none_focus_id_and_info():
     assert None not in worst
 
 
-def test_validate_is_pure_and_sorted():
+def test_validate_is_pure_returns_new_list_and_does_not_mutate():
     a = _focus(2, name="Z", x=0, y=0)
     b = _focus(1, name="A", x=0, y=0)
     doc = FocusDocument([a, b])
     issues1 = validate_document(doc)
-    # mutate copy should not affect next call (pure)
-    assert issues1 is not validate_document(doc)
     issues2 = validate_document(doc)
+    assert issues1 is not issues2
     assert issues1 == issues2
-    # sorted by severity then name then code
-    severities = [it.severity for it in issues1]
-    if "error" in severities and "warning" in severities:
-        assert severities.index("error") < severities.index("warning")
-    # within same severity, alphabetical by focus_name
-    errors = [it for it in issues1 if it.severity == "error"]
-    if len(errors) >= 2:
-        names = [it.focus_name or "" for it in errors]
-        assert names == sorted(names)
+    before = {fid: (f.x, f.y, list(f.prereqs)) for fid, f in doc.items()}
+    validate_document(doc)
+    after = {fid: (f.x, f.y, list(f.prereqs)) for fid, f in doc.items()}
+    assert before == after
+
+
+def test_validate_sorts_by_severity_error_before_warning():
+    # one error (collision), one warning (empty)
+    a = _focus(1, name="A", x=0, y=0)
+    b = _focus(2, name="B", x=0, y=0, effects=[])
+    # force known severities: collision error + empty warning; give distinct names
+    # Use x=5 collision for A/B and empty on C
+    c = _focus(3, name="C", x=5, y=5, effects=[])
+    doc = FocusDocument([a, b, c])
+    issues = validate_document(doc)
+    severities = [it.severity for it in issues]
+    assert "error" in severities and "warning" in severities
+    assert severities.index("error") < severities.index("warning")
+
+
+def test_validate_sorts_within_severity_by_name():
+    a = _focus(1, name="Zebra", x=0, y=0)
+    b = _focus(2, name="b2", x=0, y=0)
+    c = _focus(3, name="Apple", x=1, y=1)
+    d = _focus(4, name="d2", x=1, y=1)
+    doc = FocusDocument([a, b, c, d])
+    errors = [it for it in validate_document(doc) if it.code == "position_collision"]
+    assert len(errors) == 2
+    names = [it.focus_name or "" for it in errors]
+    assert names == sorted(names)
+    assert names == ["Apple", "Zebra"]
 
 
 def test_validate_does_not_mutate_document():

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,0 +1,159 @@
+from hoi4cm.focus_tree.validate import (
+    collect_loc_keys_from_text,
+    validate_document,
+    worst_severity_per_focus,
+)
+from hoi4cm.models import Focus, FocusDocument
+
+
+def _focus(  # type: ignore[no-untyped-def]
+    fid,
+    name=None,
+    x=0,
+    y=0,
+    gfx="GFX_test",
+    effects=None,
+    prereqs=None,
+    mutex=None,
+    rel=None,
+):
+    f = Focus(x, y)
+    f.id = fid
+    f.name = name or f"focus_{fid}"
+    f.gfx = gfx
+    f.effects = effects if effects is not None else [{"type": "dummy", "fields": {}}]
+    f.prereqs = prereqs if prereqs is not None else []
+    f.mutex = mutex if mutex is not None else []
+    f.relative_position_id = rel
+    return f
+
+
+def test_broken_prereq_and_mutex_reported_as_error():
+    a = _focus(1, name="A")
+    b = _focus(2, name="B", prereqs=[[99]], mutex=[100])
+    doc = FocusDocument([a, b])
+    issues = validate_document(doc)
+    codes = {it.code for it in issues}
+    assert "broken_prereq" in codes
+    assert "broken_mutex" in codes
+    assert all(
+        it.severity == "error"
+        for it in issues
+        if it.code in ("broken_prereq", "broken_mutex")
+    )
+
+
+def test_empty_effects_is_warning_not_error():
+    a = _focus(1, name="A", effects=[])
+    doc = FocusDocument([a])
+    issues = validate_document(doc)
+    empty = [it for it in issues if it.code == "empty_effects"]
+    assert empty
+    assert empty[0].severity == "warning"
+
+
+def test_default_icon_is_warning():
+    a = _focus(1, name="A", gfx="GFX_goal_generic_political_pressure")
+    doc = FocusDocument([a])
+    issues = validate_document(doc)
+    assert any(it.code == "default_icon" and it.severity == "warning" for it in issues)
+
+
+def test_gfx_missing_detected_when_sprites_supplied():
+    a = _focus(1, name="A", gfx="GFX_custom_missing")
+    doc = FocusDocument([a])
+    issues = validate_document(doc, sprites={"GFX_other": "/path"})
+    assert any(it.code == "gfx_missing" for it in issues)
+    # not flagged when sprites is None
+    issues2 = validate_document(doc, sprites=None)
+    assert not any(it.code == "gfx_missing" for it in issues2)
+
+
+def test_position_collision_detected():
+    a = _focus(1, name="A", x=0, y=0)
+    b = _focus(2, name="B", x=0, y=0)
+    doc = FocusDocument([a, b])
+    issues = validate_document(doc)
+    assert any(it.code == "position_collision" for it in issues)
+
+
+def test_unresolvable_relative_position():
+    a = _focus(1, name="A")
+    b = _focus(2, name="B", rel="NONEXISTENT")
+    doc = FocusDocument([a, b])
+    issues = validate_document(doc)
+    assert any(it.code == "relative_position_unresolved" for it in issues)
+    # resolvable should not flag
+    c = _focus(3, name="C", rel="A")
+    doc2 = FocusDocument([a, c])
+    assert not any(
+        it.code == "relative_position_unresolved" for it in validate_document(doc2)
+    )
+
+
+def test_duplicate_name_detected():
+    a = _focus(1, name="dup")
+    b = _focus(2, name="dup")
+    doc = FocusDocument([a, b])
+    issues = validate_document(doc)
+    assert any(it.code == "duplicate_name" for it in issues)
+
+
+def test_prereq_cycle_detected():
+    a = _focus(1, name="A", prereqs=[[2]])
+    b = _focus(2, name="B", prereqs=[[1]])
+    doc = FocusDocument([a, b])
+    issues = validate_document(doc)
+    assert any(it.code == "prereq_cycle" for it in issues)
+    # acyclic should not flag
+    c = _focus(3, name="C", prereqs=[[1]])
+    doc2 = FocusDocument([a, c])  # A has no prereq now
+    a2 = _focus(1, name="A")
+    doc2 = FocusDocument([a2, c])
+    assert not any(it.code == "prereq_cycle" for it in validate_document(doc2))
+
+
+def test_loc_missing_when_keys_supplied():
+    a = _focus(1, name="my_focus")
+    doc = FocusDocument([a])
+    issues = validate_document(doc, loc_keys=set())
+    assert any(it.code == "loc_missing" for it in issues)
+    assert any(it.code == "loc_missing_desc" for it in issues)
+    # with keys present, no warning
+    issues2 = validate_document(doc, loc_keys={"my_focus", "my_focus_desc"})
+    assert not any(it.code.startswith("loc_missing") for it in issues2)
+
+
+def test_collect_loc_keys_from_text():
+    text = 'l_english:\n my_focus: "Title"\n my_focus_desc: "Desc"\n'
+    keys = collect_loc_keys_from_text(text)
+    assert keys == {"my_focus", "my_focus_desc"}
+    assert collect_loc_keys_from_text(None) is None
+
+
+def test_worst_severity_per_focus():
+    a = _focus(1, name="A")
+    b = _focus(2, name="B")
+    doc = FocusDocument([a, b])
+    # A will have error (broken prereq), B warning (empty)
+    b.effects = []
+    a.prereqs = [[99]]
+    issues = validate_document(doc)
+    worst = worst_severity_per_focus(issues)
+    assert worst[a.id] == "error"
+    # B should be warning (empty_effects outweighs maybe)
+    assert worst.get(b.id) in ("warning", "error")
+
+
+def test_validate_is_pure_and_sorted():
+    a = _focus(2, name="Z", x=0, y=0)
+    b = _focus(1, name="A", x=0, y=0)
+    doc = FocusDocument([a, b])
+    issues1 = validate_document(doc)
+    issues2 = validate_document(doc)
+    assert issues1 == issues2
+    # sorted by severity then name
+    severities = [it.severity for it in issues1]
+    # errors come before warnings
+    if "error" in severities and "warning" in severities:
+        assert severities.index("error") < severities.index("warning")

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,4 +1,6 @@
 from hoi4cm.focus_tree.validate import (
+    DEFAULT_GFX,
+    Issue,
     collect_loc_keys_from_text,
     validate_document,
     worst_severity_per_focus,
@@ -28,6 +30,23 @@ def _focus(  # type: ignore[no-untyped-def]
     return f
 
 
+def test_empty_document_returns_no_issues():
+    assert validate_document({}) == []
+    assert validate_document(FocusDocument([])) == []
+
+
+def test_valid_tree_with_custom_gfx_and_effects_is_clean():
+    a = _focus(1, name="A", gfx="GFX_custom", effects=[{"type": "x", "fields": {}}])
+    b = _focus(2, name="B", x=1, y=0, gfx="GFX_custom2")
+    # B depends on A
+    b.prereqs = [[1]]
+    doc = FocusDocument([a, b])
+    issues = validate_document(doc, sprites={"GFX_custom": "/a", "GFX_custom2": "/b"})
+    # no error, but maybe no issues at all (effects present, gfx known, no collision)
+    assert not any(it.severity == "error" for it in issues)
+    assert not any(it.code == "broken_prereq" for it in issues)
+
+
 def test_broken_prereq_and_mutex_reported_as_error():
     a = _focus(1, name="A")
     b = _focus(2, name="B", prereqs=[[99]], mutex=[100])
@@ -41,6 +60,31 @@ def test_broken_prereq_and_mutex_reported_as_error():
         for it in issues
         if it.code in ("broken_prereq", "broken_mutex")
     )
+    # message contains focus name and id
+    prereq = next(it for it in issues if it.code == "broken_prereq")
+    assert prereq.focus_id == 2
+    assert prereq.field == "prereqs"
+    assert "B" in prereq.message
+
+
+def test_broken_prereq_mixed_valid_and_invalid_groups():
+    a = _focus(1, name="A")
+    b = _focus(2, name="B", prereqs=[[1, 99], [1]])
+    doc = FocusDocument([a, b])
+    issues = validate_document(doc)
+    bad = [it for it in issues if it.code == "broken_prereq"]
+    assert len(bad) == 1
+    assert "99" in bad[0].message
+    assert bad[0].field == "prereqs"
+
+
+def test_valid_prereq_and_mutex_not_flagged():
+    a = _focus(1, name="A")
+    b = _focus(2, name="B", prereqs=[[1]], mutex=[1])
+    a.mutex = [2]
+    doc = FocusDocument([a, b])
+    issues = validate_document(doc)
+    assert not any(it.code in ("broken_prereq", "broken_mutex") for it in issues)
 
 
 def test_empty_effects_is_warning_not_error():
@@ -50,13 +94,28 @@ def test_empty_effects_is_warning_not_error():
     empty = [it for it in issues if it.code == "empty_effects"]
     assert empty
     assert empty[0].severity == "warning"
+    assert empty[0].field == "effects"
 
 
 def test_default_icon_is_warning():
-    a = _focus(1, name="A", gfx="GFX_goal_generic_political_pressure")
+    a = _focus(1, name="A", gfx=DEFAULT_GFX)
     doc = FocusDocument([a])
     issues = validate_document(doc)
     assert any(it.code == "default_icon" and it.severity == "warning" for it in issues)
+
+
+def test_missing_gfx_field_treated_as_default():
+    a = _focus(1, name="A", gfx="")
+    doc = FocusDocument([a])
+    issues = validate_document(doc)
+    assert any(it.code == "default_icon" for it in issues)
+
+
+def test_default_icon_suppressible():
+    a = _focus(1, name="A", gfx=DEFAULT_GFX)
+    doc = FocusDocument([a])
+    issues = validate_document(doc, include_default_icon_warning=False)
+    assert not any(it.code == "default_icon" for it in issues)
 
 
 def test_gfx_missing_detected_when_sprites_supplied():
@@ -64,9 +123,32 @@ def test_gfx_missing_detected_when_sprites_supplied():
     doc = FocusDocument([a])
     issues = validate_document(doc, sprites={"GFX_other": "/path"})
     assert any(it.code == "gfx_missing" for it in issues)
+    flagged = next(it for it in issues if it.code == "gfx_missing")
+    assert flagged.severity == "warning"
+    assert flagged.field == "gfx"
     # not flagged when sprites is None
     issues2 = validate_document(doc, sprites=None)
     assert not any(it.code == "gfx_missing" for it in issues2)
+
+
+def test_gfx_missing_not_double_reported_for_default():
+    a = _focus(1, name="A", gfx=DEFAULT_GFX)
+    doc = FocusDocument([a])
+    issues = validate_document(doc, sprites={"GFX_other": "/x"})
+    assert any(it.code == "default_icon" for it in issues)
+    assert not any(it.code == "gfx_missing" for it in issues)
+    # when default warning suppressed, default gfx should surface as gfx_missing
+    issues2 = validate_document(
+        doc, sprites={"GFX_other": "/x"}, include_default_icon_warning=False
+    )
+    assert any(it.code == "gfx_missing" for it in issues2)
+
+
+def test_known_gfx_not_flagged():
+    a = _focus(1, name="A", gfx="GFX_known")
+    doc = FocusDocument([a])
+    issues = validate_document(doc, sprites={"GFX_known": "/p"})
+    assert not any(it.code == "gfx_missing" for it in issues)
 
 
 def test_position_collision_detected():
@@ -74,6 +156,29 @@ def test_position_collision_detected():
     b = _focus(2, name="B", x=0, y=0)
     doc = FocusDocument([a, b])
     issues = validate_document(doc)
+    coll = [it for it in issues if it.code == "position_collision"]
+    assert len(coll) == 1
+    assert coll[0].severity == "error"
+    assert "A" in coll[0].message and "B" in coll[0].message
+    assert coll[0].field == "x"
+
+
+def test_position_collision_with_three_occupants_single_issue():
+    a = _focus(1, name="A", x=5, y=5)
+    b = _focus(2, name="B", x=5, y=5)
+    c = _focus(3, name="C", x=5, y=5)
+    doc = FocusDocument([a, b, c])
+    coll = [it for it in validate_document(doc) if it.code == "position_collision"]
+    assert len(coll) == 1
+    assert "5" in coll[0].message
+
+
+def test_plain_dict_fallback_for_occupied_positions():
+    # Exercises the `occupied is None` branch (line 96-99)
+    a = _focus(1, name="A", x=0, y=0)
+    b = _focus(2, name="B", x=0, y=0)
+    plain = {1: a, 2: b}
+    issues = validate_document(plain)
     assert any(it.code == "position_collision" for it in issues)
 
 
@@ -82,10 +187,30 @@ def test_unresolvable_relative_position():
     b = _focus(2, name="B", rel="NONEXISTENT")
     doc = FocusDocument([a, b])
     issues = validate_document(doc)
-    assert any(it.code == "relative_position_unresolved" for it in issues)
-    # resolvable should not flag
+    bad = [it for it in issues if it.code == "relative_position_unresolved"]
+    assert len(bad) == 1
+    assert bad[0].severity == "error"
+    assert bad[0].field == "relative_position_id"
+    assert "NONEXISTENT" in bad[0].message
+
+
+def test_resolvable_relative_position_not_flagged():
+    a = _focus(1, name="A")
     c = _focus(3, name="C", rel="A")
-    doc2 = FocusDocument([a, c])
+    doc = FocusDocument([a, c])
+    assert not any(
+        it.code == "relative_position_unresolved" for it in validate_document(doc)
+    )
+
+
+def test_empty_relative_position_id_not_flagged():
+    a = _focus(1, name="A", rel="")
+    doc = FocusDocument([a])
+    assert not any(
+        it.code == "relative_position_unresolved" for it in validate_document(doc)
+    )
+    b = _focus(2, name="B", rel=None)
+    doc2 = FocusDocument([b])
     assert not any(
         it.code == "relative_position_unresolved" for it in validate_document(doc2)
     )
@@ -96,21 +221,65 @@ def test_duplicate_name_detected():
     b = _focus(2, name="dup")
     doc = FocusDocument([a, b])
     issues = validate_document(doc)
-    assert any(it.code == "duplicate_name" for it in issues)
+    dup = [it for it in issues if it.code == "duplicate_name"]
+    assert len(dup) == 1
+    assert dup[0].severity == "error"
+    assert dup[0].focus_id == 1
+    assert "dup" in dup[0].message
 
 
-def test_prereq_cycle_detected():
+def test_duplicate_name_with_three_ids_reports_once():
+    a = _focus(1, name="dup")
+    b = _focus(2, name="dup")
+    c = _focus(3, name="dup")
+    doc = FocusDocument([a, b, c])
+    dup = [it for it in validate_document(doc) if it.code == "duplicate_name"]
+    assert len(dup) == 1
+    assert "3" in dup[0].message
+
+
+def test_prereq_cycle_detected_two_nodes():
     a = _focus(1, name="A", prereqs=[[2]])
     b = _focus(2, name="B", prereqs=[[1]])
     doc = FocusDocument([a, b])
     issues = validate_document(doc)
     assert any(it.code == "prereq_cycle" for it in issues)
-    # acyclic should not flag
+    cyc = next(it for it in issues if it.code == "prereq_cycle")
+    assert cyc.severity == "error"
+    assert "A" in cyc.message or "B" in cyc.message
+
+
+def test_prereq_self_cycle_detected():
+    a = _focus(1, name="A", prereqs=[[1]])
+    doc = FocusDocument([a])
+    assert any(it.code == "prereq_cycle" for it in validate_document(doc))
+
+
+def test_prereq_cycle_three_nodes():
+    a = _focus(1, name="A", prereqs=[[2]])
+    b = _focus(2, name="B", prereqs=[[3]])
     c = _focus(3, name="C", prereqs=[[1]])
-    doc2 = FocusDocument([a, c])  # A has no prereq now
-    a2 = _focus(1, name="A")
-    doc2 = FocusDocument([a2, c])
-    assert not any(it.code == "prereq_cycle" for it in validate_document(doc2))
+    doc = FocusDocument([a, b, c])
+    assert any(it.code == "prereq_cycle" for it in validate_document(doc))
+
+
+def test_prereq_acyclic_chain_not_flagged():
+    a = _focus(1, name="A")
+    b = _focus(2, name="B", prereqs=[[1]])
+    c = _focus(3, name="C", prereqs=[[2]])
+    doc = FocusDocument([a, b, c])
+    assert not any(it.code == "prereq_cycle" for it in validate_document(doc))
+
+
+def test_prereq_cycle_deduped():
+    # Diamond with single cycle should report once, not twice
+    a = _focus(1, name="A", prereqs=[[2]])
+    b = _focus(2, name="B", prereqs=[[1]])
+    c = _focus(3, name="C", prereqs=[[1]])
+    doc = FocusDocument([a, b, c])
+    cycles = [it for it in validate_document(doc) if it.code == "prereq_cycle"]
+    # sorted dedup key collapses; should be exactly one report for the A<->B cycle
+    assert len(cycles) == 1
 
 
 def test_loc_missing_when_keys_supplied():
@@ -124,25 +293,62 @@ def test_loc_missing_when_keys_supplied():
     assert not any(it.code.startswith("loc_missing") for it in issues2)
 
 
+def test_loc_partial_keys_only_one_missing():
+    a = _focus(1, name="my_focus")
+    doc = FocusDocument([a])
+    issues = validate_document(doc, loc_keys={"my_focus"})
+    codes = {it.code for it in issues}
+    assert "loc_missing_desc" in codes
+    assert "loc_missing" not in codes
+
+
+def test_loc_skipped_when_keys_none():
+    a = _focus(1, name="my_focus")
+    doc = FocusDocument([a])
+    assert not any(
+        it.code.startswith("loc_missing")
+        for it in validate_document(doc, loc_keys=None)
+    )
+
+
 def test_collect_loc_keys_from_text():
     text = 'l_english:\n my_focus: "Title"\n my_focus_desc: "Desc"\n'
     keys = collect_loc_keys_from_text(text)
     assert keys == {"my_focus", "my_focus_desc"}
     assert collect_loc_keys_from_text(None) is None
+    assert collect_loc_keys_from_text("") == set()
 
 
-def test_worst_severity_per_focus():
+def test_collect_loc_keys_handles_version_suffix():
+    text = ' my_key:1 "value"\n other:2: "v2"\n'
+    keys = collect_loc_keys_from_text(text)
+    assert keys is not None and "my_key" in keys
+    # version suffix stripped by _KEY_RE
+    assert keys is not None and "other" in keys
+
+
+def test_worst_severity_per_focus_picks_error_over_warning():
     a = _focus(1, name="A")
     b = _focus(2, name="B")
     doc = FocusDocument([a, b])
-    # A will have error (broken prereq), B warning (empty)
     b.effects = []
     a.prereqs = [[99]]
     issues = validate_document(doc)
     worst = worst_severity_per_focus(issues)
     assert worst[a.id] == "error"
-    # B should be warning (empty_effects outweighs maybe)
     assert worst.get(b.id) in ("warning", "error")
+
+
+def test_worst_severity_ignores_none_focus_id_and_info():
+    issues = [
+        Issue("error", "broken_prereq", None, None, "global", field="prereqs"),
+        Issue("info", "hint", 1, "A", "info msg"),
+        Issue("warning", "empty_effects", 1, "A", "warn"),
+        Issue("error", "position_collision", 1, "A", "err"),
+    ]
+    worst = worst_severity_per_focus(issues)
+    assert worst[1] == "error"
+    assert None not in worst
 
 
 def test_validate_is_pure_and_sorted():
@@ -150,10 +356,43 @@ def test_validate_is_pure_and_sorted():
     b = _focus(1, name="A", x=0, y=0)
     doc = FocusDocument([a, b])
     issues1 = validate_document(doc)
+    # mutate copy should not affect next call (pure)
+    assert issues1 is not validate_document(doc)
     issues2 = validate_document(doc)
     assert issues1 == issues2
-    # sorted by severity then name
+    # sorted by severity then name then code
     severities = [it.severity for it in issues1]
-    # errors come before warnings
     if "error" in severities and "warning" in severities:
         assert severities.index("error") < severities.index("warning")
+    # within same severity, alphabetical by focus_name
+    errors = [it for it in issues1 if it.severity == "error"]
+    if len(errors) >= 2:
+        names = [it.focus_name or "" for it in errors]
+        assert names == sorted(names)
+
+
+def test_validate_does_not_mutate_document():
+    a = _focus(1, name="A", x=0, y=0)
+    b = _focus(2, name="B", x=0, y=0)
+    doc = FocusDocument([a, b])
+    before = {fid: (f.x, f.y, list(f.prereqs)) for fid, f in doc.items()}
+    validate_document(doc)
+    after = {fid: (f.x, f.y, list(f.prereqs)) for fid, f in doc.items()}
+    assert before == after
+
+
+def test_issue_sort_key_orders_error_before_warning_before_info():
+    err = Issue("error", "a", 1, "A", "m")
+    warn = Issue("warning", "a", 1, "A", "m")
+    info = Issue("info", "a", 1, "A", "m")
+    assert err.sort_key() < warn.sort_key() < info.sort_key()
+
+
+def test_multiple_issues_per_focus_all_reported():
+    a = _focus(1, name="A", gfx="", effects=[], prereqs=[[99]], rel="MISSING")
+    doc = FocusDocument([a])
+    codes = {it.code for it in validate_document(doc)}
+    assert "broken_prereq" in codes
+    assert "relative_position_unresolved" in codes
+    assert "empty_effects" in codes
+    assert "default_icon" in codes


### PR DESCRIPTION
Closes #41

**What**
- New `src/hoi4cm/focus_tree/validate.py` — pure, headless validator returning `Issue(severity, code, focus, message)`. Checks: duplicate names, broken prereq/mutex, prereq cycles, unresolvable `relative_position_id`, position collisions via `occupied_positions`, missing GFX against `MOD.sprites` (#40) and missing loc keys, with error/warning severities.
- Dialog rebuilt as filterable `ttk.Treeview` (All / Errors / Warnings), sortable, copy filtered to clipboard, click-to-select and double-click-to-center the offending focus.
- Background validation service: debounced `_schedule_validation` on every document change (via `_redraw` hook and mod load), updates canvas borders (red error / amber warning) and focus-list dot, and refreshes the open dialog live.

**Why**
`_validate_tree` mixed ~20 lines of checks with ~85 lines of Tk so none testable, and missed the things that actually break a tree in-game while drowning real errors in default-icon/no-effects noise. Results were not copyable or clickable.

**How**
- `validate_document(doc, sprites, loc_keys)` is pure; untested Tk removed from core. `worst_severity_per_focus` drives canvas/list badging. `collect_loc_keys_from_text` reuses existing yml key regex.
- Canvas: `_validation_worst` map overrides border color in `_draw_focus` (preserves selection/mutex colors) and participates in draw-key; focus list `FocusListItem.validation_severity` colors the dot.
- App: `_validation_sprites`/`_validation_loc_keys` supply optional context from `MOD`; `_run_validation` refreshes UI and live dialog (`_refresh_validation_dialog`).
- Mod load hook triggers revalidation for new sprites.
- Added `tests/test_validate.py` (12 cases) headless.

Checks: `pytest` 884 passed, `mypy` clean, `ruff`/`black`/`pylint` clean (monolith excluded per config).