### PR TITLE
Keep had_wrapper for shared/joint-only wrapped trees

### DIFF
--- a/src/hoi4cm/focus_tree/parse.py
+++ b/src/hoi4cm/focus_tree/parse.py
@@ -211,9 +211,11 @@ def parse_focus_tree(raw, path):
     country_tag = "TAG"
     country_raw = ""
     tree_extras: dict = {}
+    wrapper_seen = False
     i = 0
     while i < len(tokens):
         if tokens[i] == "focus_tree" and i + 1 < len(tokens) and tokens[i + 1] == "=":
+            wrapper_seen = True
             block, i = parse_block(tokens, i + 2)
             _id_val = block.get("id")
             if isinstance(_id_val, str):
@@ -260,7 +262,7 @@ def parse_focus_tree(raw, path):
         else:
             i += 1
 
-    had_wrapper = bool(focuses_data)  # True if file had a focus_tree = { } wrapper
+    had_wrapper = wrapper_seen  # True if a focus_tree = { } wrapper was parsed
 
     # Fallback: top-level focus/shared_focus/joint_focus blocks (no wrapper).
     if not focuses_data:

--- a/tests/test_focus_tree_parse.py
+++ b/tests/test_focus_tree_parse.py
@@ -75,6 +75,91 @@ joint_focus = {
 }
 """
 
+# focus_tree = { } wrappers holding only shared_focus/joint_focus blocks (or a
+# mix), used to pin issue #123: had_wrapper must reflect that a wrapper was
+# parsed, not just that a plain `focus` key was found.
+WRAPPED_JOINT_ONLY = """\
+focus_tree = {
+\tid = TST_joint_tree
+\tcountry = {
+\t\tfactor = 0
+\t\tmodifier = {
+\t\t\tadd = 20
+\t\t\toriginal_tag = TST
+\t\t}
+\t}
+\tcontinuous_focus_position = { x = 0 y = 0 }
+\tjoint_focus = {
+\t\tid = TST_joint_one
+\t\ticon = GFX_x
+\t\tx = 0
+\t\ty = 0
+\t\tcost = 1
+\t\tcompletion_reward = {
+\t\t\tadd_political_power = 50
+\t\t}
+\t}
+}
+"""
+
+WRAPPED_SHARED_ONLY = """\
+focus_tree = {
+\tid = TST_shared_only_tree
+\tcountry = {
+\t\tfactor = 0
+\t\tmodifier = {
+\t\t\tadd = 20
+\t\t\toriginal_tag = TST
+\t\t}
+\t}
+\tcontinuous_focus_position = { x = 0 y = 0 }
+\tshared_focus = {
+\t\tid = TST_shared_one
+\t\ticon = GFX_x
+\t\tx = 0
+\t\ty = 0
+\t\tcost = 1
+\t\tcompletion_reward = {
+\t\t\tadd_political_power = 50
+\t\t}
+\t}
+}
+"""
+
+WRAPPED_MIXED = """\
+focus_tree = {
+\tid = TST_mixed_tree
+\tcountry = {
+\t\tfactor = 0
+\t\tmodifier = {
+\t\t\tadd = 20
+\t\t\toriginal_tag = TST
+\t\t}
+\t}
+\tcontinuous_focus_position = { x = 0 y = 0 }
+\tfocus = {
+\t\tid = TST_mixed_focus
+\t\ticon = GFX_x
+\t\tx = 0
+\t\ty = 0
+\t\tcost = 1
+\t\tcompletion_reward = {
+\t\t\tadd_political_power = 50
+\t\t}
+\t}
+\tshared_focus = {
+\t\tid = TST_mixed_shared
+\t\ticon = GFX_x
+\t\tx = 1
+\t\ty = 1
+\t\tcost = 1
+\t\tcompletion_reward = {
+\t\t\tadd_political_power = 25
+\t\t}
+\t}
+}
+"""
+
 
 def test_parse_tree_metadata():
     p = parse_focus_tree(WRAPPED, "/tmp/TST_shared_tree.txt")
@@ -204,6 +289,23 @@ def test_parse_no_wrapper_fallback():
     assert [f["id"] for f in p.focuses_data] == ["JNT_one"]
     assert "joint_trigger" in p.raw_rewards[("JNT_one", "_joint_extra")]
     assert "is_ai = no" in p.raw_rewards[("JNT_one", "_joint_extra")]
+
+
+@pytest.mark.parametrize(
+    "src,ids",
+    [
+        (WRAPPED_JOINT_ONLY, ["TST_joint_one"]),
+        (WRAPPED_SHARED_ONLY, ["TST_shared_one"]),
+        (WRAPPED_MIXED, ["TST_mixed_focus", "TST_mixed_shared"]),
+    ],
+)
+def test_had_wrapper_true_for_shared_or_joint_only_wrapper(src, ids):
+    """Issue #123: a wrapper holding only shared_focus/joint_focus blocks (or
+    a mix) must still be recorded as wrapped, not just one with a plain
+    `focus` key."""
+    p = parse_focus_tree(src, "/tmp/x.txt")
+    assert p.had_wrapper is True
+    assert [f["id"] for f in p.focuses_data] == ids
 
 
 def test_parse_strips_bom():

--- a/tests/test_focus_tree_roundtrip.py
+++ b/tests/test_focus_tree_roundtrip.py
@@ -9,7 +9,13 @@ survive and that key content actually made it into the exported text.
 import os
 
 import pytest
-from test_focus_tree_parse import NO_WRAPPER, WRAPPED
+from test_focus_tree_parse import (
+    NO_WRAPPER,
+    WRAPPED,
+    WRAPPED_JOINT_ONLY,
+    WRAPPED_MIXED,
+    WRAPPED_SHARED_ONLY,
+)
 
 from hoi4cm.core import read_file
 from hoi4cm.focus_tree.build import build_focuses
@@ -88,7 +94,13 @@ def _summary(focuses):
 
 @pytest.mark.parametrize(
     "src,tree_type",
-    [(WRAPPED, "shared"), (NO_WRAPPER, "joint")],
+    [
+        (WRAPPED, "shared"),
+        (NO_WRAPPER, "joint"),
+        (WRAPPED_JOINT_ONLY, "joint"),
+        (WRAPPED_SHARED_ONLY, "shared"),
+        (WRAPPED_MIXED, "shared"),
+    ],
 )
 def test_export_is_idempotent(src, tree_type):
     _f1, t1 = _load_and_export(src, tree_type)
@@ -98,12 +110,40 @@ def test_export_is_idempotent(src, tree_type):
 
 @pytest.mark.parametrize(
     "src,tree_type",
-    [(WRAPPED, "shared"), (NO_WRAPPER, "joint")],
+    [
+        (WRAPPED, "shared"),
+        (NO_WRAPPER, "joint"),
+        (WRAPPED_JOINT_ONLY, "joint"),
+        (WRAPPED_SHARED_ONLY, "shared"),
+        (WRAPPED_MIXED, "shared"),
+    ],
 )
 def test_structural_fields_survive(src, tree_type):
     f1, t1 = _load_and_export(src, tree_type)
     f2, _t2 = _load_and_export(t1, tree_type)
     assert _summary(f1) == _summary(f2)
+
+
+@pytest.mark.parametrize(
+    "src,tree_type,wrapper_kept",
+    [
+        (WRAPPED_JOINT_ONLY, "joint", False),
+        (WRAPPED_SHARED_ONLY, "shared", True),
+        (WRAPPED_MIXED, "shared", True),
+    ],
+)
+def test_shared_or_joint_only_wrapper_export(src, tree_type, wrapper_kept):
+    """Issue #123: a wrapped shared-only (or mixed) tree must keep its
+    focus_tree = { } wrapper, and with it the country/extras fields it holds.
+    Joint trees still unwrap to bare joint_focus = { } blocks by design.
+    """
+    _f, t1 = _load_and_export(src, tree_type)
+    assert ("focus_tree = {" in t1) is wrapper_kept
+    if wrapper_kept:
+        assert "country = {" in t1
+        assert "continuous_focus_position = {" in t1
+    else:
+        assert "joint_focus = {" in t1
 
 
 def test_wrapped_content_present():


### PR DESCRIPTION
## Bottom line
A `focus_tree = {` wrapper holding only `shared_focus`/`joint_focus` blocks now keeps `had_wrapper`, so export preserves the wrapper and its country/extras. Joint-only trees still unwrap by design.

## Why
`parse_focus_tree` derived `had_wrapper` from `bool(focuses_data)`, which only counts plain `focus` entries. Wrapped shared-only or mixed-nested files exported as bare blocks, losing the wrapper, `country`, and `continuous_focus_position`.

## How
Track a `wrapper_seen` flag the moment the parser enters the `focus_tree =` block. Goldens pin wrapped joint-only, wrapped shared-only, and mixed cases through parse, idempotent export, and wrapper survival.

Closes #123
BLUF

https://claude.ai/code/session_01BVpKMsVYgRictZoYLh1WLw