### PR TITLE
Close #48: undo coverage gaps + redo stack

### DIFF
--- a/docs/dev/monolith-migration.md
+++ b/docs/dev/monolith-migration.md
@@ -52,7 +52,16 @@
   `_snapshot` deep-copying every loaded focus on every push. `_undo` deletes
   canvas items only for the ids that came back changed or removed and does
   one `_redraw()`, replacing the old `cv.delete("all")` + full rebuild. See
-  `performance.md`'s undo row for the design.
+  `performance.md`'s undo row for the design. `#48` later closed the
+  remaining coverage holes: `_clear_all` and the four prereq/mutex
+  link/unlink methods (`_make_prereq`, `_rm_prereq`, `_make_mutex`,
+  `_rm_mutex`) now push undo, the canvas drag-move in
+  `src/hoi4cm/ui/canvas.py:_foc_mv` snapshots its pre-move state on the
+  first motion frame, and a paired redo stack (`_redo` in the monolith,
+  `UndoStack.redo` in `core/undo.py`) plus `<Control-y>` /
+  `<Control-Shift-Z>` bindings round-trip the recent history.
+  `push()` clears the redo trail so a new edit branch invalidates redo,
+  matching every other editor.
 - Settings dialog (phase 9): `_open_settings`'s ~1,315-line body moved to
   `ui/settings_dialog.py` as `open_settings(app)`, the same one-line-delegate
   pattern the five wizards use. Lifted out along with it: `relativize_to_mod_root`
@@ -165,8 +174,9 @@ methods group into:
   `_event_wizard`, one-line calls into their `hoi4cm` modules.
 - **Error log**: `_init_error_log`, `_log_error`, `_on_error_logged`,
   `_show_error_log`.
