### PR TITLE
Clarify CC BY-ND 4.0 licensing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![Python](https://img.shields.io/badge/Python-3.14%2B-blue?logo=python)
 ![Platform](https://img.shields.io/badge/Platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey)
-![License](https://img.shields.io/badge/License-Proprietary-red)
+[![License: CC BY-ND 4.0](https://img.shields.io/badge/License-CC_BY--ND_4.0-blue)](LICENSE)
 ![Version](https://img.shields.io/badge/Version-2.0-gold)
 
 ---
@@ -27,7 +27,7 @@ HOI4 Content Maker is a standalone Python/Tkinter desktop application that lets 
 
 ## Screenshots
 
-> *Coming soon — contributions welcome.*
+> *Coming soon.*
 
 ---
 
@@ -335,7 +335,10 @@ Use **Save to Mod** (where available) to write directly to the correct path insi
 
 ## Contributing
 
-This project is currently proprietary. Forks and redistribution are not permitted without explicit written permission from the author.
+CC BY-ND 4.0 does not grant permission to share modified versions. Before
+publishing a modified fork or submitting code, read
+[CONTRIBUTING.md](docs/CONTRIBUTING.md) and obtain separate permission from the
+maintainers.
 
 If you find a bug or have a feature request, please open an **Issue** on GitHub.
 
@@ -349,9 +352,18 @@ See [CHANGELOG.md](CHANGELOG.md) for the full version history.
 
 ## License
 
-Copyright © 2025 Millennium Dawn Team. All Rights Reserved.
+Copyright © 2025 Millennium Dawn Team.
 
-This software is **open-source**. See the licence header in `hoi4_content_maker.py` for full terms.
+This repository is **source-available** under the
+[Creative Commons Attribution-NoDerivatives 4.0 International License](LICENSE).
+It is not open-source software under the conventional
+[Open Source Definition](https://opensource.org/osd).
+
+Subject to the licence terms, unmodified material may be copied and
+redistributed, including commercially, with attribution. Adapted material may
+be created for private use but may not be shared without separate permission.
+The `LICENSE` file contains the complete terms and controls if this summary
+differs from them.
 
 ---
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -80,11 +80,19 @@ linting until it is refactored into the package.
 
 ---
 
-## Licence Note
+## Licence and Code Submissions
 
-This project is **proprietary**. Submitting a contribution (pull request, patch, or otherwise) is taken as agreement that you grant the author (Blazer) full rights to use, modify, and distribute your contribution under the existing proprietary licence, with no obligation to credit contributors separately.
+This repository is source-available under
+[CC BY-ND 4.0](../LICENSE). That licence permits redistribution of unmodified
+material, but it does not grant permission to share adapted material.
 
-If you are not comfortable with these terms, please limit your participation to opening Issues.
+Before publishing a modified fork or submitting a patch or pull request, obtain
+separate permission from the maintainers. Contact them using the address below
+and wait for written confirmation of the terms that will apply to your
+submission.
+
+Bug reports and feature requests may be submitted as GitHub Issues without
+code-submission permission.
 
 ---
 

--- a/hoi4_content_maker.py
+++ b/hoi4_content_maker.py
@@ -5,35 +5,13 @@
 # =================================================================
 #
 #  COPYRIGHT NOTICE
-#  Copyright (c) 2025 Millennium Dawn Team. All Rights Reserved.
+#  Copyright (c) 2025 Millennium Dawn Team.
 #
-#  This software, including all source code, assets, and
-#  associated files, is the exclusive intellectual property
-#  of the Millennium Dawn Team ("the Author").
+#  SPDX-License-Identifier: CC-BY-ND-4.0
 #
-#  PROPRIETARY LICENCE — ALL RIGHTS RESERVED
-#
-#  This software is NOT open-source and is NOT free to use
-#  without explicit written permission from the Author.
-#
-#  Without prior written authorisation you may NOT:
-#    - Copy, reproduce, or redistribute this software
-#      or any portion of its source code
-#    - Modify, adapt, or create derivative works
-#    - Use this software commercially or include it in
-#      any other project, product, or distribution
-#    - Share, upload, or publish this software in source
-#      or compiled form on any platform
-#
-#  Permitted use is limited to:
-#    - Personal, private, non-commercial use by the
-#      individual who obtained the software directly
-#      from the Author
-#
-#  Unauthorised use, duplication, or distribution of this
-#  software, in whole or in part, is strictly prohibited
-#  and may result in civil and/or criminal penalties under
-#  applicable copyright law.
+#  Licensed under the Creative Commons Attribution-NoDerivatives
+#  4.0 International License. See LICENSE in the repository root
+#  for the complete terms.
 #
 #  CONTACT
 #  For licensing enquiries, permissions, or general contact:
@@ -45,7 +23,7 @@
 Content Maker for Hearts of Iron 4
 HOI4 Content Maker  —  v2.0  |  Millennium Dawn Team
 
-Copyright (c) 2025 Millennium Dawn Team. All Rights Reserved.
+Copyright (c) 2025 Millennium Dawn Team.
 
 Wiki    : https://hoi4.paradoxwikis.com/National_focus_modding
 Requires: Python 3.14+  (tkinter built-in, no pip install needed)


### PR DESCRIPTION
Closes #102

## What
- Describe the repository as source-available under CC BY-ND 4.0.
- Correct the README badge and licence summary.
- Replace the conflicting proprietary source header with an SPDX licence pointer.
- Require separate permission before modified forks or code submissions are shared.

## Why
The README, source header, and contribution guide contradicted the root CC BY-ND 4.0 licence about open-source status and redistribution rights.

## How
Treat the existing root LICENSE as authoritative, summarize its unmodified redistribution and no-derivatives terms, and remove duplicated proprietary wording that imposed different restrictions.