### PR TITLE
Give duplicated focuses a real counter id and fresh coords

### DIFF
--- a/hoi4_content_maker.py
+++ b/hoi4_content_maker.py
@@ -183,7 +183,6 @@ from tkinter import filedialog, messagebox
 
 log.info("tkinter imported OK")
 import bisect
-import copy
 import re
 import time
 
@@ -5774,8 +5773,7 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
             return
 
         f = self.selected
-        nf = copy.deepcopy(f)
-        nf.id = id(nf)
+        nf = f.duplicate()
         # Generate new unique name
         base = re.sub(r"_copy\d*$", "", f.name) + "_copy"
         existing_names = {foc.name for foc in self.focuses.values()}

--- a/src/hoi4cm/models/focus.py
+++ b/src/hoi4cm/models/focus.py
@@ -1,5 +1,7 @@
 """Focus data model — the canvas item at the heart of every focus tree."""
 
+import copy
+
 
 class Focus:
     """A single national focus in the editor canvas."""
@@ -52,6 +54,16 @@ class Focus:
 
     def to_dict(self):
         return {k: v for k, v in self.__dict__.items() if not k.startswith("_")}
+
+    def duplicate(self):
+        """Deep copy with a fresh counter id and no stale imported coordinates."""
+        nf = copy.deepcopy(self)
+        Focus._next += 1
+        nf.id = Focus._next
+        for attr in ("_raw_gx", "_raw_gy", "_rel_dx", "_rel_dy"):
+            if attr in nf.__dict__:
+                del nf.__dict__[attr]
+        return nf
 
     @staticmethod
     def from_dict(d):

--- a/tests/test_focus.py
+++ b/tests/test_focus.py
@@ -73,3 +73,44 @@ def test_to_dict_excludes_dynamic_private_attrs():
     restored = Focus.from_dict(f.to_dict())
     assert not hasattr(restored, "_items")
     assert not hasattr(restored, "_draw_key")
+
+
+def test_duplicate_assigns_id_from_counter():
+    f = Focus()
+    nf = f.duplicate()
+    assert nf.id != f.id
+    assert nf.id == Focus._next
+
+
+def test_duplicate_after_load_stays_small_and_unique():
+    base = Focus._next + 100
+    Focus.from_dict({"id": base, "x": 0, "y": 0})
+    f = Focus.from_dict({"id": base + 1, "x": 0, "y": 0})
+    nf = f.duplicate()
+    assert nf.id == base + 3
+    assert nf.id != f.id
+
+
+def test_duplicate_drops_raw_import_coords():
+    f = Focus()
+    f._raw_gx = 10
+    f._raw_gy = 20
+    f._rel_dx = 1
+    f._rel_dy = 2
+    nf = f.duplicate()
+    assert not hasattr(nf, "_raw_gx")
+    assert not hasattr(nf, "_raw_gy")
+    assert not hasattr(nf, "_rel_dx")
+    assert not hasattr(nf, "_rel_dy")
+    # original is untouched
+    assert f._raw_gx == 10 and f._raw_gy == 20
+
+
+def test_duplicate_copies_public_fields():
+    f = Focus(3, 4)
+    f.name = "my_focus"
+    f.cost = 5
+    nf = f.duplicate()
+    assert nf.name == f.name
+    assert nf.x == f.x and nf.y == f.y
+    assert nf.cost == f.cost

--- a/tests/test_focus_tree_export_extra.py
+++ b/tests/test_focus_tree_export_extra.py
@@ -1,0 +1,50 @@
+"""Tests for export_focus_tree (extra/shared and joint trees, tree_idx > 0)."""
+
+import pytest
+
+from hoi4cm.focus_tree.export import export_focus_tree
+from hoi4cm.models import Focus
+
+
+@pytest.fixture(autouse=True)
+def reset_counter():
+    old = Focus._next
+    Focus._next = 0
+    yield
+    Focus._next = old
+
+
+def _info(**overrides):
+    info = {"tree_id": "TST_extra", "country_tag": "TST"}
+    info.update(overrides)
+    return info
+
+
+def test_duplicate_of_extra_tree_focus_exports_at_new_canvas_position():
+    """Regression test for #116: duplicate must not reuse the original's raw coords."""
+    original = Focus(3, 5)
+    original.name = "TST_original"
+    original.tree_idx = 1
+    original._raw_gx = 1
+    original._raw_gy = 9
+
+    duplicate = original.duplicate()
+    duplicate.name = "TST_original_copy"
+    duplicate.x = original.x + 1
+    duplicate.y = original.y
+
+    lookup = {duplicate.id: duplicate}
+    text = export_focus_tree([duplicate], _info(), focus_lookup=lookup)
+    lines = text.splitlines()
+
+    assert "\tx = 4" in lines
+    assert "\ty = 5" in lines
+    assert "\tx = 1" not in lines
+    assert "\ty = 9" not in lines
+
+    # the original, exported on its own, still uses its raw file coords
+    original_lookup = {original.id: original}
+    original_text = export_focus_tree([original], _info(), focus_lookup=original_lookup)
+    original_lines = original_text.splitlines()
+    assert "\tx = 1" in original_lines
+    assert "\ty = 9" in original_lines

--- a/tests/test_project_codec.py
+++ b/tests/test_project_codec.py
@@ -162,3 +162,29 @@ def test_failed_project_write_keeps_the_previous_save(tmp_path, monkeypatch):
 
     assert path.read_text(encoding="utf-8") == original
     assert list(tmp_path.glob(".*.tmp")) == []
+
+
+# ── duplicate after load (issue #116) ────────────────────────────
+
+
+@pytest.fixture
+def reset_counter():
+    old = Focus._next
+    Focus._next = 0
+    yield
+    Focus._next = old
+
+
+def test_duplicate_after_save_load_gets_a_small_unique_id(reset_counter):
+    workspace = EditorWorkspace(
+        focuses=FocusDocument([Focus(1, 1), Focus(2, 2)]),
+        main_tree=TreeDocument(metadata=TreeMetadata(tree_id="TAG_focus_tree")),
+    )
+
+    restored = decode_project(encode_project(workspace))
+    existing_ids = set(restored.focuses)
+    original = restored.focuses[max(existing_ids)]
+    duplicate = original.duplicate()
+
+    assert duplicate.id not in existing_ids
+    assert duplicate.id < 100_000


### PR DESCRIPTION
## Bottom line
Duplicate now assigns ids from `Focus._next` instead of `id(nf)` and drops the copied `_raw_gx`/`_raw_gy`/`_rel_dx`/`_rel_dy` attrs, so extra-tree duplicates export at their new canvas position instead of on top of the original.

## Why
`id(nf)` is a memory address: huge, collision-prone after project save/load, and it bypassed the id counter. The deepcopy also carried the original's imported file coords, which extra-tree export prefers over canvas x/y.

## How
New `Focus.duplicate()` mirrors the `__init__`/`from_dict` counter logic and deletes the raw coord attrs; `codec._render_coordinates` already falls back to canvas coords when they're absent. Regression tests cover counter ids after load, dropped raw coords, and extra-tree duplicate export.

Closes #116
BLUF

https://claude.ai/code/session_01BVpKMsVYgRictZoYLh1WLw