### PR TITLE
No unsaved-changes guard or crash recovery for the main editor (#49)

### DIFF
--- a/hoi4_content_maker.py
+++ b/hoi4_content_maker.py
@@ -95,7 +95,13 @@ from hoi4cm.core import (
     show_splash,
     tr,
 )
-from hoi4cm.editor import read_project, write_project
+from hoi4cm.editor import (
+    clear_workspace_autosave,
+    read_project,
+    sibling_autosave_path,
+    workspace_autosave_path,
+    write_project,
+)
 from hoi4cm.focus_tree.validate import (
     collect_loc_keys_from_text,
     validate_document,
@@ -266,21 +272,232 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
         self._validation_worst = {}
         self._validation_job = None
         self._validation_win = None
+        self._saved_revision = self.focuses.revision
+        self._saved_fingerprint = self._workspace_fingerprint()
+        self._autosave_job = None
+        self._autosave_interval_ms = 60000
+        self._last_project_path = None
         self.protocol("WM_DELETE_WINDOW", self._on_app_close)
         self._build_ui()
         self._redraw()
         self._schedule_validation()
+        self._update_title()
+        self._schedule_autosave()
+        self.after(800, self._maybe_offer_autosave_restore)
 
     def _on_app_close(self):
+        if self._is_dirty():
+            ans = messagebox.askyesnocancel(
+                tr("dialog.unsaved_changes.title", "Unsaved Changes"),
+                tr(
+                    "dialog.unsaved_changes.close_body",
+                    "You have unsaved changes.\n\nSave before closing?",
+                ),
+                parent=self,
+            )
+            if ans is None:
+                return
+            if ans and not self._save():
+                return
         if not self._lifecycle.begin_close():
             return
         try:
+            self._cancel_autosave()
             MOD.save_config()
         except Exception:
             pass
         finally:
             self._lifecycle.finish_close()
             self.destroy()
+
+    def _workspace_fingerprint(self):
+        try:
+            cfp_x = int(self._cfp_x_var.get())
+        except (TypeError, ValueError, AttributeError):
+            cfp_x = getattr(self, "_cfp_x", None)
+        try:
+            cfp_y = int(self._cfp_y_var.get())
+        except (TypeError, ValueError, AttributeError):
+            cfp_y = getattr(self, "_cfp_y", None)
+        extra_fp = []
+        for tree in getattr(self, "_extra_trees", []):
+            extra_fp.append(
+                (
+                    tree.get("type", ""),
+                    tree.get("file_path", ""),
+                    tree.get("tree_id", ""),
+                    tree.get("cfp_x"),
+                    tree.get("cfp_y"),
+                    tree.get("country_tag", ""),
+                    tree.get("had_wrapper", True),
+                    tuple(sorted(tree.get("focus_ids", set()))),
+                    tuple(tree.get("shared_focuses", [])),
+                    tuple(tree.get("joint_focuses", [])),
+                )
+            )
+        return (
+            self._tree_id.get() if hasattr(self, "_tree_id") else "TAG_focus_tree",
+            getattr(self, "_tree_country_tag", ""),
+            getattr(self, "_tree_country_name", ""),
+            getattr(self, "_tree_country_raw", ""),
+            getattr(self, "_tree_focus_prefix", ""),
+            getattr(MOD, "edit_focus_file", "") or "",
+            getattr(self, "_tree_had_wrapper", True),
+            cfp_x,
+            cfp_y,
+            tuple(getattr(self, "_shared_focuses", [])),
+            tuple(getattr(self, "_joint_focuses", [])),
+            tuple(getattr(self, "_canvas_min", [0, 0])),
+            tuple(getattr(self, "_canvas_max", [9, 9])),
+            getattr(self, "_default_focus_prefix", ""),
+            tuple(extra_fp),
+        )
+
+    def _is_dirty(self) -> bool:
+        if getattr(self, "focuses", None) is None:
+            return False
+        if self.focuses.revision != getattr(self, "_saved_revision", 0):
+            return True
+        try:
+            return self._workspace_fingerprint() != getattr(
+                self, "_saved_fingerprint", None
+            )
+        except Exception:
+            return False
+
+    def _mark_clean(self) -> None:
+        self._saved_revision = self.focuses.revision
+        try:
+            self._saved_fingerprint = self._workspace_fingerprint()
+        except Exception:
+            self._saved_fingerprint = None
+        self._update_title()
+
+    def _confirm_discard(self, action: str = "close") -> bool:
+        if not self._is_dirty():
+            return True
+        ans = messagebox.askyesnocancel(
+            tr("dialog.unsaved_changes.title", "Unsaved Changes"),
+            tr(
+                "dialog.unsaved_changes.body",
+                "You have unsaved changes.\n\nSave before {action}?",
+                action=action,
+            ),
+            parent=self,
+        )
+        if ans is None:
+            return False
+        if ans and not self._save():
+            return False
+        return True
+
+    def _schedule_autosave(self) -> None:
+        self._cancel_autosave()
+        if not hasattr(self, "_autosave_interval_ms"):
+            return
+        try:
+            self._autosave_job = self.after(
+                self._autosave_interval_ms, self._autosave_tick
+            )
+        except Exception:
+            self._autosave_job = None
+
+    def _cancel_autosave(self) -> None:
+        job = getattr(self, "_autosave_job", None)
+        if job is not None:
+            try:
+                self.after_cancel(job)
+            except Exception:
+                pass
+            self._autosave_job = None
+
+    def _autosave_tick(self) -> None:
+        self._autosave_job = None
+        try:
+            if self._is_dirty():
+                path = workspace_autosave_path()
+                self._capture_workspace()
+                write_project(path, self.workspace)
+                sibling = getattr(self, "_last_project_path", None)
+                if sibling:
+                    try:
+                        write_project(
+                            sibling_autosave_path(sibling), self.workspace
+                        )
+                    except Exception:
+                        log.exception("sibling autosave failed")
+        except Exception:
+            log.exception("workspace autosave failed")
+        finally:
+            self._schedule_autosave()
+
+    def _maybe_offer_autosave_restore(self) -> None:
+        path = workspace_autosave_path()
+        if not os.path.isfile(path):
+            return
+        if self._is_dirty():
+            return
+        try:
+            autosaved = read_project(path)
+        except Exception:
+            return
+        if not autosaved.focuses and autosaved.main_tree.metadata.tree_id in (
+            "",
+            "TAG_focus_tree",
+        ):
+            return
+        focus_count = len(autosaved.focuses)
+        tree_id = autosaved.main_tree.metadata.tree_id or "untitled"
+        ans = messagebox.askyesnocancel(
+            tr("dialog.autosave_restore.title", "Restore Autosave?"),
+            tr(
+                "dialog.autosave_restore.body",
+                "An autosaved workspace was found ({count} focuses, tree '{tree}').\n\nRestore it?",
+                count=focus_count,
+                tree=tree_id,
+            ),
+            parent=self,
+        )
+        if ans is None:
+            return
+        if ans:
+            try:
+                self.cv.delete("all")
+                self.selected = None
+                self._lines.clear()
+                self._grid_item = None
+                self._grid_key = None
+                self._grid_img = None
+                self._install_workspace(autosaved)
+                self._update_title()
+                self._detect_and_apply_tag()
+                self._refresh_tree_meta_panel()
+                self._refresh_loaded_trees_panel()
+                self._hide_form()
+                self._redraw()
+                self._invalidate_focus_list_structure()
+                self._hint(
+                    tr(
+                        "hint.autosave_restored",
+                        "Autosaved workspace restored — save to keep it",
+                    )
+                )
+            except Exception as ex:
+                log.exception("autosave restore failed")
+                report_error(
+                    tr(
+                        "dialog.autosave_restore_error.body",
+                        "Could not restore autosave:\n{error}",
+                        error=ex,
+                    ),
+                    ex,
+                    parent=self,
+                    title=tr(
+                        "dialog.autosave_restore_error.title", "Restore Failed"
+                    ),
+                )
+        else:
+            clear_workspace_autosave(path)
 
     def _close_app_caches(self):
         from hoi4cm.wizards import _shared as _wiz_shared
@@ -2626,11 +2843,13 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
     def _update_title(self):
         """Reflect current tree ID in the window title bar."""
         tid = self._tree_id.get() or "untitled"
+        dirty = " *" if getattr(self, "_saved_fingerprint", None) is not None and self._is_dirty() else ""
         self.title(
             tr(
                 "app.title.tree",
-                "HOI4 Content Maker  -  {tree}  [Wiki Accurate v2]",
+                "HOI4 Content Maker  -  {tree}{dirty}  [Wiki Accurate v2]",
                 tree=tid,
+                dirty=dirty,
             )
         )
         self._update_statusbar()
@@ -2755,22 +2974,20 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
             tree_id = var_tree.get().strip() or ("%s_focus" % tag.lower())
             foc_pfx = var_foc.get().strip() or (tag + "_")
 
-            # Ask to save before clearing
-            if self.focuses:
-                ans = messagebox.askyesnocancel(
-                    tr("dialog.save_current_tree.title", "Save Current Tree?"),
-                    tr(
-                        "dialog.save_current_tree.body",
-                        "You have unsaved work on '{tree}'\n\nSave it before starting a new tree?",
-                        tree=self._tree_id.get(),
-                    ),
-                    parent=win,
-                )
-                if ans is None:  # Cancel
-                    return
-                if ans:  # Yes — save first
-                    self._save()
-                # Clear canvas (Yes or No both clear)
+            if self._is_dirty() or self.focuses:
+                if self._is_dirty():
+                    ans = messagebox.askyesnocancel(
+                        tr("dialog.unsaved_changes.title", "Unsaved Changes"),
+                        tr(
+                            "dialog.unsaved_changes.new_tree_body",
+                            "You have unsaved changes.\n\nSave before starting a new tree?",
+                        ),
+                        parent=win,
+                    )
+                    if ans is None:
+                        return
+                    if ans and not self._save():
+                        return
                 self.cv.delete("all")
                 self.focuses.clear()
                 self.selected = None
@@ -5259,20 +5476,37 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
             title=tr("filedialog.save_project", "Save Project"),
         )
         if not path:
-            return
+            return False
         try:
             write_project(path, self._capture_workspace())
         except Exception as e:
             log.error("project save failed: %s", e, exc_info=True)
             report_write_failure(self, path, e)
-            return
+            return False
+        try:
+            self._last_project_path = path
+        except Exception:
+            pass
+        try:
+            self._mark_clean()
+        except Exception:
+            pass
+        try:
+            clear_workspace_autosave()
+        except Exception:
+            pass
+        try:
+            clear_workspace_autosave(sibling_autosave_path(path))
+        except Exception:
+            pass
         messagebox.showinfo(
             tr("dialog.saved.title", "Saved"),
             tr("dialog.project_saved", "Project saved:\n{path}", path=path),
         )
+        return True
 
     def _detect_and_apply_tag(self):
-        """Scan all loaded focus IDs, detect common country tag prefix, apply to new focuses."""
+        """Detect common tag prefix from loaded focuses."""
         if not self.focuses:
             return
         names = [f.name for f in self.focuses.values() if f.name and "_" in f.name]
@@ -5280,24 +5514,30 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
             return
         from collections import Counter
 
-        # Extract first segment before first underscore (e.g. "JAP" from "JAP_militarism")
+        # First segment before "_" (e.g. "JAP" from "JAP_militarism")
         segs = [n.split("_")[0].upper() for n in names]
-        # Filter: must be 2-5 chars (typical HOI4 tags are 3 chars like JAP, GER, USA)
+        # Filter: 2-5 chars (typical tag like JAP, GER, USA)
         segs = [s for s in segs if 2 <= len(s) <= 5 and s.isalpha()]
         if not segs:
             return
         most_common, count = Counter(segs).most_common(1)[0]
-        # Apply if appears in at least 2 focuses OR >30% of all (handles small trees too)
+        # Apply if >=2 focuses and >=30% (handles small trees)
         threshold = count >= 2 and (count / len(names) >= 0.30)
         if threshold and len(most_common) >= 2:
             self._default_focus_prefix = most_common + "_"
             self._hint(
-                f"🏷 Tag detected: {most_common}  —  new focuses will auto-prefix '{most_common}_'"
+                f"🏷 Tag {most_common} — new focuses auto-prefix "
+                f"'{most_common}_'"
             )
         else:
             self._default_focus_prefix = ""
 
     def _load(self):
+        try:
+            if not self._confirm_discard(action="loading"):
+                return
+        except AttributeError:
+            pass
         path = filedialog.askopenfilename(
             filetypes=[
                 (tr("filetype.json_project", "JSON Project"), "*.json"),
@@ -5327,7 +5567,18 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
         self._grid_key = None
         self._grid_img = None
         self._install_workspace(workspace)
-        self._update_title()
+        try:
+            self._last_project_path = path
+        except Exception:
+            pass
+        try:
+            self._mark_clean()
+        except Exception:
+            pass
+        try:
+            clear_workspace_autosave()
+        except Exception:
+            pass
         self._detect_and_apply_tag()
         self._refresh_tree_meta_panel()
         self._refresh_loaded_trees_panel()

--- a/hoi4_content_maker.py
+++ b/hoi4_content_maker.py
@@ -313,11 +313,11 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
     def _workspace_fingerprint(self):
         try:
             cfp_x = int(self._cfp_x_var.get())
-        except (TypeError, ValueError, AttributeError):
+        except TypeError, ValueError, AttributeError:
             cfp_x = getattr(self, "_cfp_x", None)
         try:
             cfp_y = int(self._cfp_y_var.get())
-        except (TypeError, ValueError, AttributeError):
+        except TypeError, ValueError, AttributeError:
             cfp_y = getattr(self, "_cfp_y", None)
         extra_fp = []
         for tree in getattr(self, "_extra_trees", []):
@@ -341,6 +341,7 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
             getattr(self, "_tree_country_name", ""),
             getattr(self, "_tree_country_raw", ""),
             getattr(self, "_tree_focus_prefix", ""),
+            getattr(self, "_tree_extras", {}),
             getattr(MOD, "edit_focus_file", "") or "",
             getattr(self, "_tree_had_wrapper", True),
             cfp_x,
@@ -421,9 +422,7 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
                 sibling = getattr(self, "_last_project_path", None)
                 if sibling:
                     try:
-                        write_project(
-                            sibling_autosave_path(sibling), self.workspace
-                        )
+                        write_project(sibling_autosave_path(sibling), self.workspace)
                     except Exception:
                         log.exception("sibling autosave failed")
         except Exception:
@@ -492,9 +491,7 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
                     ),
                     ex,
                     parent=self,
-                    title=tr(
-                        "dialog.autosave_restore_error.title", "Restore Failed"
-                    ),
+                    title=tr("dialog.autosave_restore_error.title", "Restore Failed"),
                 )
         else:
             clear_workspace_autosave(path)
@@ -608,9 +605,7 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
         self._shared_focuses = self.workspace.main_tree.metadata.shared_focuses
         self._joint_focuses = self.workspace.main_tree.metadata.joint_focuses
         # Extra loaded trees (shared/joint trees loaded alongside the main tree)
-        self._extra_trees = (
-            []
-        )  # list of dicts: {type, file_path, tree_id, cfp_x, cfp_y, shared_focuses, joint_focuses, country_tag, country_raw, tree_extras, had_wrapper, focus_ids}
+        self._extra_trees = []  # list of dicts: {type, file_path, tree_id, cfp_x, cfp_y, shared_focuses, joint_focuses, country_tag, country_raw, tree_extras, had_wrapper, focus_ids}
         self._tree_badge_table = None  # rebuilt by _get_tree_badge on change
         toolbar = tk.Frame(self, bg=BG_DARK)
         toolbar.pack(fill="x")
@@ -2336,8 +2331,7 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
             return parser(var.get()), False
         except ValueError, TypeError:
             self._log_error(
-                f"Invalid {field_name} value {var.get()!r}; "
-                f"using fallback {fallback}"
+                f"Invalid {field_name} value {var.get()!r}; using fallback {fallback}"
             )
             return fallback, True
 
@@ -2843,7 +2837,12 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
     def _update_title(self):
         """Reflect current tree ID in the window title bar."""
         tid = self._tree_id.get() or "untitled"
-        dirty = " *" if getattr(self, "_saved_fingerprint", None) is not None and self._is_dirty() else ""
+        dirty = (
+            " *"
+            if getattr(self, "_saved_fingerprint", None) is not None
+            and self._is_dirty()
+            else ""
+        )
         self.title(
             tr(
                 "app.title.tree",
@@ -5143,9 +5142,9 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
                     add_error(f"Write failed: {result.plan.focus_path}: {result.error}")
                 continue
             if result.plan.extra_tree_idx is not None:
-                self._extra_trees[result.plan.extra_tree_idx - 1][
-                    "file_path"
-                ] = result.plan.focus_path
+                self._extra_trees[result.plan.extra_tree_idx - 1]["file_path"] = (
+                    result.plan.focus_path
+                )
             if MOD.loaded and MOD.root:
                 for path in result.written_paths:
                     MOD.note_file_written(path)
@@ -5526,8 +5525,7 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
         if threshold and len(most_common) >= 2:
             self._default_focus_prefix = most_common + "_"
             self._hint(
-                f"🏷 Tag {most_common} — new focuses auto-prefix "
-                f"'{most_common}_'"
+                f"🏷 Tag {most_common} — new focuses auto-prefix '{most_common}_'"
             )
         else:
             self._default_focus_prefix = ""

--- a/hoi4_content_maker.py
+++ b/hoi4_content_maker.py
@@ -605,7 +605,9 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
         self._shared_focuses = self.workspace.main_tree.metadata.shared_focuses
         self._joint_focuses = self.workspace.main_tree.metadata.joint_focuses
         # Extra loaded trees (shared/joint trees loaded alongside the main tree)
-        self._extra_trees = []  # list of dicts: {type, file_path, tree_id, cfp_x, cfp_y, shared_focuses, joint_focuses, country_tag, country_raw, tree_extras, had_wrapper, focus_ids}
+        self._extra_trees = (
+            []
+        )  # list of dicts: {type, file_path, tree_id, cfp_x, cfp_y, shared_focuses, joint_focuses, country_tag, country_raw, tree_extras, had_wrapper, focus_ids}
         self._tree_badge_table = None  # rebuilt by _get_tree_badge on change
         toolbar = tk.Frame(self, bg=BG_DARK)
         toolbar.pack(fill="x")
@@ -5142,9 +5144,9 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
                     add_error(f"Write failed: {result.plan.focus_path}: {result.error}")
                 continue
             if result.plan.extra_tree_idx is not None:
-                self._extra_trees[result.plan.extra_tree_idx - 1]["file_path"] = (
-                    result.plan.focus_path
-                )
+                self._extra_trees[result.plan.extra_tree_idx - 1][
+                    "file_path"
+                ] = result.plan.focus_path
             if MOD.loaded and MOD.root:
                 for path in result.written_paths:
                     MOD.note_file_written(path)

--- a/src/hoi4cm/editor/__init__.py
+++ b/src/hoi4cm/editor/__init__.py
@@ -1,3 +1,18 @@
 from .project_codec import decode_project, encode_project, read_project, write_project
+from .workspace_autosave import (
+    AUTOSAVE_NAME,
+    clear_workspace_autosave,
+    sibling_autosave_path,
+    workspace_autosave_path,
+)
 
-__all__ = ["decode_project", "encode_project", "read_project", "write_project"]
+__all__ = [
+    "AUTOSAVE_NAME",
+    "clear_workspace_autosave",
+    "decode_project",
+    "encode_project",
+    "read_project",
+    "sibling_autosave_path",
+    "workspace_autosave_path",
+    "write_project",
+]

--- a/src/hoi4cm/editor/workspace_autosave.py
+++ b/src/hoi4cm/editor/workspace_autosave.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import os
+
+from hoi4cm.core.paths import autosave_path
+
+AUTOSAVE_NAME = "workspace.json"
+
+
+def workspace_autosave_path(name: str = AUTOSAVE_NAME) -> str:
+    return autosave_path(name)
+
+
+def sibling_autosave_path(project_path: str) -> str:
+    # ".autosave.json" sibling next to the chosen project file — C extension
+    # keeps crash recovery beside the user's save while the global
+    # ~/.hoi4cm/autosave/workspace.json remains the primary restore source.
+    if project_path.endswith(".json"):
+        return project_path[: -len(".json")] + ".autosave.json"
+    return project_path + ".autosave.json"
+
+
+def clear_workspace_autosave(path: str | None = None) -> None:
+    p = path or workspace_autosave_path()
+    try:
+        os.unlink(p)
+    except OSError:
+        pass
+
+
+__all__ = ["AUTOSAVE_NAME", "clear_workspace_autosave", "workspace_autosave_path"]

--- a/src/hoi4cm/editor/workspace_autosave.py
+++ b/src/hoi4cm/editor/workspace_autosave.py
@@ -28,4 +28,9 @@ def clear_workspace_autosave(path: str | None = None) -> None:
         pass
 
 
-__all__ = ["AUTOSAVE_NAME", "clear_workspace_autosave", "workspace_autosave_path"]
+__all__ = [
+    "AUTOSAVE_NAME",
+    "clear_workspace_autosave",
+    "sibling_autosave_path",
+    "workspace_autosave_path",
+]

--- a/tests/test_workspace_autosave.py
+++ b/tests/test_workspace_autosave.py
@@ -55,7 +55,8 @@ def test_clear_workspace_autosave_removes_file(tmp_path, monkeypatch):
     monkeypatch.setattr(os.path, "expanduser", lambda p: p.replace("~", str(tmp_path)))
     path = workspace_autosave_path()
     os.makedirs(os.path.dirname(path), exist_ok=True)
-    open(path, "w").write("x")
+    # test tmp is safe — not a user-controlled traversal sink
+    open(path, "w", encoding="utf-8").write("x")  # nosemgrep: python-path-traversal
     assert os.path.isfile(path)
     clear_workspace_autosave()
     assert not os.path.isfile(path)

--- a/tests/test_workspace_autosave.py
+++ b/tests/test_workspace_autosave.py
@@ -1,0 +1,118 @@
+import os
+
+import hoi4cm.editor.workspace_autosave as wa  # type: ignore[import-untyped]
+from hoi4cm.editor import read_project, write_project
+from hoi4cm.models import (
+    EditorWorkspace,
+    Focus,
+    FocusDocument,
+    TreeDocument,
+    TreeMetadata,
+)
+
+AUTOSAVE_NAME = wa.AUTOSAVE_NAME
+clear_workspace_autosave = wa.clear_workspace_autosave
+sibling_autosave_path = wa.sibling_autosave_path
+workspace_autosave_path = wa.workspace_autosave_path
+
+
+def test_workspace_autosave_path_uses_autosave_name(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(os.path, "expanduser", lambda p: p.replace("~", str(tmp_path)))
+    got = workspace_autosave_path()
+    assert got == os.path.join(str(tmp_path), ".hoi4cm", "autosave", AUTOSAVE_NAME)
+    assert os.path.isdir(os.path.dirname(got))
+
+
+def test_workspace_autosave_path_custom_name(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(os.path, "expanduser", lambda p: p.replace("~", str(tmp_path)))
+    assert workspace_autosave_path("custom.json").endswith("custom.json")
+
+
+def test_sibling_autosave_path_with_json_extension():
+    assert sibling_autosave_path("/tmp/proj/project.json") == (
+        "/tmp/proj/project.autosave.json"
+    )
+    assert sibling_autosave_path("a.json") == "a.autosave.json"
+
+
+def test_sibling_autosave_path_without_json_extension():
+    assert sibling_autosave_path("/tmp/proj/project") == (
+        "/tmp/proj/project.autosave.json"
+    )
+    assert sibling_autosave_path("/tmp/proj/archive.txt") == (
+        "/tmp/proj/archive.txt.autosave.json"
+    )
+
+
+def test_sibling_autosave_path_preserves_directory():
+    assert sibling_autosave_path("/a/b/c.json") == "/a/b/c.autosave.json"
+
+
+def test_clear_workspace_autosave_removes_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(os.path, "expanduser", lambda p: p.replace("~", str(tmp_path)))
+    path = workspace_autosave_path()
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    open(path, "w").write("x")
+    assert os.path.isfile(path)
+    clear_workspace_autosave()
+    assert not os.path.isfile(path)
+
+
+def test_clear_workspace_autosave_noop_when_missing(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(os.path, "expanduser", lambda p: p.replace("~", str(tmp_path)))
+    path = workspace_autosave_path()
+    if os.path.isfile(path):
+        os.unlink(path)
+    clear_workspace_autosave()  # must not raise
+    clear_workspace_autosave(path)  # explicit path variant
+
+
+def test_clear_workspace_autosave_ignores_os_error(monkeypatch, tmp_path):
+    # OSError on unlink (e.g. permission) must be swallowed — best-effort.
+    monkeypatch.setattr(
+        os, "unlink", lambda _p: (_ for _ in ()).throw(OSError("denied"))
+    )
+    clear_workspace_autosave(str(tmp_path / "ghost.json"))
+
+
+def test_clear_workspace_autosave_explicit_path(tmp_path):
+    target = tmp_path / "sibling.autosave.json"
+    target.write_text("x")
+    clear_workspace_autosave(str(target))
+    assert not target.exists()
+    clear_workspace_autosave(str(target))  # second clear is no-op
+
+
+def _one_focus_workspace():
+    focus = Focus(1, 2)
+    focus.name = "TAG_start"
+    return EditorWorkspace(
+        focuses=FocusDocument([focus]),
+        main_tree=TreeDocument(metadata=TreeMetadata(tree_id="TAG_focus_tree")),
+    )
+
+
+def test_workspace_autosave_roundtrips_via_write_project(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(os.path, "expanduser", lambda p: p.replace("~", str(tmp_path)))
+    path = workspace_autosave_path()
+    write_project(path, _one_focus_workspace())
+    restored = read_project(path)
+    assert [f.name for f in restored.focuses.values()] == ["TAG_start"]
+    clear_workspace_autosave()
+    assert not os.path.isfile(path)
+
+
+def test_sibling_autosave_roundtrips(tmp_path):
+    project = tmp_path / "project.json"
+    sibling = sibling_autosave_path(str(project))
+    ws = _one_focus_workspace()
+    write_project(sibling, ws)
+    restored = read_project(sibling)
+    assert restored.main_tree.metadata.tree_id == "TAG_focus_tree"
+    clear_workspace_autosave(sibling)
+    assert not os.path.isfile(sibling)

--- a/tests/test_workspace_dirty.py
+++ b/tests/test_workspace_dirty.py
@@ -1,0 +1,410 @@
+"""Dirty tracking and autosave guard tests for issue #49."""
+
+# pyright: reportAttributeAccessIssue=false, reportUnknownMemberType=false, reportUnknownVariableType=false
+
+import os
+
+import hoi4_content_maker as m
+from hoi4cm.models import (
+    EditorWorkspace,
+    Focus,
+    FocusDocument,
+    TreeDocument,
+    TreeMetadata,
+)
+
+
+class _Var:
+    def __init__(self, v=""):
+        self._v = v
+
+    def get(self):
+        return self._v
+
+    def set(self, v):
+        self._v = v
+
+
+def _fake_app(**overrides):
+    """Minimal App-shaped object with real dirty helpers bound."""
+    # Bind the real App methods as unbound functions, then attach to fake.
+    fake = type("Fake", (), {})()
+    for name in (
+        "_workspace_fingerprint",
+        "_is_dirty",
+        "_mark_clean",
+        "_confirm_discard",
+        "_schedule_autosave",
+        "_cancel_autosave",
+        "_autosave_tick",
+        "_maybe_offer_autosave_restore",
+        "_update_title",
+    ):
+        setattr(fake, name, getattr(m.App, name).__get__(fake))
+    # Required attributes for fingerprint
+    fake._tree_id = _Var("TAG_focus_tree")
+    fake._tree_country_tag = ""
+    fake._tree_country_name = ""
+    fake._tree_country_raw = ""
+    fake._tree_focus_prefix = ""
+    fake._tree_extras = {}
+    fake._tree_had_wrapper = True
+    fake._cfp_x = None
+    fake._cfp_y = None
+    fake._cfp_x_var = _Var("")
+    fake._cfp_y_var = _Var("")
+    fake._shared_focuses = []
+    fake._joint_focuses = []
+    fake._canvas_min = [0, 0]
+    fake._canvas_max = [9, 9]
+    fake._default_focus_prefix = ""
+    fake._extra_trees = []
+    fake.focuses = FocusDocument()
+    fake._saved_revision = fake.focuses.revision
+    fake._saved_fingerprint = fake._workspace_fingerprint()
+    fake._autosave_job = None
+    fake._autosave_interval_ms = 60000
+    fake._last_project_path = None
+    # Tk-ish stubs
+    fake.after = lambda ms, cb: "job"
+    fake.after_cancel = lambda j: None
+    fake.title = lambda t: setattr(fake, "_title", t)
+    fake._update_statusbar = lambda: None
+    fake._capture_workspace = lambda: None
+    fake.workspace = EditorWorkspace()
+    fake._hint = lambda msg: setattr(fake, "_hint_msg", msg)
+    # Provide minimal MOD edit_focus_file
+    for k, v in overrides.items():
+        setattr(fake, k, v)
+    return fake
+
+
+def test_is_dirty_initially_clean():
+    app = _fake_app()
+    assert app._is_dirty() is False
+
+
+def test_is_dirty_after_focus_added():
+    app = _fake_app()
+    app.focuses.add(Focus(0, 0))
+    assert app._is_dirty() is True
+
+
+def test_is_dirty_after_fingerprint_change_tree_id():
+    app = _fake_app()
+    app._tree_id.set("OTHER_tree")
+    assert app._is_dirty() is True
+
+
+def test_is_dirty_after_cfp_change():
+    app = _fake_app()
+    app._cfp_x_var.set("5")
+    assert app._is_dirty() is True
+
+
+def test_is_dirty_after_extra_tree_append():
+    app = _fake_app()
+    app._extra_trees.append(
+        {"type": "shared", "file_path": "a.txt", "tree_id": "t", "focus_ids": {1}}
+    )
+    assert app._is_dirty() is True
+
+
+def test_is_dirty_after_canvas_change():
+    app = _fake_app()
+    app._canvas_max = [20, 20]
+    assert app._is_dirty() is True
+
+
+def test_is_dirty_after_tree_extras_change():
+    app = _fake_app()
+    app._tree_extras = {"custom": 1}
+    assert app._is_dirty() is True
+
+
+def test_is_dirty_after_edit_focus_file_change(monkeypatch):
+    app = _fake_app()
+    monkeypatch.setattr(m.MOD, "edit_focus_file", "new/path.txt", raising=False)
+    assert app._is_dirty() is True
+
+
+def test_mark_clean_resets_dirty():
+    app = _fake_app()
+    app.focuses.add(Focus(0, 0))
+    assert app._is_dirty() is True
+    app._mark_clean()
+    assert app._is_dirty() is False
+    assert app._saved_revision == app.focuses.revision
+
+
+def test_workspace_fingerprint_changes_with_extra_tree_focus_ids_order():
+    app = _fake_app()
+    fp1 = app._workspace_fingerprint()
+    app._extra_trees = [
+        {
+            "type": "shared",
+            "file_path": "a.txt",
+            "tree_id": "t",
+            "focus_ids": {2, 1},
+            "shared_focuses": [],
+            "joint_focuses": [],
+        }
+    ]
+    fp2 = app._workspace_fingerprint()
+    assert fp1 != fp2
+    # Order of focus_ids must not matter (sorted)
+    app2 = _fake_app()
+    app2._extra_trees = [
+        {
+            "type": "shared",
+            "file_path": "a.txt",
+            "tree_id": "t",
+            "focus_ids": {1, 2},
+            "shared_focuses": [],
+            "joint_focuses": [],
+        }
+    ]
+    assert fp2 == app2._workspace_fingerprint()
+
+
+def test_confirm_discard_no_dirty_returns_true_without_prompt(monkeypatch):
+    app = _fake_app()
+    called = []
+    monkeypatch.setattr(
+        m.messagebox, "askyesnocancel", lambda *a, **kw: called.append(1) or True
+    )
+    assert app._confirm_discard("loading") is True
+    assert called == []
+
+
+def test_confirm_discard_dirty_cancel_returns_false(monkeypatch):
+    app = _fake_app()
+    app.focuses.add(Focus(0, 0))
+    monkeypatch.setattr(m.messagebox, "askyesnocancel", lambda *a, **kw: None)
+    assert app._confirm_discard("loading") is False
+
+
+def test_confirm_discard_dirty_no_returns_true_without_save(monkeypatch):
+    app = _fake_app()
+    app.focuses.add(Focus(0, 0))
+    monkeypatch.setattr(m.messagebox, "askyesnocancel", lambda *a, **kw: False)
+    app._save = lambda: (_ for _ in ()).throw(AssertionError("should not save"))
+    assert app._confirm_discard("loading") is True
+
+
+def test_confirm_discard_dirty_yes_saves(monkeypatch):
+    app = _fake_app()
+    app.focuses.add(Focus(0, 0))
+    monkeypatch.setattr(m.messagebox, "askyesnocancel", lambda *a, **kw: True)
+    saved = []
+    app._save = lambda: saved.append(1) or True
+    assert app._confirm_discard("loading") is True
+    assert saved == [1]
+
+
+def test_confirm_discard_dirty_yes_save_fails_returns_false(monkeypatch):
+    app = _fake_app()
+    app.focuses.add(Focus(0, 0))
+    monkeypatch.setattr(m.messagebox, "askyesnocancel", lambda *a, **kw: True)
+    app._save = lambda: False
+    assert app._confirm_discard("loading") is False
+
+
+def test_autosave_tick_writes_when_dirty(monkeypatch, tmp_path):
+    app = _fake_app()
+    app.focuses.add(Focus(0, 0))
+    writes = []
+    monkeypatch.setattr(m, "write_project", lambda p, ws: writes.append(p))
+    monkeypatch.setattr(
+        m, "workspace_autosave_path", lambda: str(tmp_path / "autosave.json")
+    )
+    app._capture_workspace = lambda: None
+    app.workspace = EditorWorkspace(focuses=app.focuses)
+    app._schedule_autosave = lambda: None
+    app._autosave_tick()
+    assert len(writes) == 1
+    assert writes[0].endswith("autosave.json")
+
+
+def test_autosave_tick_no_write_when_clean(monkeypatch, tmp_path):
+    app = _fake_app()
+    writes = []
+    monkeypatch.setattr(m, "write_project", lambda p, ws: writes.append(p))
+    monkeypatch.setattr(
+        m, "workspace_autosave_path", lambda: str(tmp_path / "autosave.json")
+    )
+    app._schedule_autosave = lambda: None
+    app._autosave_tick()
+    assert writes == []
+
+
+def test_autosave_tick_writes_sibling_when_last_path(monkeypatch, tmp_path):
+    app = _fake_app()
+    app.focuses.add(Focus(0, 0))
+    app._last_project_path = str(tmp_path / "project.json")
+    writes = []
+    monkeypatch.setattr(m, "write_project", lambda p, ws: writes.append(p))
+    monkeypatch.setattr(
+        m, "workspace_autosave_path", lambda: str(tmp_path / "autosave.json")
+    )
+    # sibling helper returns .autosave.json
+    monkeypatch.setattr(
+        m, "sibling_autosave_path", lambda p: p.replace(".json", ".autosave.json")
+    )
+    app._capture_workspace = lambda: None
+    app.workspace = EditorWorkspace(focuses=app.focuses)
+    app._schedule_autosave = lambda: None
+    app._autosave_tick()
+    assert len(writes) == 2
+    assert any(".autosave.json" in p for p in writes)
+
+
+def test_autosave_tick_swallows_write_error(monkeypatch, tmp_path):
+    app = _fake_app()
+    app.focuses.add(Focus(0, 0))
+    monkeypatch.setattr(
+        m, "write_project", lambda p, ws: (_ for _ in ()).throw(OSError("disk full"))
+    )
+    monkeypatch.setattr(
+        m, "workspace_autosave_path", lambda: str(tmp_path / "autosave.json")
+    )
+    app._capture_workspace = lambda: None
+    app.workspace = EditorWorkspace()
+    app._schedule_autosave = lambda: setattr(app, "_scheduled", True)
+    app._autosave_tick()
+    assert getattr(app, "_scheduled", False) is True
+
+
+def test_maybe_offer_restore_no_file_no_prompt(monkeypatch, tmp_path):
+    app = _fake_app()
+    monkeypatch.setattr(
+        m, "workspace_autosave_path", lambda: str(tmp_path / "missing.json")
+    )
+    monkeypatch.setattr(os.path, "isfile", lambda p: False)
+    called = []
+    monkeypatch.setattr(
+        m.messagebox, "askyesnocancel", lambda *a, **kw: called.append(1) or True
+    )
+    app._maybe_offer_autosave_restore()
+    assert called == []
+
+
+def test_maybe_offer_restore_when_dirty_no_prompt(monkeypatch, tmp_path):
+    app = _fake_app()
+    app.focuses.add(Focus(0, 0))
+    monkeypatch.setattr(
+        m, "workspace_autosave_path", lambda: str(tmp_path / "autosave.json")
+    )
+    monkeypatch.setattr(os.path, "isfile", lambda p: True)
+    called = []
+    monkeypatch.setattr(
+        m.messagebox, "askyesnocancel", lambda *a, **kw: called.append(1) or True
+    )
+    app._maybe_offer_autosave_restore()
+    assert called == []
+
+
+def test_maybe_offer_restore_malformed_no_prompt(monkeypatch, tmp_path):
+    app = _fake_app()
+    path = tmp_path / "autosave.json"
+    path.write_text("not json")
+    monkeypatch.setattr(m, "workspace_autosave_path", lambda: str(path))
+    monkeypatch.setattr(os.path, "isfile", lambda p: True)
+    monkeypatch.setattr(
+        m, "read_project", lambda p: (_ for _ in ()).throw(ValueError("bad"))
+    )
+    called = []
+    monkeypatch.setattr(
+        m.messagebox, "askyesnocancel", lambda *a, **kw: called.append(1) or True
+    )
+    app._maybe_offer_autosave_restore()
+    assert called == []
+
+
+def test_maybe_offer_restore_empty_not_offered(monkeypatch, tmp_path):
+    app = _fake_app()
+    empty_ws = EditorWorkspace(
+        main_tree=TreeDocument(metadata=TreeMetadata(tree_id="TAG_focus_tree"))
+    )
+    monkeypatch.setattr(
+        m, "workspace_autosave_path", lambda: str(tmp_path / "autosave.json")
+    )
+    monkeypatch.setattr(os.path, "isfile", lambda p: True)
+    monkeypatch.setattr(m, "read_project", lambda p: empty_ws)
+    called = []
+    monkeypatch.setattr(
+        m.messagebox, "askyesnocancel", lambda *a, **kw: called.append(1) or True
+    )
+    app._maybe_offer_autosave_restore()
+    assert called == []
+
+
+def test_maybe_offer_restore_yes_restores(monkeypatch, tmp_path):
+    app = _fake_app()
+    # needed attrs for restore path
+    app.cv = type("CV", (), {"delete": lambda self, a: None})()
+    app.selected = None
+    app._lines = []
+    app._grid_item = None
+    app._grid_key = None
+    app._grid_img = None
+    app._install_workspace = lambda ws: setattr(app, "_installed", ws)
+    app._detect_and_apply_tag = lambda: None
+    app._refresh_tree_meta_panel = lambda: None
+    app._refresh_loaded_trees_panel = lambda: None
+    app._hide_form = lambda: None
+    app._redraw = lambda: None
+    app._invalidate_focus_list_structure = lambda: None
+
+    ws = EditorWorkspace(
+        focuses=FocusDocument([Focus(0, 0)]),
+        main_tree=TreeDocument(metadata=TreeMetadata(tree_id="MY_tree")),
+    )
+    path = tmp_path / "autosave.json"
+    path.write_text("x")
+    monkeypatch.setattr(m, "workspace_autosave_path", lambda: str(path))
+    monkeypatch.setattr(os.path, "isfile", lambda p: True)
+    monkeypatch.setattr(m, "read_project", lambda p: ws)
+    monkeypatch.setattr(m.messagebox, "askyesnocancel", lambda *a, **kw: True)
+    app._maybe_offer_autosave_restore()
+    assert getattr(app, "_installed", None) is ws
+    assert hasattr(app, "_hint_msg")
+
+
+def test_maybe_offer_restore_no_clears_file(monkeypatch, tmp_path):
+    app = _fake_app()
+    ws = EditorWorkspace(
+        focuses=FocusDocument([Focus(0, 0)]),
+        main_tree=TreeDocument(metadata=TreeMetadata(tree_id="MY_tree")),
+    )
+    path = tmp_path / "autosave.json"
+    path.write_text("x")
+    monkeypatch.setattr(m, "workspace_autosave_path", lambda: str(path))
+    monkeypatch.setattr(os.path, "isfile", lambda p: True)
+    monkeypatch.setattr(m, "read_project", lambda p: ws)
+    monkeypatch.setattr(m.messagebox, "askyesnocancel", lambda *a, **kw: False)
+    cleared = []
+    monkeypatch.setattr(m, "clear_workspace_autosave", lambda p: cleared.append(p))
+    app._maybe_offer_autosave_restore()
+    assert cleared == [str(path)]
+
+
+def test_maybe_offer_restore_cancel_keeps_file(monkeypatch, tmp_path):
+    app = _fake_app()
+    ws = EditorWorkspace(
+        focuses=FocusDocument([Focus(0, 0)]),
+        main_tree=TreeDocument(metadata=TreeMetadata(tree_id="MY_tree")),
+    )
+    path = tmp_path / "autosave.json"
+    path.write_text("x")
+    monkeypatch.setattr(m, "workspace_autosave_path", lambda: str(path))
+    monkeypatch.setattr(os.path, "isfile", lambda p: True)
+    monkeypatch.setattr(m, "read_project", lambda p: ws)
+    monkeypatch.setattr(m.messagebox, "askyesnocancel", lambda *a, **kw: None)
+    cleared = []
+    monkeypatch.setattr(m, "clear_workspace_autosave", lambda p: cleared.append(p))
+    installed = []
+    app._install_workspace = lambda ws: installed.append(ws)
+    app._maybe_offer_autosave_restore()
+    assert cleared == []
+    assert installed == []


### PR DESCRIPTION
Closes #49

**What**
- Dirty tracking via `FocusDocument.revision` + workspace fingerprint gates `WM_DELETE_WINDOW`, `Load Project`, and `New Tree` with Save/Discard/Cancel.
- Title bar shows `*` when dirty; explicit save/load marks clean.
- Timer autosave (60s, only when dirty) writes `~/.hoi4cm/autosave/workspace.json` via `write_project` (atomic). C extension also writes a sibling `.autosave.json` beside the last saved project.
- On next launch, if autosave exists and workspace is still clean, offers to restore (Restore/Discard). Restored workspace stays dirty until explicit save; explicit save clears both autosaves.

**Why**
Closing the window or loading a project previously destroyed the workspace with no prompt (`_on_app_close` had no guard, `_load` replaced workspace unconditionally). The five wizards autosaved, the focus-tree editor did not.

**How**
- New `src/hoi4cm/editor/workspace_autosave.py` (`workspace_autosave_path`, `sibling_autosave_path`, `clear_workspace_autosave`) — single writer stays in `WorkspaceFiles`.
- `App`: `_workspace_fingerprint`, `_is_dirty`, `_mark_clean`, `_confirm_discard`, `_schedule_autosave`/`_cancel_autosave`/`_autosave_tick`, `_maybe_offer_autosave_restore` (after 800ms). `_save`/`_load` now return/signal success and maintain `_last_project_path`/`_saved_revision`/`_saved_fingerprint`.