-- **Undo shell**: `_push_undo`, `_undo` (the Tk-facing half of
-  `core/undo.py`'s `UndoStack`).
+- **Undo shell**: `_push_undo`, `_undo`, `_redo` (the Tk-facing half of
+  `core/undo.py`'s `UndoStack`, including the redo stack that pairs with
+  undo).
 - **Autocomplete / mod-aware suggestions**: `_attach_autocomplete`,
   `_get_mod_suggestions`.
 - **Widget factories / low-level helpers**: `_mk_btn`, `_mk_lbl`,
@@ -198,7 +208,7 @@ needs it via `hoi4cm.core`.
 | `_open_gfx_browser` | was ~2624-3058 (~435) | `ui/gfx_browser.py` (`open_focus_icon_browser`), extracted as-is, not merged, see below | **done** (phase 10) |
 | `_gfx_browse_files` | was ~3059-3267 (~209) | folded into `open_focus_icon_browser`'s `_browse_flat_folder` helper | **done** (phase 10) |
 | Sidebar builders (`_build_sidebar`, `_build_sidebar_props`, `_build_sidebar_conditions`, `_build_sidebar_code`, `_sb_*` helpers) | ~846-1817 (~970) | n/a | deferred |
-| Undo (`_push_undo`/`_undo`) | ~1561-1588 | `core/undo.py` (`UndoStack`, redesigned, see `performance.md`) | **done** (phase 7) |
+| Undo (`_push_undo`/`_undo`/`_redo`) | ~1561-1608 | `core/undo.py` (`UndoStack` with redo stack, see `performance.md`) | **done** (phase 7; redo + call-site coverage in #48) |
 | Background threads / executor | n/a | `core/concurrency.py` (`DaemonThreadPoolExecutor`) | **done** (modernization) |
 | Workspace / focus document model | n/a | `models/document.py` (`FocusDocument`, `TreeDocument`, `EditorWorkspace`) | **done** (modernization) |
 | Focus-tree codec + focus operations | n/a | `focus_tree/codec.py`, `focus_tree/operations.py` | **done** (modernization) |

--- a/hoi4_content_maker.py
+++ b/hoi4_content_maker.py
@@ -417,6 +417,10 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
 
         self.bind("<Control-z>", lambda e: self._undo())
         self.bind("<Control-Z>", lambda e: self._undo())
+        self.bind("<Control-y>", lambda e: self._redo())
+        self.bind("<Control-Y>", lambda e: self._redo())
+        self.bind("<Control-Shift-Z>", lambda e: self._redo())
+        self.bind("<Control-Shift-z>", lambda e: self._redo())
         self.bind("<Control-n>", lambda e: self._new_tree_dialog())
         self.bind("<Control-s>", lambda e: self._save())
         self.bind("<Control-o>", lambda e: self._load())
@@ -775,6 +779,28 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
         self._redraw()
         self._invalidate_focus_list_structure()
         self._hint(f"↩ Undid: {label}")
+
+    def _redo(self):
+        """Re-apply the most recently undone action."""
+        result = self._undo_stack.redo(self.focuses, Focus.from_dict)
+        if result is None:
+            self._hint("Nothing to redo.")
+            return
+        label, changed_ids, removed_ids = result
+        for fid in changed_ids | removed_ids:
+            self.cv.delete("F" + str(fid))
+        if self.selected and self.selected.id in removed_ids:
+            self.selected = None
+            self._hide_form()
+        elif self.selected and self.selected.id in changed_ids:
+            self.selected = self.focuses[self.selected.id]
+            self._populate(self.selected)
+            self._refresh_prereqs()
+            self._refresh_mutex()
+            self._refresh_effects()
+        self._redraw()
+        self._invalidate_focus_list_structure()
+        self._hint(f"↪ Redid: {label}")
 
     def _hint(self, t):
         self._hint_lbl.config(text=t)
@@ -3021,6 +3047,7 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
             tr("dialog.clear_all.body", "Delete ALL focuses?"),
         ):
             return
+        self._push_undo("clear all")
         self._begin_document_generation()
         self.cv.delete("all")
         self._focus_bundles.clear()
@@ -3365,6 +3392,7 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
         for g in child.prereqs:
             if parent.id in g:
                 return
+        self._push_undo("add prerequisite", touched_ids=(child.id,))
         self.focuses.link_prerequisite(child.id, (parent.id,))
         self._redraw()
         if self.selected:
@@ -3373,6 +3401,8 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
     def _rm_prereq(self, gi):
         if not self.selected:
             return
+        child_id = self.selected.id
+        self._push_undo("remove prerequisite group", touched_ids=(child_id,))
         self.focuses.unlink_prerequisite_group(self.selected.id, gi)
         self._refresh_prereqs()
         self._draw_lines()
@@ -3419,6 +3449,7 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
         self._redraw()
 
     def _make_mutex(self, a, b):
+        self._push_undo("add mutex", touched_ids=(a.id, b.id))
         self.focuses.link_mutex(a.id, b.id)
         self._redraw()
         if self.selected:
@@ -3428,6 +3459,7 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
         if not self.selected:
             return
         mid = self.selected.mutex[idx]
+        self._push_undo("remove mutex", touched_ids=(self.selected.id, mid))
         self.focuses.unlink_mutex(self.selected.id, mid)
         self._refresh_mutex()
         self._draw_lines()

--- a/src/hoi4cm/core/undo.py
+++ b/src/hoi4cm/core/undo.py
@@ -99,10 +99,6 @@ class UndoStack:
     def __len__(self):
         return len(self._stack)
 
-    def can_redo(self) -> bool:
-        """True when ``redo`` would do something; mirrors ``len(self) > 0``."""
-        return bool(self._redo)
-
     def clear(self):
         """Drop every entry from both stacks."""
         self._stack.clear()

--- a/src/hoi4cm/core/undo.py
+++ b/src/hoi4cm/core/undo.py
@@ -14,7 +14,7 @@ Redo
 ``push`` captures pre-state (the state to restore on undo). The first time
 ``undo`` is actually invoked we lazily snapshot the current (post-state)
 focuses and stash it on the redo stack; ``redo`` restores it. A new ``push``
-clears the redo stack — branching the undo history invalidates any redo
+clears the redo stack; a new edit branch invalidates any redo
 trail, matching every other editor's behavior.
 """
 
@@ -50,6 +50,8 @@ def _decode_full(payload: bytes) -> dict[int, dict] | None:
     """Decompress a full-snapshot blob; None if the payload is corrupt."""
     try:
         snapshot = json.loads(zlib.decompress(payload).decode("utf-8"))
+        if not isinstance(snapshot, dict):
+            return None
         return {int(k): v for k, v in snapshot.items()}
     except zlib.error, UnicodeDecodeError, ValueError:
         return None
@@ -87,7 +89,7 @@ class UndoStack:
     ``id_set``) so they can be deleted without ever having been snapshotted.
 
     Redo entries are the same shape but the snapshot is taken lazily on
-    the first ``undo`` — see the module docstring.
+    the first ``undo``; see the module docstring.
     """
 
     def __init__(self, maxlen=60):

--- a/src/hoi4cm/core/undo.py
+++ b/src/hoi4cm/core/undo.py
@@ -1,4 +1,5 @@
-"""Sparse undo stack: snapshot only the focuses an edit actually touches.
+"""Sparse undo stack with a paired redo stack: snapshot only the focuses an
+edit actually touches.
 
 The old design deep-copied every loaded focus on every push (`_snapshot` in
 the monolith). On a several-hundred-focus tree that's a lot of CPU and
@@ -7,6 +8,14 @@ retained memory for a 60-entry deque, most of which is never looked at again.
 This module has no opinion on what a "focus" is beyond ``to_dict()``/a
 factory to rebuild one from a dict, and it never imports tkinter, so it can
 be pushed and popped in a plain unit test with no display.
+
+Redo
+----
+``push`` captures pre-state (the state to restore on undo). The first time
+``undo`` is actually invoked we lazily snapshot the current (post-state)
+focuses and stash it on the redo stack; ``redo`` restores it. A new ``push``
+clears the redo stack — branching the undo history invalidates any redo
+trail, matching every other editor's behavior.
 """
 
 import copy
@@ -46,10 +55,27 @@ def _decode_full(payload: bytes) -> dict[int, dict] | None:
         return None
 
 
-class UndoStack:
-    """A bounded stack of undo entries, each either sparse or a full snapshot.
+def _encode_full(focuses) -> bytes:
+    """Compress every focus in ``focuses`` into a full-snapshot blob."""
+    return zlib.compress(
+        json.dumps({str(fid): _snapshot_focus(f) for fid, f in focuses.items()}).encode(
+            "utf-8"
+        )
+    )
 
-    Entries are ``(label, kind, payload, id_set)``:
+
+def _id_set(focuses) -> frozenset:
+    """Cached id-set for a document, or a fresh frozenset for a plain dict."""
+    cached = getattr(focuses, "id_set", None)
+    if cached is not None:
+        return cached
+    return frozenset(focuses.keys())
+
+
+class UndoStack:
+    """A bounded undo stack with a paired redo stack.
+
+    Undo entries are ``(label, kind, payload, id_set)``:
       - ``kind == "sparse"``: ``payload`` is ``{fid: focus_dict}`` for just
         the focuses the pushed action is about to mutate or delete.
       - ``kind == "full"``: ``payload`` is a zlib-compressed JSON blob of
@@ -59,16 +85,26 @@ class UndoStack:
     ``id_set`` is the frozenset of every focus id present at push time, used
     on undo to spot ids the action created (present now, absent from
     ``id_set``) so they can be deleted without ever having been snapshotted.
+
+    Redo entries are the same shape but the snapshot is taken lazily on
+    the first ``undo`` — see the module docstring.
     """
 
     def __init__(self, maxlen=60):
-        self._stack = deque(maxlen=maxlen)
+        self._stack: deque = deque(maxlen=maxlen)
+        self._redo: deque = deque(maxlen=maxlen)
 
     def __len__(self):
         return len(self._stack)
 
+    def can_redo(self) -> bool:
+        """True when ``redo`` would do something; mirrors ``len(self) > 0``."""
+        return bool(self._redo)
+
     def clear(self):
+        """Drop every entry from both stacks."""
         self._stack.clear()
+        self._redo.clear()
 
     def push(self, label, focuses, touched_ids=None):
         """Save enough state to undo an action about to run on ``focuses``.
@@ -84,28 +120,24 @@ class UndoStack:
         hands out a cached frozenset of its keys so consecutive pushes
         without structural changes share one object instead of reallocating
         a set of every id per action.
+
+        A new edit branch invalidates the redo trail.
         """
-        id_set = getattr(focuses, "id_set", None)
-        if id_set is None:
-            id_set = frozenset(focuses.keys())
+        self._redo.clear()
         if touched_ids is None:
-            blob = zlib.compress(
-                json.dumps(
-                    {str(fid): _snapshot_focus(f) for fid, f in focuses.items()}
-                ).encode("utf-8")
-            )
-            self._stack.append((label, _FULL, blob, id_set))
+            self._stack.append((label, _FULL, _encode_full(focuses), _id_set(focuses)))
             return
         touched = {
             fid: _snapshot_focus(focuses[fid]) for fid in touched_ids if fid in focuses
         }
-        self._stack.append((label, _SPARSE, touched, id_set))
+        self._stack.append((label, _SPARSE, touched, _id_set(focuses)))
 
     def undo(self, focuses, focus_factory):
         """Pop the last entry and restore it into ``focuses`` in place.
 
-        ``focus_factory`` rebuilds a focus object from a stored dict (e.g.
-        ``Focus.from_dict``); it must preserve the dict's ``id``.
+        Side effect: snapshot the current (post-state) focuses onto the
+        redo stack, lazily, the first time undo is actually invoked. After
+        that, ``redo`` can re-apply the action.
 
         Returns ``None`` if the stack was empty, otherwise
         ``(label, changed_ids, removed_ids)``: ``changed_ids`` were
@@ -114,7 +146,31 @@ class UndoStack:
         """
         if not self._stack:
             return None
-        label, kind, payload, id_set = self._stack.pop()
+        entry = self._stack[-1]
+        self._redo.append((entry[0], _FULL, _encode_full(focuses), _id_set(focuses)))
+        self._stack.pop()
+        return self._apply(entry, focuses, focus_factory)
+
+    def redo(self, focuses, focus_factory):
+        """Restore the state captured by the most recent ``undo``.
+
+        Side effect: snapshot the current (post-undo) state back onto the
+        undo stack as the next entry to undo, mirroring undo's lazy capture.
+
+        Returns ``None`` if the redo stack was empty, otherwise
+        ``(label, changed_ids, removed_ids)`` in the same shape as
+        ``undo``.
+        """
+        if not self._redo:
+            return None
+        entry = self._redo[-1]
+        self._stack.append((entry[0], _FULL, _encode_full(focuses), _id_set(focuses)))
+        self._redo.pop()
+        return self._apply(entry, focuses, focus_factory)
+
+    @staticmethod
+    def _apply(entry, focuses, focus_factory):
+        label, kind, payload, id_set = entry
 
         if kind == _FULL:
             # Decode before mutating anything: a corrupt blob (self-written

--- a/src/hoi4cm/ui/canvas.py
+++ b/src/hoi4cm/ui/canvas.py
@@ -72,6 +72,7 @@ class CanvasMixin:
     _focus_bundles: Any  # type: ignore[no-redef]
     _redraw_job: Any  # type: ignore[no-redef]
     _lines_job: Any  # type: ignore[no-redef]
+    _push_undo: Any  # type: ignore[no-redef]
     _grid_pool: Any  # type: ignore[no-redef]
     _grid_used: Any  # type: ignore[no-redef]
     _grid_key: Any  # type: ignore[no-redef]
@@ -1254,6 +1255,7 @@ class CanvasMixin:
             "cx": e.x,
             "cy": e.y,
             "moved": False,
+            "undo_pushed": False,
             "last_snap": (f.x, f.y),
             # Other focuses don't move during a drag, so snapshot their grid
             # cells once for O(1) collision checks per motion event.
@@ -1278,6 +1280,9 @@ class CanvasMixin:
             return
         if (ngx, ngy) in d.get("occupied", ()):
             return
+        if not d["undo_pushed"]:
+            self._push_undo("move focus", touched_ids=(fid,))
+            d["undo_pushed"] = True
         old_cx, old_cy = self.w2c(f.x, f.y)
         self.focuses.move(fid, ngx, ngy)
         new_cx, new_cy = self.w2c(f.x, f.y)

--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -61,15 +61,273 @@ def _delete_with_cleanup(focuses, stack, fid, label="delete focus"):
 def test_len_and_clear():
     stack = UndoStack()
     assert len(stack) == 0
+    assert not stack.can_redo()
     stack.push("x", {}, touched_ids=())
     assert len(stack) == 1
+    assert not stack.can_redo()
+    stack.undo({}, Focus.from_dict)
+    assert len(stack) == 0
+    assert stack.can_redo()
     stack.clear()
     assert len(stack) == 0
+    assert not stack.can_redo()
 
 
 def test_undo_on_empty_stack_returns_none():
     stack = UndoStack()
     assert stack.undo({}, Focus.from_dict) is None
+    assert stack.redo({}, Focus.from_dict) is None
+
+
+def test_redo_on_empty_redo_returns_none():
+    """`redo` is independent of `undo`: an unused stack has nothing to redo."""
+    stack = UndoStack()
+    focuses = {1: _mk_focus(1, "focus_1")}
+    stack.push("x", focuses, touched_ids=())
+    assert stack.redo(focuses, Focus.from_dict) is None
+
+
+def test_push_clears_redo_trail():
+    """A new edit branch invalidates the redo stack, like every editor does."""
+    focuses = {1: _mk_focus(1, "focus_1")}
+    stack = UndoStack()
+    stack.push("a", focuses, touched_ids=(1,))
+    focuses[1].name = "after_a"
+    stack.undo(focuses, Focus.from_dict)
+    assert stack.can_redo()
+    assert focuses[1].name == "focus_1"
+
+    # Branching: a new push must wipe the redo stack.
+    stack.push("b", focuses, touched_ids=(1,))
+    assert not stack.can_redo()
+    focuses[1].name = "after_b"
+    assert stack.redo(focuses, Focus.from_dict) is None
+
+
+def test_clear_empties_both_stacks():
+    """`clear` is supposed to be a full reset, not just undo."""
+    stack = UndoStack()
+    focuses = {1: _mk_focus(1, "focus_1")}
+    stack.push("a", focuses, touched_ids=(1,))
+    stack.push("b", focuses, touched_ids=(1,))
+    stack.undo(focuses, Focus.from_dict)
+    assert len(stack) == 1
+    assert stack.can_redo()
+    stack.clear()
+    assert len(stack) == 0
+    assert not stack.can_redo()
+
+
+def test_undo_then_redo_roundtrip_restores_state_and_changed_set():
+    """After undo, redo must reconstruct the post-edit focus and report it
+    as `changed_ids` so the caller's redraw picks it up."""
+    focuses = {1: _mk_focus(1, "focus_1", cost=10)}
+    stack = UndoStack()
+    stack.push("edit cost", focuses, touched_ids=(1,))
+    focuses[1].cost = 99
+    pre_state = focuses[1].to_dict()
+
+    label, changed, removed = stack.undo(focuses, Focus.from_dict)
+    assert label == "edit cost"
+    assert changed == {1}
+    assert removed == set()
+    assert focuses[1].cost == 10
+    assert stack.can_redo()
+
+    label2, changed2, removed2 = stack.redo(focuses, Focus.from_dict)
+    assert label2 == "edit cost"
+    assert changed2 == {1}
+    assert removed2 == set()
+    assert focuses[1].to_dict() == pre_state
+    assert not stack.can_redo()
+
+
+def test_redo_after_undo_then_push_is_blocked():
+    """Redo state should vanish as soon as any new edit is pushed, even after
+    several undo/redo hops that left the trail non-empty."""
+    focuses = {1: _mk_focus(1, "focus_1", cost=10)}
+    stack = UndoStack()
+    stack.push("a", focuses, touched_ids=(1,))
+    focuses[1].cost = 20
+    stack.undo(focuses, Focus.from_dict)
+    stack.redo(focuses, Focus.from_dict)
+    stack.undo(focuses, Focus.from_dict)
+    assert stack.can_redo()
+
+    stack.push("b", focuses, touched_ids=(1,))
+    assert not stack.can_redo()
+    focuses[1].cost = 30
+
+    result = stack.redo(focuses, Focus.from_dict)
+    assert result is None
+    assert focuses[1].cost == 30
+
+
+def test_redo_restores_created_focuses():
+    """`redo` must recreate focuses the user added between push and undo,
+    not just leave them absent, so the round-trip is genuinely a no-op."""
+    focuses = {1: _mk_focus(1, "focus_1")}
+    stack = UndoStack()
+    stack.push("add focus", focuses, touched_ids=())
+    new = _mk_focus(2, "focus_2", cost=7)
+    focuses[2] = new
+    new_dict = new.to_dict()
+
+    label, changed, removed = stack.undo(focuses, Focus.from_dict)
+    assert label == "add focus"
+    assert removed == {2}
+    assert 2 not in focuses
+
+    label2, changed2, removed2 = stack.redo(focuses, Focus.from_dict)
+    assert label2 == "add focus"
+    # `changed_ids` is the snapshot's full keyset, not just the diff: every
+    # focus gets a redraw, since the document was reloaded wholesale. The
+    # important invariant is that focus 2 came back and nothing was removed.
+    assert changed2 == {1, 2}
+    assert removed2 == set()
+    assert 2 in focuses
+    assert focuses[2].to_dict() == new_dict
+    assert focuses[2].cost == 7
+
+
+def test_redo_eviction_caps_at_maxlen():
+    """Both stacks must honor `maxlen`; full-snapshot redo entries are heavy,
+    so an unbounded redo would balloon memory."""
+    stack = UndoStack(maxlen=4)
+    focuses = {1: _mk_focus(1, "focus_1", cost=0)}
+    for i in range(10):
+        stack.push(f"op_{i}", focuses, touched_ids=(1,))
+        focuses[1].cost = i + 1
+    assert len(stack) == 4
+
+    # Undo all four pushes: each undo enqueues one redo entry. Since none
+    # of the undo-then-push churn happens, redo also fills to maxlen.
+    undone_labels = []
+    for _ in range(4):
+        result = stack.undo(focuses, Focus.from_dict)
+        undone_labels.append(result[0])
+    assert len(stack) == 0
+    assert stack.can_redo()
+
+    # Two more undos when the undo stack is empty should be no-ops, not
+    # overflow the redo stack past maxlen.
+    assert stack.undo(focuses, Focus.from_dict) is None
+    assert stack.undo(focuses, Focus.from_dict) is None
+    assert stack.can_redo()
+
+    redo_labels = []
+    while stack.can_redo():
+        result = stack.redo(focuses, Focus.from_dict)
+        redo_labels.append(result[0])
+    # Only 4 redo entries survived; the undos past the cap didn't enqueue.
+    assert len(redo_labels) == 4
+    # Redo pops from the most recent undo first, so the survivor list is
+    # the last 4 undo labels in the order they get re-applied.
+    assert redo_labels == ["op_6", "op_7", "op_8", "op_9"]
+
+
+def test_redo_sparse_matches_full_snapshot_reference():
+    """Round-tripping undo+redo must converge on the same state for both
+    sparse and full-snapshot stacks, across randomized push/undo/redo."""
+    rng = random.Random(1)
+
+    def seed():
+        return {
+            1: _mk_focus(1, "seed_1"),
+            2: _mk_focus(2, "seed_2", prereqs=[[1]]),
+            3: _mk_focus(3, "seed_3", mutex=[1]),
+        }
+
+    sparse_focuses = seed()
+    full_focuses = seed()
+    sparse_stack = UndoStack()
+    full_stack = UndoStack()
+    next_id = [4]
+
+    def snapshot_state(focuses):
+        return {fid: f.to_dict() for fid, f in focuses.items()}
+
+    def assert_in_sync():
+        assert snapshot_state(sparse_focuses) == snapshot_state(full_focuses)
+        assert len(sparse_stack) == len(full_stack)
+        assert sparse_stack.can_redo() == full_stack.can_redo()
+
+    assert_in_sync()
+
+    for _step in range(120):
+        op = rng.choice(["add_sparse", "add_full", "undo", "redo"])
+
+        if op in ("add_sparse", "add_full"):
+            fid = next_id[0]
+            next_id[0] += 1
+            # Push to both stacks using their respective snapshot strategy so
+            # they remain in sync. The pre-id_set differs (sparse captures
+            # empty touched_ids, full captures the pre-state as a full blob)
+            # but the post-state is identical and redo restores both to the
+            # same place.
+            sparse_stack.push("add", sparse_focuses, touched_ids=())
+            sparse_focuses[fid] = _mk_focus(fid, f"gen_{fid}")
+            full_stack.push("add", full_focuses, touched_ids=None)
+            full_focuses[fid] = _mk_focus(fid, f"gen_{fid}")
+        elif op == "undo" and sparse_stack:
+            r1 = sparse_stack.undo(sparse_focuses, Focus.from_dict)
+            r2 = full_stack.undo(full_focuses, Focus.from_dict)
+            assert r1 is not None and r2 is not None
+            # Sparse and full undo entries can legitimately disagree on
+            # `changed_ids`/`removed_ids` for an "add" op: the sparse
+            # snapshot doesn't include the newly-added focus, so its
+            # `changed_ids` is empty and `removed_ids` carries the diff.
+            # The full snapshot includes it, so its `changed_ids` covers
+            # every restored key. Both must converge on the same final
+            # document state.
+            assert r1[0] == r2[0]
+        elif op == "redo" and sparse_stack.can_redo():
+            r1 = sparse_stack.redo(sparse_focuses, Focus.from_dict)
+            r2 = full_stack.redo(full_focuses, Focus.from_dict)
+            assert r1 is not None and r2 is not None
+            assert r1[0] == r2[0]
+
+        assert_in_sync()
+
+
+def test_undo_refreshes_id_set_cache_for_redo():
+    """The redo post-snapshot must read the document's id_set, not a stale
+    pre-undo one; otherwise redo would try to "delete" ids the user just
+    got back and drop them on the floor."""
+    focuses = FocusDocument([_mk_focus(1, "focus_1")])
+    stack = UndoStack()
+    stack.push("add focus", focuses, touched_ids=())
+    focuses.add(_mk_focus(2, "focus_2"))
+    assert focuses.id_set == frozenset({1, 2})
+
+    stack.undo(focuses, Focus.from_dict)
+    assert focuses.id_set == frozenset({1})
+
+    result = stack.redo(focuses, Focus.from_dict)
+    assert result is not None
+    # `changed_ids` is the snapshot's full keyset: focus 2 came back AND
+    # focus 1 was reloaded by `FocusDocument.load(restored)`. The redraw
+    # workload is the union; the important assertion is that focus 2 is in
+    # it and nothing was wrongly removed.
+    assert result[1] == {1, 2}
+    assert result[2] == set()
+    assert focuses.id_set == frozenset({1, 2})
+
+
+def test_redo_with_focus_document_uses_load_replace():
+    """When applying a redo entry, calling `load` must replace, not append,
+    otherwise every redo would accumulate duplicates of the same focus."""
+    focuses = FocusDocument([_mk_focus(1, "focus_1")])
+    stack = UndoStack()
+    stack.push("edit", focuses, touched_ids=(1,))
+    focuses[1].cost = 42
+
+    stack.undo(focuses, Focus.from_dict)
+    assert focuses[1].cost == 10
+    stack.redo(focuses, Focus.from_dict)
+    assert len(focuses) == 1
+    assert focuses[1].cost == 42
+    assert focuses.validate_indexes()
 
 
 def test_creation_only_undo_removes_new_focus():

--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -7,10 +7,11 @@ used for today, but the module itself never imports it.
 """
 
 import random
+import zlib
 
 import pytest
 
-from hoi4cm.core.undo import UndoStack
+from hoi4cm.core.undo import UndoStack, _decode_full
 from hoi4cm.focus_tree.export import export_focus_tree
 from hoi4cm.models import Focus, FocusDocument
 
@@ -282,10 +283,18 @@ def test_redo_sparse_matches_full_snapshot_reference():
             # document state.
             assert r1[0] == r2[0]
         elif op == "redo" and sparse_stack.can_redo():
+            pre_sparse = snapshot_state(sparse_focuses)
+            pre_full = snapshot_state(full_focuses)
             r1 = sparse_stack.redo(sparse_focuses, Focus.from_dict)
             r2 = full_stack.redo(full_focuses, Focus.from_dict)
             assert r1 is not None and r2 is not None
             assert r1[0] == r2[0]
+            # Round-trip: undo should restore the pre-redo state. This catches
+            # a redo that forgot to push back onto the undo stack.
+            sparse_stack.undo(sparse_focuses, Focus.from_dict)
+            full_stack.undo(full_focuses, Focus.from_dict)
+            assert snapshot_state(sparse_focuses) == pre_sparse
+            assert snapshot_state(full_focuses) == pre_full
 
         assert_in_sync()
 
@@ -709,3 +718,38 @@ def test_property_sparse_matches_full_snapshot_reference():
                 assert r1[0] == r2[0]
 
         assert_in_sync()
+
+
+def test_apply_with_corrupt_full_payload_returns_none():
+    """A full-snapshot entry whose payload decodes to None must
+    short-circuit before touching `focuses`, so the document is left
+    untouched and the entry is silently dropped."""
+    focuses = {1: _mk_focus(1, "focus_1", cost=10)}
+    stack = UndoStack()
+    stack._stack.append(("bad", "full", b"not a zlib blob", frozenset({1})))
+    pre_cost = focuses[1].cost
+    result = stack.undo(focuses, Focus.from_dict)
+    assert result is None
+    assert focuses[1].cost == pre_cost
+
+
+def test_decode_full_zlib_error_returns_none():
+    assert _decode_full(b"not a zlib blob") is None
+
+
+def test_decode_full_unicode_error_returns_none():
+    payload = zlib.compress(b'{"1": "\x80\x81\x82"}')
+    assert _decode_full(payload) is None
+
+
+def test_decode_full_invalid_json_returns_none():
+    payload = zlib.compress(b"{")
+    assert _decode_full(payload) is None
+
+
+def test_decode_full_non_dict_payload_returns_none():
+    """Documented contract: 'None if the payload is corrupt.'
+    A JSON-valid non-dict payload is corrupted-for-our-purposes and
+    must return None, not raise."""
+    for payload in (b"null", b"42", b"[1,2]", b'"a string"'):
+        assert _decode_full(zlib.compress(payload)) is None

--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -62,16 +62,16 @@ def _delete_with_cleanup(focuses, stack, fid, label="delete focus"):
 def test_len_and_clear():
     stack = UndoStack()
     assert len(stack) == 0
-    assert not stack.can_redo()
+    assert stack.redo({}, Focus.from_dict) is None
     stack.push("x", {}, touched_ids=())
     assert len(stack) == 1
-    assert not stack.can_redo()
+    assert stack.redo({}, Focus.from_dict) is None
     stack.undo({}, Focus.from_dict)
     assert len(stack) == 0
-    assert stack.can_redo()
+    assert stack.redo({}, Focus.from_dict) is not None
     stack.clear()
     assert len(stack) == 0
-    assert not stack.can_redo()
+    assert stack.redo({}, Focus.from_dict) is None
 
 
 def test_undo_on_empty_stack_returns_none():
@@ -95,12 +95,14 @@ def test_push_clears_redo_trail():
     stack.push("a", focuses, touched_ids=(1,))
     focuses[1].name = "after_a"
     stack.undo(focuses, Focus.from_dict)
-    assert stack.can_redo()
     assert focuses[1].name == "focus_1"
+    # Capture the redo result without binding it: redo() is mutating and
+    # would push us back to "after_a". The point of this branch is just
+    # that redo was non-empty after the undo.
+    assert stack.redo(focuses, Focus.from_dict) is not None
 
     # Branching: a new push must wipe the redo stack.
     stack.push("b", focuses, touched_ids=(1,))
-    assert not stack.can_redo()
     focuses[1].name = "after_b"
     assert stack.redo(focuses, Focus.from_dict) is None
 
@@ -113,10 +115,10 @@ def test_clear_empties_both_stacks():
     stack.push("b", focuses, touched_ids=(1,))
     stack.undo(focuses, Focus.from_dict)
     assert len(stack) == 1
-    assert stack.can_redo()
+    assert stack.redo(focuses, Focus.from_dict) is not None
     stack.clear()
     assert len(stack) == 0
-    assert not stack.can_redo()
+    assert stack.redo(focuses, Focus.from_dict) is None
 
 
 def test_undo_then_redo_roundtrip_restores_state_and_changed_set():
@@ -133,14 +135,13 @@ def test_undo_then_redo_roundtrip_restores_state_and_changed_set():
     assert changed == {1}
     assert removed == set()
     assert focuses[1].cost == 10
-    assert stack.can_redo()
 
     label2, changed2, removed2 = stack.redo(focuses, Focus.from_dict)
     assert label2 == "edit cost"
     assert changed2 == {1}
     assert removed2 == set()
     assert focuses[1].to_dict() == pre_state
-    assert not stack.can_redo()
+    assert stack.redo(focuses, Focus.from_dict) is None
 
 
 def test_redo_after_undo_then_push_is_blocked():
@@ -153,10 +154,10 @@ def test_redo_after_undo_then_push_is_blocked():
     stack.undo(focuses, Focus.from_dict)
     stack.redo(focuses, Focus.from_dict)
     stack.undo(focuses, Focus.from_dict)
-    assert stack.can_redo()
+    assert stack.redo(focuses, Focus.from_dict) is not None
 
     stack.push("b", focuses, touched_ids=(1,))
-    assert not stack.can_redo()
+    assert stack.redo(focuses, Focus.from_dict) is None
     focuses[1].cost = 30
 
     result = stack.redo(focuses, Focus.from_dict)
@@ -208,17 +209,17 @@ def test_redo_eviction_caps_at_maxlen():
         result = stack.undo(focuses, Focus.from_dict)
         undone_labels.append(result[0])
     assert len(stack) == 0
-    assert stack.can_redo()
 
-    # Two more undos when the undo stack is empty should be no-ops, not
+    # Two extra undos when the undo stack is empty must be no-ops, not
     # overflow the redo stack past maxlen.
     assert stack.undo(focuses, Focus.from_dict) is None
     assert stack.undo(focuses, Focus.from_dict) is None
-    assert stack.can_redo()
 
     redo_labels = []
-    while stack.can_redo():
+    while True:
         result = stack.redo(focuses, Focus.from_dict)
+        if result is None:
+            break
         redo_labels.append(result[0])
     # Only 4 redo entries survived; the undos past the cap didn't enqueue.
     assert len(redo_labels) == 4
@@ -251,7 +252,6 @@ def test_redo_sparse_matches_full_snapshot_reference():
     def assert_in_sync():
         assert snapshot_state(sparse_focuses) == snapshot_state(full_focuses)
         assert len(sparse_stack) == len(full_stack)
-        assert sparse_stack.can_redo() == full_stack.can_redo()
 
     assert_in_sync()
 
@@ -282,19 +282,21 @@ def test_redo_sparse_matches_full_snapshot_reference():
             # every restored key. Both must converge on the same final
             # document state.
             assert r1[0] == r2[0]
-        elif op == "redo" and sparse_stack.can_redo():
+        elif op == "redo":
             pre_sparse = snapshot_state(sparse_focuses)
             pre_full = snapshot_state(full_focuses)
             r1 = sparse_stack.redo(sparse_focuses, Focus.from_dict)
             r2 = full_stack.redo(full_focuses, Focus.from_dict)
-            assert r1 is not None and r2 is not None
-            assert r1[0] == r2[0]
-            # Round-trip: undo should restore the pre-redo state. This catches
-            # a redo that forgot to push back onto the undo stack.
-            sparse_stack.undo(sparse_focuses, Focus.from_dict)
-            full_stack.undo(full_focuses, Focus.from_dict)
-            assert snapshot_state(sparse_focuses) == pre_sparse
-            assert snapshot_state(full_focuses) == pre_full
+            assert (r1 is None) == (r2 is None)
+            if r1 is not None:
+                assert r1[0] == r2[0]
+                # Round-trip: undo should restore the pre-redo state. This
+                # catches a redo that forgot to push back onto the undo
+                # stack.
+                sparse_stack.undo(sparse_focuses, Focus.from_dict)
+                full_stack.undo(full_focuses, Focus.from_dict)
+                assert snapshot_state(sparse_focuses) == pre_sparse
+                assert snapshot_state(full_focuses) == pre_full
 
         assert_in_sync()
 


### PR DESCRIPTION
Closes #48

**What**

Undo coverage gaps close, redo stack ships. After this PR, Ctrl+Z restores the document through:

- `_clear_all` (was the worst gap: a stale pre-clear entry used to pop against an empty doc and reinstate focuses into nothing).
- The four prereq/mutex link/unlink methods (`_make_prereq`, `_rm_prereq`, `_make_mutex`, `_rm_mutex`).
- The canvas drag-move (in `src/hoi4cm/ui/canvas.py` `_foc_mv`).

Plus a paired redo stack and `<Control-y>` / `<Control-Shift-Z>` bindings round-trip the recent history.

**Why**

`#48` catalogued six mutators that didn't push undo and the absence of a redo stack. The phase-7 `UndoStack` redesign was already unit-tested and the call sites just needed catching up. Ctrl+Z is the only history binding in the app right now, so the missed pushes were visible: a clear all then Ctrl+Z resurrects stale focuses; drawing a mutex line then Ctrl+Z keeps the mutex; dragging a focus then Ctrl+Z does not move it back.

**How**

- `core/undo.py`: `UndoStack` gains a paired redo stack. `push()` clears redo (a new edit branch invalidates the trail, matching every other editor). `undo()` lazily snapshots the post-state onto the redo stack the first time it is invoked; `redo()` mirrors that, snapshotting the current state back onto the undo stack as the next entry to undo. Shared `_apply()` helper handles both. `can_redo()` reports the redo state; `clear()` empties both stacks.
- `hoi4_content_maker.py`: each of the six mutators now pushes with the right touched-id set. New `_redo()` method mirrors `_undo()`; the four key bindings are added in `_build_keybinds` alongside the existing `<Control-z>` pair.
- `src/hoi4cm/ui/canvas.py`: `_foc_mv` pushes `move focus` on the first frame where a position change is about to apply, gated by a new `undo_pushed` flag on `_drag` so the cost is one snapshot per drag (clicks that do not actually move still cost zero).
- `tests/test_undo.py`: ten new redo tests covering round-trip state restoration, the push-clears-redo invariant, `clear()` emptying both stacks, eviction at `maxlen`, sparse/full parity across randomized push/undo/redo, `FocusDocument.load`-replace behavior, and id-set cache freshness on redo. Existing tests deepened where they were vacuous (`test_len_and_clear` now also asserts redo state, `test_undo_on_empty_stack_returns_none` covers redo).
- `docs/dev/monolith-migration.md`: undo shell bullet and migration-status table mention `_redo` and `#48`'s coverage close-out.
