### PR TITLE
Run validation off the Tk thread and stop swallowing errors

### DIFF
--- a/hoi4_content_maker.py
+++ b/hoi4_content_maker.py
@@ -1040,40 +1040,45 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
             self._run_validation()
 
     def _run_validation(self):
+        """Validate the document on a worker thread; apply results in on_done.
+
+        sprites/loc_keys gathering stays on the Tk thread (it only reads
+        ``MOD`` and disk, not widgets, but is captured before dispatch same
+        as ``self.focuses``) so the worker only ever sees plain snapshots.
+        ``lifecycle.begin`` invalidates any older "validation"-scoped run
+        still in flight, so a stale result never overwrites a newer one.
+        """
         self._validation_job = None
-        try:
-            sprites = self._validation_sprites()
-            loc_keys = self._validation_loc_keys()
-            issues = validate_document(self.focuses, sprites=sprites, loc_keys=loc_keys)
-        except Exception:
-            return
+        self._lifecycle.begin("validation")
+        sprites = self._validation_sprites()
+        loc_keys = self._validation_loc_keys()
+        focuses = dict(self.focuses)
+
+        def work():
+            return validate_document(focuses, sprites=sprites, loc_keys=loc_keys)
+
+        run_bg(self, work, self._apply_validation_result, scope="validation")
+
+    def _apply_validation_result(self, issues):
         try:
             worst = worst_severity_per_focus(issues)
         except Exception:
             worst = {}
-        prev_issues = getattr(self, "_validation_issues", None)
-        prev_worst = getattr(self, "_validation_worst", None)
+        prev_issues = self._validation_issues
+        prev_worst = self._validation_worst
         changed = issues != prev_issues or worst != prev_worst
         self._validation_issues = issues
         self._validation_worst = worst
-        if not changed:
-            # still refresh dialog if open but avoid redraw churn
-            win = getattr(self, "_validation_win", None)
-            if win is not None and win.winfo_exists():
-                try:
-                    self._refresh_validation_dialog(win)
-                except Exception:
-                    pass
-            return
-        # refresh UI surfaces that depend on validation
-        try:
-            self._redraw()
-        except Exception:
-            pass
-        try:
-            self._invalidate_focus_list_structure()
-        except Exception:
-            pass
+        if changed:
+            # refresh UI surfaces that depend on validation
+            try:
+                self._redraw()
+            except Exception:
+                pass
+            try:
+                self._invalidate_focus_list_structure()
+            except Exception:
+                pass
         # if validation dialog is open, refresh its contents
         win = getattr(self, "_validation_win", None)
         if win is not None and win.winfo_exists():
