### PR TITLE
Fix doc drift: update LOD status and monolith App stats

### DIFF
--- a/docs/dev/monolith-migration.md
+++ b/docs/dev/monolith-migration.md
@@ -132,8 +132,8 @@
 What's left in `hoi4_content_maker.py` today is essentially: the `sys.path`
 shim and import block (lines ~62-152), two Windows-DPI helpers (~155-207),
 and `class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk)`
-(~241-5929, 108 methods, most bodies much smaller now), plus the
-`__main__` entry point that calls `show_splash(_launch)`. Those 108
+(~204-6336, 139 methods, most bodies much smaller now), plus the
+`__main__` entry point that calls `show_splash(_launch)`. Those 139
 methods group into:
 
 - **Sidebar** (still deferred, see below): `_build_sidebar`,

--- a/docs/dev/performance.md
+++ b/docs/dev/performance.md
@@ -53,11 +53,11 @@ are pooled the same way `_draw_lines`' line pool already was (reuse +
 hide-surplus instead of delete-and-recreate every call), and above 2,000
 focuses the minimap buckets to one dot per occupied pixel cell and skips
 prereq lines, since individual dots/edges aren't legible at that density
-anyway. A low-zoom level-of-detail pass (one pooled rectangle per focus
-below some zoom threshold, instead of the full multi-item card) was
-scoped for phase 8 but not implemented — noted here as future work, since
-lazy item creation already removes the up-front item explosion for the
-zoomed-in case, which was the more common one.
+anyway. The low-zoom level-of-detail pass (one pooled rectangle per focus
+below `_FOCUS_LOD_ZOOM` at 0.4 zoom, instead of the full multi-item card)
+is implemented in `ui/canvas.py`: `_draw_focus` selects `lod = "compact"`
+based on the zoom threshold, and the compact branch renders a single
+rectangle per focus instead of the full 14-item bundle.
 
 ### Drag-snap step
 


### PR DESCRIPTION
## Bottom line

Two doc-drift fixes for #55: the LOD pass in performance.md is described as future work but it's shipped, and monolith-migration.md's class App range/method count are stale.

## Why

The docs are the map for the improvement series (per docs/dev/README.md's maintenance rule). Stale numbers and a shipped feature listed as "not implemented" will confuse anyone reading the migration status or perf roadmap.

## How

- `docs/dev/performance.md`: Replace the "scoped for phase 8 but not implemented" sentence with text noting the LOD is implemented via `_FOCUS_LOD_ZOOM = 0.4` and the compact branch in `ui/canvas.py`.
- `docs/dev/monolith-migration.md`: Update class App from `~241-5929, 108 methods` to `~204-6336, 139 methods` (verified: `class App` starts at line 204, 139 one-level `def` methods, `_launch` is in the `__main__` block not a class method).

BLUF