### PR TITLE
Gate pixel-coord migration to legacy project decode

### DIFF
--- a/src/hoi4cm/editor/project_codec.py
+++ b/src/hoi4cm/editor/project_codec.py
@@ -147,7 +147,7 @@ def _decode_legacy(data: Mapping[str, Any]) -> EditorWorkspace:
     metadata = TreeMetadata(tree_id=data.get("tree_name", "TAG_focus_tree"))
     return EditorWorkspace(
         focuses=FocusDocument(
-            Focus.from_dict(focus) for focus in data.get("focuses", [])
+            Focus.from_dict(focus, legacy=True) for focus in data.get("focuses", [])
         ),
         main_tree=TreeDocument(metadata=metadata),
         extras={

--- a/src/hoi4cm/models/focus.py
+++ b/src/hoi4cm/models/focus.py
@@ -54,15 +54,18 @@ class Focus:
         return {k: v for k, v in self.__dict__.items() if not k.startswith("_")}
 
     @staticmethod
-    def from_dict(d):
+    def from_dict(d, *, legacy=False):
         f = object.__new__(Focus)
         for k, v in d.items():
             setattr(f, k, v)
-        # Migrate old pixel-based coords to grid integers
-        if f.x >= 96 and f.x % 96 == 0:
-            f.x = f.x // 96
-        if f.y >= 96 and f.y % 96 == 0:
-            f.y = f.y // 96
+        # Legacy pre-versioning project files stored pixel coords; grid
+        # coords are indistinguishable from a multiple-of-96 pixel coord, so
+        # this migration must never run on current-format or snapshot data.
+        if legacy:
+            if f.x >= 96 and f.x % 96 == 0:
+                f.x = f.x // 96
+            if f.y >= 96 and f.y % 96 == 0:
+                f.y = f.y // 96
         defaults = [
             ("mutex", []),
             ("cancel_if_invalid", True),

--- a/tests/test_focus.py
+++ b/tests/test_focus.py
@@ -45,10 +45,16 @@ def test_to_dict_roundtrips():
     assert restored.id == f.id
 
 
-def test_from_dict_migrates_pixel_coords():
-    f = Focus.from_dict({"id": 5, "x": 192, "y": 384})
+def test_from_dict_migrates_pixel_coords_when_legacy():
+    f = Focus.from_dict({"id": 5, "x": 192, "y": 384}, legacy=True)
     assert f.x == 2
     assert f.y == 4
+
+
+def test_from_dict_leaves_grid_coords_alone_by_default():
+    f = Focus.from_dict({"id": 5, "x": 96, "y": 192})
+    assert f.x == 96
+    assert f.y == 192
 
 
 def test_from_dict_applies_defaults_for_missing_attrs():

--- a/tests/test_project_codec.py
+++ b/tests/test_project_codec.py
@@ -50,6 +50,26 @@ def test_legacy_two_field_project_loads_without_changing_focus_data():
     assert restored.focuses.names["duplicate"] == (91, 92)
 
 
+def test_legacy_decode_still_migrates_pixel_coords():
+    legacy = {
+        "tree_name": "legacy_tree",
+        "focuses": [
+            {
+                "id": 1,
+                "name": "TAG_start",
+                "x": 192,
+                "y": 384,
+                "effects": [],
+                "prereqs": [],
+            }
+        ],
+    }
+
+    workspace = decode_project(legacy)
+
+    assert (workspace.focuses[1].x, workspace.focuses[1].y) == (2, 4)
+
+
 def test_legacy_decode_yields_empty_file_path():
     # The app must not treat this empty file_path as "clear the export target"
     # -- loading an old project keeps whatever export file the user had chosen.
@@ -113,6 +133,20 @@ def test_v2_roundtrip_preserves_workspace_and_tree_metadata():
     assert restored.extras == {"future_root_field": [1, 2, 3]}
     assert list(restored.focuses) == [main.id, extra.id]
     assert restored.focuses.names["same_name"] == (main.id, extra.id)
+
+
+def test_v2_roundtrip_preserves_grid_coords_that_are_multiples_of_96():
+    """Grid coords that happen to be multiples of 96 (XGRID) must survive a
+    current-format save/load unchanged -- they aren't legacy pixel coords."""
+    focus = Focus(96, 192)
+    workspace = EditorWorkspace(
+        focuses=FocusDocument([focus]),
+        main_tree=TreeDocument(metadata=TreeMetadata(tree_id="TAG_focus_tree")),
+    )
+
+    restored = decode_project(encode_project(workspace))
+
+    assert (restored.focuses[focus.id].x, restored.focuses[focus.id].y) == (96, 192)
 
 
 def test_future_project_version_is_rejected_without_legacy_fallback():

--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -121,6 +121,21 @@ def test_clear_empties_both_stacks():
     assert stack.redo(focuses, Focus.from_dict) is None
 
 
+def test_undo_then_redo_preserves_grid_coords_that_are_multiples_of_96():
+    """A focus legitimately at a grid coord that's a multiple of 96 (e.g.
+    x=96) must not be mistaken for a legacy pixel coord and halved."""
+    focuses = {1: _mk_focus(1, "focus_1", x=96, y=192)}
+    stack = UndoStack()
+    stack.push("edit cost", focuses, touched_ids=(1,))
+    focuses[1].cost = 99
+
+    stack.undo(focuses, Focus.from_dict)
+    assert (focuses[1].x, focuses[1].y) == (96, 192)
+
+    stack.redo(focuses, Focus.from_dict)
+    assert (focuses[1].x, focuses[1].y) == (96, 192)
+
+
 def test_undo_then_redo_roundtrip_restores_state_and_changed_set():
     """After undo, redo must reconstruct the post-edit focus and report it
     as `changed_ids` so the caller's redraw picks it up."""


### PR DESCRIPTION
## Bottom line
`Focus.from_dict` divided any coord that was a multiple of 96 on every call, so a focus legitimately at grid 96/192/288 jumped on undo/redo of an unrelated edit or on project reload. The migration now runs only on the legacy (pre-versioning) decode path.

Closes #112

## How
- `Focus.from_dict` takes keyword-only `legacy=False`; the 96-divide runs only when true.
- Only `_decode_legacy` in `project_codec.py` passes `legacy=True`. The v2 path and both undo/redo call sites use the default.
- Tests: legacy files still migrate (192/384 to 2/4); grid (96, 192) survives undo+redo and a v2 save/load round-trip.

BLUF