### PR TITLE
Strengthen canvas drag undo coverage

### DIFF
--- a/tests/test_undo_call_sites.py
+++ b/tests/test_undo_call_sites.py
@@ -239,7 +239,7 @@ def test_drag_click_without_grid_move_does_not_push_undo():
     CanvasMixin._foc_pr(
         cast(CanvasMixin, app), focus.id, SimpleNamespace(x=0, y=0, state=0)
     )
-    CanvasMixin._foc_mv(cast(CanvasMixin, app), focus.id, SimpleNamespace(x=4, y=4))
+    CanvasMixin._foc_mv(cast(CanvasMixin, app), focus.id, SimpleNamespace(x=3, y=3))
 
     app._push_undo.assert_not_called()
     assert (focus.x, focus.y) == (0, 0)
@@ -313,6 +313,9 @@ def test_drag_move_pushes_once_with_moved_focus_id():
     CanvasMixin._foc_pr(
         cast(CanvasMixin, app), focus.id, SimpleNamespace(x=0, y=0, state=0)
     )
+    CanvasMixin._foc_mv(cast(CanvasMixin, app), focus.id, SimpleNamespace(x=3, y=3))
+    app._push_undo.assert_not_called()
+
     CanvasMixin._foc_mv(
         cast(CanvasMixin, app), focus.id, SimpleNamespace(x=XGRID, y=YGRID)
     )


### PR DESCRIPTION
Closes #99

**What**

- Tightens the no-op drag test to use a genuinely sub-threshold 3 px event.
- Adds a sub-threshold event to the same drag stream before the first grid move.
- Asserts no undo is pushed before the threshold is crossed.

**Why**

The existing tests covered the pieces separately, but did not prove the complete event sequence required by the drag threshold: no push before crossing, one push on the first valid move, and no duplicate pushes afterward.

**How**

The test reuses the existing `_UndoCallSiteApp` and `FocusDocument` harness, so it exercises `CanvasMixin._foc_pr` and `_foc_mv` directly without adding Tk coupling.