### PR TITLE
Finish leftover atomic writes for scripted loc

### DIFF
--- a/src/hoi4cm/script/__init__.py
+++ b/src/hoi4cm/script/__init__.py
@@ -1,5 +1,10 @@
 """Low-level HOI4 script marshalling helpers."""
 
+import os
+import re
+
+from hoi4cm.mod.workspace_files import WorkspaceFiles
+
 from .effects import render_effect
 from .syntax import (
     emit_scalar,
@@ -154,11 +159,8 @@ def append_scripted_loc(sloc_path, blocks, saved, errs, mod_root=None):
     """
     if not sloc_path or not blocks:
         return
-    import os
-    import re
 
     try:
-        os.makedirs(os.path.dirname(sloc_path), exist_ok=True)
         existing = ""
         if os.path.isfile(sloc_path):
             with open(sloc_path, encoding="utf-8", errors="replace") as f:
@@ -189,8 +191,11 @@ def append_scripted_loc(sloc_path, blocks, saved, errs, mod_root=None):
             new_blocks.append("\n".join(lines))
         if new_blocks:
             sep = "\n\n" if existing.strip() else ""
-            with open(sloc_path, "a", encoding="utf-8") as f:
-                f.write(sep + "\n\n".join(new_blocks) + "\n")
+            WorkspaceFiles().append_text(
+                sloc_path,
+                sep + "\n\n".join(new_blocks) + "\n",
+                encoding="utf-8",
+            )
             rel = os.path.relpath(sloc_path, mod_root) if mod_root else sloc_path
             saved.append(rel + f"  (+{len(new_blocks)} scripted_loc blocks)")
     except (OSError, ValueError, TypeError, RuntimeError) as exc:

--- a/src/hoi4cm/wizards/_image_loader.py
+++ b/src/hoi4cm/wizards/_image_loader.py
@@ -12,16 +12,16 @@ from hoi4cm.ui.lifecycle import find_lifecycle
 
 
 class TkOwner(Protocol):
-    def after(self, milliseconds: int, callback: Callable[[], None]) -> object: ...
+    def after(self, ms: int, func: Callable[..., object] = ...) -> object: ...
 
-    def after_cancel(self, identifier: object) -> None: ...
+    def after_cancel(self, job: object, /) -> None: ...
 
     def winfo_exists(self) -> int: ...
 
     def bind(
         self,
         sequence: str,
-        callback: Callable[[object], None],
+        func: Callable[..., object] | None = None,
         add: str | None = None,
     ) -> object: ...
 
@@ -44,14 +44,14 @@ _Item = TypeVar("_Item")
 
 
 class TkImageLoader:
-    def __init__(self, owner: TkOwner, *, poll_interval: int = 16) -> None:
+    def __init__(self, owner: TkOwner | tk.Misc, *, poll_interval: int = 16) -> None:
         self._owner = owner
         self._poll_interval = poll_interval
         self._owner_thread = threading.get_ident()
         self._generation = 0
         self._pending_batches = 0
         self._poll_scheduled = False
-        self._poll_job: object | None = None
+        self._poll_job: str | None = None
         self._closed = False
         self._results: queue.SimpleQueue[_QueueItem] = queue.SimpleQueue()
         self._remove_resource: Callable[[], None] | None = None
@@ -145,7 +145,7 @@ class TkImageLoader:
             return
         self._poll_scheduled = True
         try:
-            self._poll_job = self._owner.after(self._poll_interval, self._poll)
+            self._poll_job = str(self._owner.after(self._poll_interval, self._poll))
         except AttributeError, RuntimeError, tk.TclError:
             self._closed = True
             self._poll_scheduled = False

--- a/src/hoi4cm/wizards/decision.py
+++ b/src/hoi4cm/wizards/decision.py
@@ -191,7 +191,7 @@ def open_decision_wizard(app):
     C_CARD = BG_CARD  # "#1e2435"
     C_TEXT = TEXT  # "#e2e8f0"
     C_DIM = TEXT_DIM  # "#6b7280"
-    C_BORD = BORDER  # "#2d3748"
+    C_BORDER = BORDER  # "#2d3748"
     C_BORDG = BORDER_G  # "#374151"
     C_BLUE = BLUE  # "#3b82f6"
     C_GREEN = GREEN  # "#22c55e"
@@ -747,7 +747,7 @@ def open_decision_wizard(app):
                 padx=5,
                 pady=1,
             ).pack()
-            tk.Frame(tree_inner, bg=C_BORD, height=1).pack(fill="x")
+            tk.Frame(tree_inner, bg=C_BORDER, height=1).pack(fill="x")
 
             _tree_rows[cat["uid"]] = (crow, lbar, inn, SEL_BG_TREE, C_PANEL)
 
@@ -807,7 +807,7 @@ def open_decision_wizard(app):
                         _tag(
                             tagrow, dec["chain"][:8], C_PURPLE, PURP_TAG_BG, PURP_TAG_BD
                         )
-                    tk.Frame(tree_inner, bg=C_BORD, height=1).pack(fill="x")
+                    tk.Frame(tree_inner, bg=C_BORDER, height=1).pack(fill="x")
                     _tree_rows[dec["uid"]] = (drow, dlbar, dinn, SEL_BG_TREE, C_PANEL)
 
                     def _on_dec(e, uid=dec["uid"]):
@@ -1360,11 +1360,11 @@ def open_decision_wizard(app):
         nc["cat_id"] = c["cat_id"] + "_copy"
         dm_cats.append(nc)
         for d in _decs_for(uid):
-            nd = copy.deepcopy(d)
-            nd["uid"] = str(uuid.uuid4())
-            nd["cat_uid"] = nc["uid"]
-            nd["dec_id"] = d["dec_id"] + "_copy"
-            dm_decs.append(nd)
+            new_dec = copy.deepcopy(d)
+            new_dec["uid"] = str(uuid.uuid4())
+            new_dec["cat_uid"] = nc["uid"]
+            new_dec["dec_id"] = d["dec_id"] + "_copy"
+            dm_decs.append(new_dec)
         sel["uid"] = nc["uid"]
         sel["type"] = "cat"
         _rebuild_tree()
@@ -1404,11 +1404,11 @@ def open_decision_wizard(app):
         d = _get_dec(uid)
         if not d:
             return
-        nd = copy.deepcopy(d)
-        nd["uid"] = str(uuid.uuid4())
-        nd["dec_id"] = d["dec_id"] + "_copy"
-        dm_decs.append(nd)
-        sel["uid"] = nd["uid"]
+        new_dec = copy.deepcopy(d)
+        new_dec["uid"] = str(uuid.uuid4())
+        new_dec["dec_id"] = d["dec_id"] + "_copy"
+        dm_decs.append(new_dec)
+        sel["uid"] = new_dec["uid"]
         sel["type"] = "dec"
         _rebuild_tree()
         _rebuild_editor()
@@ -3203,13 +3203,8 @@ def open_decision_wizard(app):
 
         # Convert literal \n escape sequences to real newlines
         text = text.replace("\\n", "\n").replace("\\\\n", "\n")
-        # Strip trailing backslashes (common in raw HOI4 strings)
-        text = text.rstrip("\\").strip()
-        # Strip trailing backslashes (common in raw HOI4 strings)
         text = text.rstrip("\\").strip()
 
-        # Estimate height needed: roughly 1 line per 45 chars of wraplength
-        max(1, wraplength // 7)
         est_lines = max(2, text.count("\n") + len(text) // max(1, wraplength // 7 * 6))
         height = min(max(2, est_lines), 12)
 
@@ -4628,11 +4623,11 @@ def open_decision_wizard(app):
                         d["fire_only_once"] = True
                     if _re.search(r"\bfire_only_once\b", dec_inner):
                         d["fire_only_once"] = True
-                    if _get_yes_no(dec_inner, "fixed_random_seed") is False:
+                    if _get_yes_no(dec_inner, "fixed_random_seed") in (False,):
                         d["fixed_random_seed"] = False
                     if _get_yes_no(dec_inner, "is_mission"):
                         d["is_mission"] = True
-                    if _get_yes_no(dec_inner, "selectable_mission") is False:
+                    if _get_yes_no(dec_inner, "selectable_mission") in (False,):
                         d["selectable_mission"] = False
                     if _get_yes_no(dec_inner, "is_good"):
                         d["is_good"] = True
@@ -4868,7 +4863,6 @@ def open_decision_wizard(app):
             dec_path = os.path.join(
                 mod_root, "common", "decisions", f"{ns}_decisions.txt"
             )
-        os.makedirs(os.path.dirname(dec_path), exist_ok=True)
         try:
             wf.write_text(dec_path, _gen_decisions_file(), encoding="utf-8")
             try:
@@ -4885,7 +4879,6 @@ def open_decision_wizard(app):
             cat_path = os.path.join(
                 mod_root, "common", "decisions", "categories", f"{ns}_categories.txt"
             )
-        os.makedirs(os.path.dirname(cat_path), exist_ok=True)
         try:
             wf.write_text(cat_path, _gen_categories_file(), encoding="utf-8")
             try:
@@ -4906,7 +4899,6 @@ def open_decision_wizard(app):
                 loc_target.filename(f"{ns}_decisions"),
             )
         )
-        os.makedirs(os.path.dirname(yml_path), exist_ok=True)
         try:
             import re as _re_loc2
 

--- a/src/hoi4cm/wizards/decision.py
+++ b/src/hoi4cm/wizards/decision.py
@@ -248,7 +248,9 @@ def open_decision_wizard(app):
             highlight_states="",
         )
 
-    def _new_dec(cat_uid=""):
+    def _new_dec(cat_uid: object = ""):
+        if not isinstance(cat_uid, str):
+            cat_uid = ""
         return dict(
             uid=_uid(),
             cat_uid=cat_uid,
@@ -612,7 +614,8 @@ def open_decision_wizard(app):
     _tree_filter.trace_add("write", lambda *_: _rebuild_tree())
 
     _tree_rows = {}  # uid -> (crow, lbar) for fast highlight updates
-    _tree_icon_refs: list = []
+    _tree_icon_refs = []
+    _preview_img_refs = []
 
     def _update_tree_highlight():
         """Update tree row highlight colors without rebuilding."""
@@ -919,8 +922,6 @@ def open_decision_wizard(app):
         )
         return widget
 
-    PAD = dict(padx=14, pady=2)
-
     def _sec(label, color=C_GOLD):
         """Section header with coloured underline — matches SectionHeader in mockup."""
         f = tk.Frame(mid_frm, bg=C_PANEL)
@@ -938,7 +939,7 @@ def open_decision_wizard(app):
     def _field(label, var, mono=False, hint=""):
         """Labelled entry — matches Field component."""
         f = tk.Frame(mid_frm, bg=C_PANEL)
-        f.pack(fill="x", **PAD)
+        f.pack(fill="x", padx=14, pady=2)
         lbl_text = label.upper()
         tk.Label(
             f, text=lbl_text, bg=C_PANEL, fg=C_DIM, font=("Courier", 8), anchor="w"
@@ -994,7 +995,7 @@ def open_decision_wizard(app):
     def _triggerblock(label, key, initial="", hint=None, rows=2):
         """Trigger / code textarea — matches TriggerBlock."""
         f = tk.Frame(mid_frm, bg=C_PANEL)
-        f.pack(fill="x", **PAD)
+        f.pack(fill="x", padx=14, pady=2)
         hrow = tk.Frame(f, bg=C_PANEL)
         hrow.pack(fill="x")
         tk.Label(
@@ -1024,9 +1025,9 @@ def open_decision_wizard(app):
         return _reg_text(key, t, initial)
 
     def _effectblock(label, key, initial="", rows=4):
-        """Effect textarea + Effect Picker button — matches TextArea with extra button."""
+        """Effect textarea + Effect Picker button - matches TextArea with extra button."""
         f = tk.Frame(mid_frm, bg=C_PANEL)
-        f.pack(fill="x", **PAD)
+        f.pack(fill="x", padx=14, pady=2)
         tk.Label(
             f, text=label.upper(), bg=C_PANEL, fg=C_DIM, font=("Courier", 8), anchor="w"
         ).pack(fill="x")
@@ -1063,9 +1064,9 @@ def open_decision_wizard(app):
         return _reg_text(key, t, initial)
 
     def _gfx_field(label, key, initial="", prefix_note="", warn=""):
-        """GFX drop zone — matches GfxDropZone component."""
+        """GFX drop zone - matches GfxDropZone component."""
         f = tk.Frame(mid_frm, bg=C_PANEL)
-        f.pack(fill="x", **PAD)
+        f.pack(fill="x", padx=14, pady=2)
         tk.Label(
             f, text=label.upper(), bg=C_PANEL, fg=C_DIM, font=("Courier", 8), anchor="w"
         ).pack(fill="x", pady=(0, 2))
@@ -1134,8 +1135,12 @@ def open_decision_wizard(app):
                 get_logger("decision").debug("drop handling failed: %s", exc)
 
         try:
-            drop_outer.drop_target_register("DND_Files")
-            drop_outer.dnd_bind("<<Drop>>", _on_drop)
+            register = getattr(
+                drop_outer, "drop_target_register", lambda *_a, **_k: None
+            )
+            bind_dnd = getattr(drop_outer, "dnd_bind", lambda *_a, **_k: None)
+            register("DND_Files")
+            bind_dnd("<<Drop>>", _on_drop)
         except tk.TclError:
             pass
         if prefix_note:
@@ -1727,7 +1732,7 @@ def open_decision_wizard(app):
                 _evars["cost_type"] = tk.StringVar(value="pp")
                 # inline field inside cost_host
                 cf = tk.Frame(cost_host, bg=C_PANEL)
-                cf.pack(fill="x", **PAD)
+                cf.pack(fill="x", padx=14, pady=2)
                 tk.Label(
                     cf,
                     text=tr("decision.cost_pp", "COST (POLITICAL POWER)"),
@@ -2407,7 +2412,7 @@ def open_decision_wizard(app):
                 fg=C_RED,
                 font=("Courier", 9, "bold"),
                 padx=6,
-                pady=(8, 2),
+                pady="8 2",
             ).pack(fill="x")
 
             def _wt(lbl3, k3, v3):
@@ -2504,7 +2509,7 @@ def open_decision_wizard(app):
             # sub-frame approach — inline build:
             def _sub_effectblock(lbl3, k3, v3, rows2=3):
                 sf = tk.Frame(timer_host, bg=C_PANEL)
-                sf.pack(fill="x", **PAD)
+                sf.pack(fill="x", padx=14, pady=2)
                 tk.Label(
                     sf, text=lbl3.upper(), bg=C_PANEL, fg=C_DIM, font=("Courier", 8)
                 ).pack(fill="x")
@@ -2542,7 +2547,7 @@ def open_decision_wizard(app):
 
             def _sub_trigblock(lbl3, k3, v3):
                 sf = tk.Frame(timer_host, bg=C_PANEL)
-                sf.pack(fill="x", **PAD)
+                sf.pack(fill="x", padx=14, pady=2)
                 tk.Label(
                     sf, text=lbl3.upper(), bg=C_PANEL, fg=C_DIM, font=("Courier", 8)
                 ).pack(fill="x")
@@ -2673,7 +2678,7 @@ def open_decision_wizard(app):
 
     # ── rebuild_editor  (clears mid_frm and dispatches) ──────────────────────
     # Track what type is currently built so we know when to do a full rebuild
-    _editor_state = {"type": None, "uid": None}  # what the editor currently shows
+    _editor_state: dict[str, object] = {"type": None, "uid": None}
 
     def _set_var_silent(key, value):
         """Set a tkinter var without firing its write traces."""
@@ -2989,24 +2994,20 @@ def open_decision_wizard(app):
     _dec_prev_img_cache = {}
     _app_img_caches.append(_dec_prev_img_cache)  # register for mod-reload invalidation
 
-    # ── PIL / DDS capability check ────────────────────────────────────────
     _dds_supported = False
-    if PIL_OK:
+    if PILImage is not None:
         try:
-            from PIL import features as _pil_feat
-
-            _dds_supported = _pil_feat.check_feature("libtiff") or True
-            # Actually test by checking registered formats
-            from PIL import Image as _tpil
-
-            _dds_supported = (
-                "DDS" in _tpil.registered_extensions().get(".dds", "").upper()
-                if hasattr(_tpil, "registered_extensions")
-                else False
-            )
-        except (OSError, ValueError, AttributeError, ImportError) as exc:
+            extensions = getattr(PILImage, "registered_extensions", lambda: {})()
+            _dds_supported = "DDS" in str(extensions.get(".dds", "")).upper()
+        except (OSError, ValueError, AttributeError, TypeError) as exc:
             get_logger("decision").debug("dds check failed: %s", exc)
             _dds_supported = False
+
+    def _to_photo(pil):
+        tk_image = PILImageTk
+        if tk_image is None:
+            return None
+        return tk_image.PhotoImage(pil)
 
     def _decode_dec_icon(gfx_key, size=24):
         if not gfx_key or PILImage is None:
@@ -3337,6 +3338,7 @@ def open_decision_wizard(app):
     _dds_warned = [False]
 
     def _build_preview():
+        _preview_img_refs.clear()
         _collect()
         # ── DDS warning banner ────────────────────────────────────────────────
         if (
@@ -3402,7 +3404,6 @@ def open_decision_wizard(app):
                 frm, bg="#1a1f2e", highlightthickness=1, highlightbackground="#3a4a6a"
             )
             panel.pack(fill="x", padx=10, pady=8)
-            panel._img_refs = []  # keep images alive per-panel
 
             # ── Header: icon + name ───────────────────────────────────────────
             hdr = tk.Frame(panel, bg="#141929")
@@ -3411,7 +3412,7 @@ def open_decision_wizard(app):
             icon_key = cat.get("icon", "").strip()
             cat_img = _load_dec_icon(icon_key, 32) if icon_key else None
             if cat_img:
-                panel._img_refs.append(cat_img)
+                _preview_img_refs.append(cat_img)
                 ic_lbl = tk.Label(hdr, image=cat_img, bg="#141929", width=32, height=32)
             else:
                 ic_lbl = tk.Frame(hdr, bg="#2a3550", width=32, height=32)
@@ -3469,7 +3470,7 @@ def open_decision_wizard(app):
                     pic_box.pack_propagate(False)
                     cat_pic = _load_cat_picture(pic_key, 64, 64)
                     if cat_pic:
-                        panel._img_refs.append(cat_pic)
+                        _preview_img_refs.append(cat_pic)
                         tk.Label(pic_box, image=cat_pic, bg="#2a3550").pack(expand=True)
                     else:
                         # Show placeholder, try async load
@@ -3479,7 +3480,7 @@ def open_decision_wizard(app):
                         ph.pack(expand=True)
 
                         def _async_cat_pic(
-                            key=pic_key, box=pic_box, ph_lbl=ph, refs=panel._img_refs
+                            key=pic_key, box=pic_box, ph_lbl=ph, refs=_preview_img_refs
                         ):
                             try:
                                 if not box.winfo_exists():
@@ -3498,7 +3499,7 @@ def open_decision_wizard(app):
                             TkImageLoader(box).submit(
                                 (key, 64, 64),
                                 lambda item: _decode_cat_picture(*item),
-                                realizer=lambda pil: PILImageTk.PhotoImage(pil),
+                                realizer=_to_photo,
                                 apply=_paint,
                             )
 
@@ -3559,7 +3560,7 @@ def open_decision_wizard(app):
 
                     icon_box.bind("<Button-3>", _ctx_dec_icon)
                 if dec_img:
-                    panel._img_refs.append(dec_img)
+                    _preview_img_refs.append(dec_img)
                     tk.Label(icon_box, image=dec_img, bg="#2a3550").pack(expand=True)
                 else:
                     ic = CHAIN_ICONS.get(dec.get("chain", "").lower(), "⚖")
@@ -3573,7 +3574,7 @@ def open_decision_wizard(app):
                             key=dec_icon_key,
                             box=icon_box,
                             fb=fallback,
-                            refs=panel._img_refs,
+                            refs=_preview_img_refs,
                         ):
                             try:
                                 if not box.winfo_exists():
@@ -3592,7 +3593,7 @@ def open_decision_wizard(app):
                             TkImageLoader(box).submit(
                                 (key, 24),
                                 lambda item: _decode_dec_icon(*item),
-                                realizer=lambda pil: PILImageTk.PhotoImage(pil),
+                                realizer=_to_photo,
                                 apply=_paint,
                             )
 
@@ -4623,23 +4624,23 @@ def open_decision_wizard(app):
                         d["icon"] = iv
 
                     # ── boolean flags ──
-                    if _get_yes_no(dec_inner, "fire_only_once") is True:
+                    if _get_yes_no(dec_inner, "fire_only_once"):
                         d["fire_only_once"] = True
                     if _re.search(r"\bfire_only_once\b", dec_inner):
                         d["fire_only_once"] = True
                     if _get_yes_no(dec_inner, "fixed_random_seed") is False:
                         d["fixed_random_seed"] = False
-                    if _get_yes_no(dec_inner, "is_mission") is True:
+                    if _get_yes_no(dec_inner, "is_mission"):
                         d["is_mission"] = True
                     if _get_yes_no(dec_inner, "selectable_mission") is False:
                         d["selectable_mission"] = False
-                    if _get_yes_no(dec_inner, "is_good") is True:
+                    if _get_yes_no(dec_inner, "is_good"):
                         d["is_good"] = True
-                    if _get_yes_no(dec_inner, "cancel_if_not_visible") is True:
+                    if _get_yes_no(dec_inner, "cancel_if_not_visible"):
                         d["cancel_if_not_visible"] = True
-                    if _get_yes_no(dec_inner, "targets_dynamic") is True:
+                    if _get_yes_no(dec_inner, "targets_dynamic"):
                         d["targets_dynamic"] = True
-                    if _get_yes_no(dec_inner, "target_non_existing") is True:
+                    if _get_yes_no(dec_inner, "target_non_existing"):
                         d["target_non_existing"] = True
 
                     # ── cost type detection ──

--- a/src/hoi4cm/wizards/decision.py
+++ b/src/hoi4cm/wizards/decision.py
@@ -220,7 +220,7 @@ def open_decision_wizard(app):
     # ── data model ───────────────────────────────────────────────────────────
     dm_cats = []
     dm_decs = []
-    sel = {"uid": None, "type": None}
+    sel: dict[str, object] = {"uid": None, "type": None}
     _uid_n = [0]
 
     def _uid():
@@ -612,6 +612,7 @@ def open_decision_wizard(app):
     _tree_filter.trace_add("write", lambda *_: _rebuild_tree())
 
     _tree_rows = {}  # uid -> (crow, lbar) for fast highlight updates
+    _tree_icon_refs: list = []
 
     def _update_tree_highlight():
         """Update tree row highlight colors without rebuilding."""
@@ -626,6 +627,7 @@ def open_decision_wizard(app):
 
     def _rebuild_tree():
         _tree_rows.clear()
+        _tree_icon_refs.clear()
         for w in tree_inner.winfo_children():
             w.destroy()
         # Apply search filter
@@ -673,7 +675,7 @@ def open_decision_wizard(app):
             _cicon_img = _load_dec_icon(_cicon_key, 24) if _cicon_key else None
             if _cicon_img:
                 _cicon_lbl = tk.Label(inn, image=_cicon_img, bg=bg_c)
-                _cicon_lbl.image = _cicon_img  # keep ref
+                _tree_icon_refs.append(_cicon_img)
                 _cicon_lbl.pack(side="left", padx=(0, 2))
             else:
                 tk.Label(inn, text="📁", bg=bg_c, font=("Helvetica", 12)).pack(
@@ -772,7 +774,7 @@ def open_decision_wizard(app):
                     _dicon_img = _load_dec_icon(_dicon_key, 20) if _dicon_key else None
                     if _dicon_img:
                         _dicon_lbl = tk.Label(dinn, image=_dicon_img, bg=bg_d)
-                        _dicon_lbl.image = _dicon_img  # keep ref
+                        _tree_icon_refs.append(_dicon_img)
                         _dicon_lbl.pack(side="left", padx=(28, 2), pady=5)
                     else:
                         tk.Label(dinn, text="📋", bg=bg_d, font=("Helvetica", 10)).pack(
@@ -2957,7 +2959,7 @@ def open_decision_wizard(app):
     right_body = tk.Frame(right_f, bg=C_DARK)
     right_body.pack(fill="both", expand=True)
 
-    _rr_job = [None]
+    _rr_job: list[str | None] = [None]
 
     def _rebuild_right():
         # Debounce: cancel pending rebuild and schedule new one 80ms out
@@ -3007,7 +3009,7 @@ def open_decision_wizard(app):
             _dds_supported = False
 
     def _decode_dec_icon(gfx_key, size=24):
-        if not gfx_key or not PIL_OK:
+        if not gfx_key or PILImage is None:
             return None
         path = (
             MOD.decision_sprites.get(gfx_key)
@@ -3066,7 +3068,7 @@ def open_decision_wizard(app):
 
     def _load_dec_icon(gfx_key, size=24):
         """Load a decision icon image, returns PhotoImage or None. Cached."""
-        if not gfx_key or not PIL_OK:
+        if not gfx_key or PILImageTk is None:
             return None
         cache_key = (gfx_key, size)
         if cache_key in _dec_prev_img_cache:
@@ -3080,7 +3082,7 @@ def open_decision_wizard(app):
         return img
 
     def _decode_cat_picture(gfx_key, w=64, h=64):
-        if not gfx_key or not PIL_OK:
+        if not gfx_key or PILImage is None:
             return None
         # Try key as-is, then with common category prefixes
         path = (
@@ -3140,7 +3142,7 @@ def open_decision_wizard(app):
 
     def _load_cat_picture(gfx_key, w=64, h=64):
         """Load a category picture image. Cached."""
-        if not gfx_key or not PIL_OK:
+        if not gfx_key or PILImageTk is None:
             return None
         cache_key = (gfx_key, w, h)
         if cache_key in _dec_prev_img_cache:
@@ -3332,6 +3334,8 @@ def open_decision_wizard(app):
         txt.config(state="disabled")
         return txt
 
+    _dds_warned = [False]
+
     def _build_preview():
         _collect()
         # ── DDS warning banner ────────────────────────────────────────────────
@@ -3340,7 +3344,7 @@ def open_decision_wizard(app):
             and not _dds_supported
             and MOD.loaded
             and MOD.decision_sprites
-            and not getattr(_build_preview, "_dds_warned", False)
+            and not _dds_warned[0]
         ):
             # Check if any sprites are .dds — show warning only once per session
             has_dds = any(
@@ -3348,7 +3352,7 @@ def open_decision_wizard(app):
                 for v in list(MOD.decision_sprites.values())[:20]
             )
             if has_dds:
-                _build_preview._dds_warned = True
+                _dds_warned[0] = True
                 warn_f = tk.Frame(right_body, bg="#3a1a00")
                 warn_f.pack(fill="x")
                 tk.Label(
@@ -3886,7 +3890,7 @@ def open_decision_wizard(app):
             _mark(_HL_NUMBER, "kw_number")
 
         # Debounced — run highlight 400ms after last keystroke
-        _hl_job = [None]
+        _hl_job: list[str | None] = [None]
 
         def _sched_highlight(e=None):
             if _hl_job[0]:

--- a/src/hoi4cm/wizards/decision.py
+++ b/src/hoi4cm/wizards/decision.py
@@ -44,6 +44,7 @@ from hoi4cm.ui import (
     open_gfx_placement_editor,
     open_universal_gfx_browser,
     report_error,
+    report_write_failure,
 )
 from hoi4cm.wizards import _generators
 from hoi4cm.wizards._graphics import find_catalog_image
@@ -3972,16 +3973,15 @@ def open_decision_wizard(app):
             if tab == "scripted_loc":
                 if MOD.edit_scripted_loc_file:
                     try:
-                        with open(
-                            MOD.edit_scripted_loc_file, "w", encoding="utf-8"
-                        ) as _f:
-                            _f.write(raw)
+                        WorkspaceFiles().write_text(
+                            MOD.edit_scripted_loc_file, raw, encoding="utf-8"
+                        )
                         _dm_status.config(
                             text=f"  ✓  Scripted loc saved to {os.path.basename(MOD.edit_scripted_loc_file)}"
                         )
-                    except OSError as _ex:
-                        report_error(
-                            f"Save error: {_ex}", _ex, parent=win, title="Save Error"
+                    except (OSError, ValueError, TypeError, RuntimeError) as _ex:
+                        report_write_failure(
+                            win, MOD.edit_scripted_loc_file, _ex, title="Save Error"
                         )
                 else:
                     win.clipboard_clear()

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,5 +1,6 @@
 """Tests for hoi4cm.script marshalling helpers."""
 
+from hoi4cm.mod.workspace_files import WorkspaceFiles
 from hoi4cm.script import append_scripted_loc, dict_to_raw, normalize_effect_fields
 
 
@@ -114,15 +115,51 @@ def test_append_scripted_loc_skips_existing_name(tmp_path):
     assert saved == []  # nothing added
 
 
+def test_append_scripted_loc_preserves_existing_content(tmp_path):
+    sloc = tmp_path / "test_scripted_loc.txt"
+    sloc.write_text("defined_text = {\n\tname = OLD\n}\n", encoding="utf-8")
+    saved = []
+    errs = []
+    append_scripted_loc(str(sloc), [{"name": "NEW", "texts": []}], saved, errs)
+    assert not errs
+    assert len(saved) == 1
+    text = sloc.read_text(encoding="utf-8")
+    assert "name = OLD" in text
+    assert "name = NEW" in text
+
+
+def test_append_scripted_loc_uses_workspace_files(tmp_path, monkeypatch):
+    sloc = tmp_path / "test_scripted_loc.txt"
+    sloc.write_text("existing\n", encoding="utf-8")
+    calls = []
+
+    def capture(self, path, text, *, encoding):
+        calls.append((str(path), text, encoding))
+
+    monkeypatch.setattr(WorkspaceFiles, "append_text", capture)
+    saved = []
+    errs = []
+    append_scripted_loc(str(sloc), [{"name": "NEW", "texts": []}], saved, errs)
+    assert not errs
+    assert len(calls) == 1
+    path, text, encoding = calls[0]
+    assert path == str(sloc)
+    assert encoding == "utf-8"
+    assert "name = NEW" in text
+    assert sloc.read_text(encoding="utf-8") == "existing\n"
+
+
 def test_append_scripted_loc_reports_errors(tmp_path, monkeypatch):
     sloc = tmp_path / "file.txt"
+    sloc.write_text("old\n", encoding="utf-8")
     saved = []
     errs = []
 
-    def bad_makedirs(*args, **kwargs):
+    def boom(self, path, text, *, encoding):
         raise OSError("permission denied")
 
-    monkeypatch.setattr("os.makedirs", bad_makedirs)
+    monkeypatch.setattr(WorkspaceFiles, "append_text", boom)
     append_scripted_loc(str(sloc), [{"name": "x", "texts": []}], saved, errs)
     assert errs
     assert "Scripted Loc" in errs[0]
+    assert sloc.read_text(encoding="utf-8") == "old\n"

--- a/tests/test_wizard_image_loader.py
+++ b/tests/test_wizard_image_loader.py
@@ -10,23 +10,24 @@ from hoi4cm.wizards._image_loader import TkImageLoader
 class FakeOwner:
     def __init__(self) -> None:
         self.exists = True
-        self.callbacks: list[Callable[[], None]] = []
+        self.callbacks: list[Callable[..., object]] = []
         self.cancelled: list[object] = []
 
-    def after(self, milliseconds: int, callback: Callable[[], None]) -> object:
-        self.callbacks.append(callback)
-        return len(self.callbacks)
+    def after(self, ms: int, func: Callable[..., object] | None = None) -> object:
+        if func is not None:
+            self.callbacks.append(func)
+        return str(len(self.callbacks))
 
     def winfo_exists(self) -> int:
         return int(self.exists)
 
-    def after_cancel(self, identifier: object) -> None:
-        self.cancelled.append(identifier)
+    def after_cancel(self, job: object) -> None:
+        self.cancelled.append(job)
 
     def bind(
         self,
         sequence: str,
-        callback: Callable[[object], None],
+        func: Callable[..., object] | None = None,
         add: str | None = None,
     ) -> object:
         return None
@@ -150,5 +151,5 @@ def test_close_cancels_poll_and_drops_worker_result() -> None:
     loader.close()
     gate.set()
 
-    assert owner.cancelled == [1]
+    assert owner.cancelled == ["1"]
     assert applied == []


### PR DESCRIPTION
Closes #46

**What**
Route the two remaining tracked-mod writes through `WorkspaceFiles`. Decision Apply on the scripted_loc tab now uses `write_text` plus `report_write_failure`. `append_scripted_loc` uses `append_text`.

**Why**
PR #82 converted the listed export/project/mod-loading sites, but these two still bypassed the writer. Apply truncated the user's scripted loc file in place.

**How**
`append_text` still appends (same as the other loc/scripted-loc paths). Parent-dir creation moves into the writer. Failures on Apply now name the file and say it was left unchanged.