### PR TITLE
Decode files strictly so latin-1 fallback is reachable

### DIFF
--- a/src/hoi4cm/core/paths.py
+++ b/src/hoi4cm/core/paths.py
@@ -37,7 +37,7 @@ def read_file(path, max_bytes=MAX_READ_BYTES):
         return ""
     for enc in ("utf-8-sig", "utf-8", "latin-1"):
         try:
-            with open(path, encoding=enc, errors="replace") as f:
+            with open(path, encoding=enc, errors="strict") as f:
                 if max_bytes is None:
                     return f.read()
                 data = f.read(max_bytes + 1)

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -22,6 +22,13 @@ def test_read_file_missing_returns_empty(tmp_path):
     assert paths.read_file(str(tmp_path / "does_not_exist.txt")) == ""
 
 
+def test_read_file_falls_back_to_latin1(tmp_path):
+    p = tmp_path / "c.txt"
+    p.write_bytes("café".encode("latin-1"))  # 0xe9 is not valid UTF-8
+    assert paths.read_file(str(p)) == "café"
+    assert "�" not in paths.read_file(str(p))
+
+
 def test_default_mod_dir_linux(monkeypatch):
     monkeypatch.setattr(sys, "platform", "linux")
     expected = os.path.join(


### PR DESCRIPTION
## Bottom line
`read_file` opened every encoding with `errors="replace"`, so utf-8 never failed and the latin-1 fallback was dead code. Windows-1252/latin-1 files imported full of U+FFFD, and export then wrote the mangled text back. Now each attempt decodes strictly and falls through; latin-1 stays the catch-all.

Closes #122

## How
- `src/hoi4cm/core/paths.py`: `errors="replace"` to `errors="strict"`. `max_bytes`/oversize behavior unchanged.
- Test: latin-1 bytes round-trip through `read_file` with no replacement char.

BLUF