### PR TITLE
Push undo before remove-effect and offset edits

### DIFF
--- a/hoi4_content_maker.py
+++ b/hoi4_content_maker.py
@@ -1742,6 +1742,7 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
         """Add a blank offset entry to the selected focus and refresh UI."""
         if not self.selected:
             return
+        self._push_undo("add offset", touched_ids=(self.selected.id,))
         self._save_offsets_to_focus()
         self.selected.offsets.append({"x": 0, "y": 0, "trigger": ""})
         self._refresh_offsets(self.selected)
@@ -1750,6 +1751,7 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
         """Remove offset at idx from the selected focus and refresh UI."""
         if not self.selected:
             return
+        self._push_undo("remove offset", touched_ids=(self.selected.id,))
         self._save_offsets_to_focus()
         offs = getattr(self.selected, "offsets", [])
         if 0 <= idx < len(offs):

--- a/src/hoi4cm/ui/effects_panel.py
+++ b/src/hoi4cm/ui/effects_panel.py
@@ -825,6 +825,7 @@ class EffectsMixin:
     def _rm_effect(self, idx):
         if not self.selected:
             return
+        self._push_undo("remove effect", touched_ids=(self.selected.id,))
         self.selected.effects.pop(idx)
         self._refresh_effects()
         self._focus_list_cache.invalidate()

--- a/tests/test_undo_call_sites.py
+++ b/tests/test_undo_call_sites.py
@@ -37,6 +37,9 @@ class _UndoCallSiteApp:
         self._refresh_prereqs = Mock()
         self._refresh_mutex = Mock()
         self._refresh_effects = Mock()
+        self._focus_list_cache = Mock()
+        self._save_offsets_to_focus = Mock()
+        self._refresh_offsets = Mock()
         self._populate = Mock()
         self._hint = Mock()
         self._draw_lines = Mock()
@@ -228,6 +231,108 @@ def test_remove_mutex_pushes_selected_and_partner_ids():
     )
     assert selected.mutex == []
     assert partner.mutex == []
+
+
+def test_rm_effect_pushes_focus_id():
+    focus = Focus()
+    focus.effects = [{"type": "add_ideas", "fields": {}}]
+    app = _UndoCallSiteApp([focus])
+    app.selected = focus
+
+    app_module.App._rm_effect(_as_app(app), 0)
+
+    app._push_undo.assert_called_once_with("remove effect", touched_ids=(focus.id,))
+    assert focus.effects == []
+
+
+def test_rm_effect_round_trip_through_real_undo_stack():
+    focus = Focus()
+    focus.effects = [{"type": "add_ideas", "fields": {}}]
+    app = _UndoCallSiteApp([focus])
+    app.selected = focus
+    app._undo_stack = UndoStack()
+
+    def push_undo(label="action", touched_ids=None):
+        app_module.App._push_undo(_as_app(app), label, touched_ids)
+
+    app._push_undo = push_undo
+
+    app_module.App._rm_effect(_as_app(app), 0)
+    assert focus.effects == []
+
+    app_module.App._undo(_as_app(app))
+
+    assert app.selected.effects == [{"type": "add_ideas", "fields": {}}]
+
+
+def test_add_offset_pushes_focus_id_and_appends_offset():
+    focus = Focus()
+    focus.offsets = [{"x": 1, "y": 2, "trigger": "has_war = yes"}]
+    app = _UndoCallSiteApp([focus])
+    app.selected = focus
+
+    app_module.App._add_offset(_as_app(app))
+
+    app._push_undo.assert_called_once_with("add offset", touched_ids=(focus.id,))
+    assert focus.offsets == [
+        {"x": 1, "y": 2, "trigger": "has_war = yes"},
+        {"x": 0, "y": 0, "trigger": ""},
+    ]
+
+
+def test_add_offset_round_trip_through_real_undo_stack():
+    focus = Focus()
+    focus.offsets = [{"x": 1, "y": 2, "trigger": ""}]
+    app = _UndoCallSiteApp([focus])
+    app.selected = focus
+    app._undo_stack = UndoStack()
+
+    def push_undo(label="action", touched_ids=None):
+        app_module.App._push_undo(_as_app(app), label, touched_ids)
+
+    app._push_undo = push_undo
+
+    app_module.App._add_offset(_as_app(app))
+    assert len(focus.offsets) == 2
+
+    app_module.App._undo(_as_app(app))
+
+    assert app.selected.offsets == [{"x": 1, "y": 2, "trigger": ""}]
+
+
+def test_del_offset_pushes_focus_id_and_removes_offset():
+    focus = Focus()
+    focus.offsets = [{"x": 1, "y": 2, "trigger": ""}, {"x": 3, "y": 4, "trigger": ""}]
+    app = _UndoCallSiteApp([focus])
+    app.selected = focus
+
+    app_module.App._del_offset(_as_app(app), 0)
+
+    app._push_undo.assert_called_once_with("remove offset", touched_ids=(focus.id,))
+    assert focus.offsets == [{"x": 3, "y": 4, "trigger": ""}]
+
+
+def test_del_offset_round_trip_through_real_undo_stack():
+    focus = Focus()
+    focus.offsets = [{"x": 1, "y": 2, "trigger": ""}, {"x": 3, "y": 4, "trigger": ""}]
+    app = _UndoCallSiteApp([focus])
+    app.selected = focus
+    app._undo_stack = UndoStack()
+
+    def push_undo(label="action", touched_ids=None):
+        app_module.App._push_undo(_as_app(app), label, touched_ids)
+
+    app._push_undo = push_undo
+
+    app_module.App._del_offset(_as_app(app), 0)
+    assert len(focus.offsets) == 1
+
+    app_module.App._undo(_as_app(app))
+
+    assert app.selected.offsets == [
+        {"x": 1, "y": 2, "trigger": ""},
+        {"x": 3, "y": 4, "trigger": ""},
+    ]
 
 
 def test_drag_click_without_grid_move_does_not_push_undo():


### PR DESCRIPTION
## Bottom line
Deleting an effect or adding/removing an offset never pushed an undo entry, so those edits were un-undoable and a later undo of something else could restore a snapshot predating them. All three call sites now push `_push_undo(..., touched_ids=(self.selected.id,))` first, matching add-effect.

Closes #124

## How
- `src/hoi4cm/ui/effects_panel.py` `_rm_effect` pushes "remove effect".
- `hoi4_content_maker.py` `_add_offset`/`_del_offset` push before `_save_offsets_to_focus()`, since that call also mutates `offsets` and must land in the same snapshot.
- Six new tests in the existing `test_undo_call_sites.py` harness: push-label assertions plus real-UndoStack round-trips for all three call sites.

BLUF