@@ -6150,10 +6155,7 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
         tk.Button(
             filt_row,
             text=tr("validation.revalidate", "Re-validate"),
-            command=lambda: (
-                self._run_validation(),
-                self._refresh_validation_dialog(win),
-            ),
+            command=self._run_validation,
             bg=BG_CARD,
             fg=TEXT,
             relief="flat",

--- a/src/hoi4cm/focus_tree/validate.py
+++ b/src/hoi4cm/focus_tree/validate.py
@@ -15,6 +15,7 @@ from hoi4cm.models import Focus
 
 Severity = Literal["error", "warning", "info"]
 DEFAULT_GFX = "GFX_goal_generic_political_pressure"
+MAX_ISSUES = 300
 _KEY_RE = re.compile(r"\s+(\S+?)(?::\d+)?\s*[=:]?\s*\"")
 
 SEVERITY_RANK = {"error": 0, "warning": 1, "info": 2}
@@ -54,12 +55,15 @@ def validate_document(
     sprites: Mapping[str, str] | None = None,
     loc_keys: set[str] | None = None,
     include_default_icon_warning: bool = True,
+    max_issues: int = MAX_ISSUES,
 ) -> list[Issue]:
     """Validate a focus document.
 
     doc: FocusDocument or plain mapping id->Focus.
     sprites: MOD.sprites dict (gfx_name -> path) or None to skip GFX check.
     loc_keys: set of localisation keys present in the .yml or None to skip.
+    max_issues: cap on the returned list; excess issues are dropped and
+        replaced with one trailing "issues_truncated" info issue.
     """
     issues: list[Issue] = []
     if not doc:
@@ -99,8 +103,16 @@ def validate_document(
         occupied = dict(occupied)
 
     for (x, y), occupants in occupied.items():
-        if len(occupants) > 1:
-            sorted_ids = sorted(occupants)
+        if len(occupants) <= 1:
+            continue
+        # focuses from different loaded trees legitimately share coordinates
+        by_tree: dict[int, list[int]] = defaultdict(list)
+        for fid in occupants:
+            by_tree[getattr(doc[fid], "tree_idx", 0)].append(fid)
+        for tree_occupants in by_tree.values():
+            if len(tree_occupants) <= 1:
+                continue
+            sorted_ids = sorted(tree_occupants)
             names = [doc[i].name for i in sorted_ids]
             issues.append(
                 Issue(
@@ -284,6 +296,18 @@ def validate_document(
             dfs(nid)
 
     issues.sort(key=lambda issue: issue.sort_key())
+    if len(issues) > max_issues:
+        hidden = len(issues) - max_issues
+        issues = issues[:max_issues]
+        issues.append(
+            Issue(
+                "info",
+                "issues_truncated",
+                None,
+                None,
+                f"{hidden} more issue(s) not shown (showing first {max_issues})",
+            )
+        )
     return issues
 
 
@@ -301,6 +325,7 @@ def worst_severity_per_focus(issues: list[Issue]) -> dict[int, Severity]:
 
 __all__ = [
     "DEFAULT_GFX",
+    "MAX_ISSUES",
     "Issue",
     "Severity",
     "collect_loc_keys_from_text",

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -18,6 +18,7 @@ def _focus(  # type: ignore[no-untyped-def]
     prereqs=None,
     mutex=None,
     rel=None,
+    tree_idx=0,
 ):
     f = Focus(x, y)
     f.id = fid
@@ -27,6 +28,7 @@ def _focus(  # type: ignore[no-untyped-def]
     f.prereqs = prereqs if prereqs is not None else []
     f.mutex = mutex if mutex is not None else []
     f.relative_position_id = rel
+    f.tree_idx = tree_idx
     return f
 
 
@@ -173,6 +175,25 @@ def test_position_collision_with_three_occupants_single_issue():
     coll = [it for it in validate_document(doc) if it.code == "position_collision"]
     assert len(coll) == 1
     assert "5" in coll[0].message
+
+
+def test_position_collision_ignored_across_different_trees():
+    a = _focus(1, name="A", x=0, y=0, tree_idx=0)
+    b = _focus(2, name="B", x=0, y=0, tree_idx=1)
+    doc = FocusDocument([a, b])
+    issues = validate_document(doc)
+    assert not any(it.code == "position_collision" for it in issues)
+
+
+def test_position_collision_still_reported_within_same_tree():
+    a = _focus(1, name="A", x=0, y=0, tree_idx=1)
+    b = _focus(2, name="B", x=0, y=0, tree_idx=1)
+    c = _focus(3, name="C", x=0, y=0, tree_idx=2)
+    doc = FocusDocument([a, b, c])
+    coll = [it for it in validate_document(doc) if it.code == "position_collision"]
+    assert len(coll) == 1
+    assert "A" in coll[0].message and "B" in coll[0].message
+    assert "C" not in coll[0].message
 
 
 def test_plain_dict_fallback_for_occupied_positions():
@@ -418,3 +439,23 @@ def test_multiple_issues_per_focus_all_reported():
     assert "relative_position_unresolved" in codes
     assert "empty_effects" in codes
     assert "default_icon" in codes
+
+
+def test_issues_capped_with_truncation_notice():
+    focuses = [
+        _focus(fid, name=f"F{fid}", x=fid, gfx="", effects=[]) for fid in range(1, 11)
+    ]
+    doc = FocusDocument(focuses)
+    issues = validate_document(doc, max_issues=5)
+    assert len(issues) == 6
+    assert issues[-1].code == "issues_truncated"
+    assert issues[-1].severity == "info"
+    assert "15" in issues[-1].message
+    assert all(it.code != "issues_truncated" for it in issues[:-1])
+
+
+def test_issues_not_truncated_when_under_cap():
+    a = _focus(1, name="A", gfx="", effects=[])
+    doc = FocusDocument([a])
+    issues = validate_document(doc, max_issues=5)
+    assert not any(it.code == "issues_truncated" for it in issues)


### PR DESCRIPTION
## Bottom line
Auto-validation now runs on the shared worker pool instead of freezing the Tk thread, validator crashes surface through add_error instead of vanishing, cross-tree position collisions are no longer flagged, and the issue list is capped at 300 with a truncation notice.

## Why
`_run_validation` ran a full `validate_document` pass inline ~150ms after Load All Trees (a second UI freeze) and its bare `except Exception: return` hid any validator crash. After Load All, focuses from different trees share coordinates, flooding the dialog with false `position_collision` rows.

## How
Inputs (sprites, loc keys, a focuses snapshot) are captured on the Tk thread, `validate_document` runs via `run_bg` under a new "validation" lifecycle scope so a superseded run's result is dropped, and results apply in `on_done`. `validate.py` groups same-cell occupants by `tree_idx` and gained a `max_issues` cap (default 300) that appends one `issues_truncated` info row.

Closes #117
BLUF

https://claude.ai/code/session_01BVpKMsVYgRictZoYLh1WLw