### PR TITLE
Pan CFP markers and cull them off-screen

### DIFF
--- a/src/hoi4cm/ui/canvas.py
+++ b/src/hoi4cm/ui/canvas.py
@@ -41,6 +41,9 @@ from hoi4cm.ui.viewport import edge_visible, focus_visible, visible_world_rect
 # it, so nothing pops in/out right at the screen edge.
 _CULL_MARGIN_BOXES = 2
 _FOCUS_LOD_ZOOM = 0.4
+# Below this zoom a CFP marker is small enough (and its label already
+# suppressed) that it's not worth drawing — matches the LOD floor above.
+_CFP_MARKER_MIN_ZOOM = 0.3
 # Screens of grid generated beyond the viewport on each side. The grid is only
 # regenerated on zoom/resize/bounds change — a pan is a pure ``cv.move`` — so
 # the margin is what keeps lines under the cursor during a pan that has not
@@ -1185,7 +1188,7 @@ class CanvasMixin:
         self.cv.move("focus", dx, dy)
         self.cv.move("line", dx, dy)
         self.cv.move("templine", dx, dy)
-        self.cv.move("cfp", dx, dy)
+        self.cv.move("cfp_marker", dx, dy)
         # The dim mask and coordinate ruler are screen-anchored; a redraw of just
         # these two is cheap (a handful of items) and keeps them crisp.
         self._draw_canvas_bounds()
@@ -1367,14 +1370,19 @@ class CanvasMixin:
         We convert: grid_coord = cfp_value / GRID_SIZE.
         """
         self.cv.delete("cfp_marker")
-        cv = self.cv
         z = self.zoom
+        if z < _CFP_MARKER_MIN_ZOOM:
+            return
+        cv = self.cv
+        vis_rect = self._visible_rect()
         # 2× the old size: half-extent is now BOX*z instead of BOX*z/2
         h = BOX * z
         font_sz = max(8, int(9 * z))
         lw = max(2, int(2.5 * z))
 
         def _draw_box(gx, gy, color, label):
+            if vis_rect is not None and not focus_visible(gx, gy, vis_rect):
+                return
             cx, cy = self.w2c(gx, gy)
             # Subtle tinted fill via stipple (tkinter has no native alpha)
             cv.create_rectangle(
@@ -1389,17 +1397,16 @@ class CanvasMixin:
                 dash=(max(4, int(6 * z)), max(3, int(4 * z))),
                 tags="cfp_marker",
             )
-            if z >= 0.3:
-                cv.create_text(
-                    cx,
-                    cy,
-                    text=label,
-                    fill=color,
-                    anchor="center",
-                    font=("Helvetica", font_sz, "bold"),
-                    width=max(60, int(h * 1.8)),
-                    tags="cfp_marker",
-                )
+            cv.create_text(
+                cx,
+                cy,
+                text=label,
+                fill=color,
+                anchor="center",
+                font=("Helvetica", font_sz, "bold"),
+                width=max(60, int(h * 1.8)),
+                tags="cfp_marker",
+            )
 
         # Main tree CFP
         if (

--- a/tests/test_canvas_tk.py
+++ b/tests/test_canvas_tk.py
@@ -6,6 +6,7 @@ headless dev box.
 """
 
 import tkinter as tk
+from types import SimpleNamespace
 
 import pytest
 
@@ -14,7 +15,7 @@ from hoi4cm.models import Focus
 from hoi4cm.models.document import FocusDocument
 from hoi4cm.ui.canvas import CanvasMixin
 from hoi4cm.ui.canvas_scheduler import RedrawChannel
-from hoi4cm.ui.theme import XGRID
+from hoi4cm.ui.theme import XGRID, YGRID
 
 FAR_RECT = (0.0, 0.0, 10.0, 10.0)
 NEAR_RECT = (490.0, 490.0, 510.0, 510.0)
@@ -481,3 +482,46 @@ def test_full_redraw_cancels_pending_line_job(tk_root, monkeypatch):
 
     assert canceled == ["after#lines"]
     assert app._lines_job is None
+
+
+def test_pan_moves_the_cfp_marker_with_the_offset(tk_root):
+    cv = tk.Canvas(tk_root, width=200, height=200)
+    app = _FakeApp(cv)
+    app._cfp_x = XGRID * 5
+    app._cfp_y = YGRID * 5
+
+    app._draw_cfp_markers()
+    box = next(i for i in cv.find_withtag("cfp_marker") if cv.type(i) == "rectangle")
+
+    app._pan_pr(SimpleNamespace(x=0, y=0))
+    app._pan_mv(SimpleNamespace(x=30, y=-20))
+
+    x0, y0, x1, y1 = cv.coords(box)
+    center = ((x0 + x1) / 2, (y0 + y1) / 2)
+    # The marker sits at a fixed world position; after the pan its on-screen
+    # center must match that world position under the *new* offset.
+    assert center == pytest.approx(app.w2c(5, 5))
+
+
+def test_cfp_marker_hidden_below_the_zoom_floor(tk_root):
+    cv = tk.Canvas(tk_root, width=200, height=200)
+    app = _FakeApp(cv)
+    app.zoom = 0.2
+    app._cfp_x = XGRID * 5
+    app._cfp_y = YGRID * 5
+
+    app._draw_cfp_markers()
+
+    assert not cv.find_withtag("cfp_marker")
+
+
+def test_cfp_marker_culled_when_outside_the_viewport(tk_root, monkeypatch):
+    cv = tk.Canvas(tk_root, width=200, height=200)
+    app = _FakeApp(cv)
+    app._cfp_x = XGRID * 500
+    app._cfp_y = YGRID * 500
+    monkeypatch.setattr(app, "_visible_rect", lambda: FAR_RECT)
+
+    app._draw_cfp_markers()
+
+    assert not cv.find_withtag("cfp_marker")


### PR DESCRIPTION
## Bottom line
`_pan_mv` moved tag `"cfp"` but Continuous Focus Position markers are tagged `"cfp_marker"`, so they stayed glued to the screen during a pan and jumped on release. Pan now moves the real tag, and markers get the same viewport cull and a zoom floor.

Closes #121

## How
- `src/hoi4cm/ui/canvas.py`: pan moves `"cfp_marker"`. `_draw_cfp_markers` returns early below `_CFP_MARKER_MIN_ZOOM = 0.3` (the value that previously gated only the text label) and skips boxes outside `_visible_rect()` via the existing `focus_visible` helper.
- Tests in `test_canvas_tk.py` (existing headless-Tk pattern): pan tracks world position (fails pre-fix), zoom-floor hide, viewport cull.

BLUF