### PR TITLE
Rewrite changed loc descriptions and escape wizard loc values

### DIFF
--- a/src/hoi4cm/focus_tree/loc.py
+++ b/src/hoi4cm/focus_tree/loc.py
@@ -8,7 +8,12 @@ import json
 import re
 from dataclasses import dataclass
 
-_KEY_RE = re.compile(r'\s+(\S+?)(?::\d+)?\s*[=:]?\s*"')
+_KEY_RE = re.compile(
+    r'^(?P<prefix>\s+(?P<key>\S+?)(?::\d+)?\s*[=:]?\s*")'
+    r'(?P<value>(?:[^"\\]|\\.)*)'
+    r'(?P<suffix>".*)$',
+    re.MULTILINE,
+)
 
 
 @dataclass(frozen=True)
@@ -70,42 +75,66 @@ class LocTarget:
 
 
 def build_loc_yml(existing_text, focuses, country_tag, *, language="english"):
-    """Return ``(new_text, added_count)`` for the focus-tree loc .yml.
+    """Return ``(new_text, changed_count)`` for the focus-tree loc .yml.
 
     ``existing_text`` is the current file contents, or ``None`` if the file
     doesn't exist yet (distinct from an existing-but-empty file, which still
     gets appended to rather than re-headered). ``focuses`` contributes a
     title-cased name key and a ``_desc`` key per focus (falling back to a
     generated sentence when the focus has no ``desc``). ``country_tag`` names
-    the section header. Returns ``(None, 0)`` when every key is already
-    present in ``existing_text`` — the caller should skip the write.
-    """
-    existing_keys = set()
-    if existing_text is not None:
-        for line in existing_text.splitlines():
-            m = _KEY_RE.match(line)
-            if m:
-                existing_keys.add(m.group(1))
+    the section header.
 
-    new_loc = {}
+    A missing key is appended. An existing ``_desc`` key is rewritten in
+    place when the focus has a non-empty ``desc`` that differs from the
+    value already on that line — a blank ``desc`` never overwrites a hand
+    edit. Title keys (the bare focus name) are never rewritten. Returns
+    ``(None, 0)`` when nothing needs to change — the caller should skip the
+    write.
+    """
+    existing_values = {}
+    if existing_text is not None:
+        for m in _KEY_RE.finditer(existing_text):
+            existing_values[m.group("key")] = m.group("value")
+
+    to_add = {}
+    to_update = {}
     for f in focuses:
         title = f.name.replace("_", " ").title()
         desc = f.desc if f.desc else f"Complete the {title} national focus."
-        new_loc[f.name] = title
-        new_loc[f"{f.name}_desc"] = desc
+        if f.name not in existing_values:
+            to_add[f.name] = title
 
-    to_add = {k: v for k, v in new_loc.items() if k not in existing_keys}
-    if not to_add:
+        desc_key = f"{f.name}_desc"
+        if desc_key not in existing_values:
+            to_add[desc_key] = desc
+        elif f.desc:
+            escaped = json.dumps(f.desc, ensure_ascii=False)[1:-1]
+            if existing_values[desc_key] != escaped:
+                to_update[desc_key] = f.desc
+
+    if not to_add and not to_update:
         return None, 0
 
     target = LocTarget(language)
     base = existing_text if existing_text is not None else target.header() + "\n"
     if base and not base.endswith("\n"):
         base += "\n"
+
+    if to_update:
+
+        def _rewrite(m):
+            key = m.group("key")
+            if key not in to_update:
+                return m.group(0)
+            new_value = json.dumps(to_update[key], ensure_ascii=False)[1:-1]
+            return m.group("prefix") + new_value + m.group("suffix")
+
+        base = _KEY_RE.sub(_rewrite, base)
+
     needs_header = f"##########Focuses - {country_tag}##########" not in base
     addition = []
     if needs_header:
         addition.append(f"\n ##########Focuses - {country_tag}##########\n")
     for k, v in to_add.items():
         addition.append(f" {k}: {json.dumps(v, ensure_ascii=False)}\n")
-    return base + "".join(addition), len(to_add)
+    return base + "".join(addition), len(to_add) + len(to_update)

--- a/src/hoi4cm/wizards/_generators.py
+++ b/src/hoi4cm/wizards/_generators.py
@@ -11,6 +11,8 @@ are extracted verbatim, only relocated — so widget-driven callers and
 headless callers agree byte-for-byte.
 """
 
+import json
+
 from hoi4cm.focus_tree.loc import LocTarget
 
 
@@ -120,10 +122,11 @@ def generate_event_loc_yml(events, *, loc_language="english"):
         return ""
     lines = [LocTarget(loc_language).header(), ""]
     for ev in events:
-        lines.append(f' {ev.eid}.t: "{ev.title_text}"')
-        lines.append(f' {ev.eid}.d: "{ev.desc_text}"')
+        lines.append(f" {ev.eid}.t: {json.dumps(ev.title_text, ensure_ascii=False)}")
+        lines.append(f" {ev.eid}.d: {json.dumps(ev.desc_text, ensure_ascii=False)}")
         for opt in ev.options:
-            lines.append(f' {opt["name"]}: "{opt.get("text", opt["name"])}"')
+            opt_text = opt.get("text", opt["name"])
+            lines.append(f" {opt['name']}: {json.dumps(opt_text, ensure_ascii=False)}")
         lines.append("")
     return "\n".join(lines)
 
@@ -462,8 +465,8 @@ def build_dyn_mod_output(
         "# File must be UTF-8-BOM encoded",
         "# ============================================================",
         "",
-        f' {mid}: "{name}"',
-        f' {mid}_desc: "{desc}"',
+        f" {mid}: {json.dumps(name, ensure_ascii=False)}",
+        f" {mid}_desc: {json.dumps(desc, ensure_ascii=False)}",
         ' modifies_dynamic_modifier_tt: "Modifies $MODIFIER$"',
         ' adds_dynamic_modifier_tt: "Adds $MODIFIER$ which grants:"  # for activation focuses',  # noqa: E501
     ]
@@ -597,8 +600,8 @@ def build_national_spirit_output(
     )
     out.append("# ============================================================")
     out.append("")
-    out.append(f' {sid}: "{loc_n}"')
-    out.append(f' {sid}_desc: "{loc_d}"')
+    out.append(f" {sid}: {json.dumps(loc_n, ensure_ascii=False)}")
+    out.append(f" {sid}_desc: {json.dumps(loc_d, ensure_ascii=False)}")
     return "\n".join(out)
 
 
@@ -736,15 +739,20 @@ def generate_decision_loc_yml(cats, decs, *, loc_language="english"):
     for cat in cats:
         cid = _strip_val(cat["cat_id"])
         if cid:
-            lines.append(f' {cid}: "{cat["loc_name"]}"')
+            lines.append(f" {cid}: {json.dumps(cat['loc_name'], ensure_ascii=False)}")
             if _strip_val(cat.get("loc_desc", "")):
-                lines.append(f' {cid}_desc: "{_strip_val(cat["loc_desc"])}"')
+                cat_desc = _strip_val(cat["loc_desc"])
+                lines.append(f" {cid}_desc: {json.dumps(cat_desc, ensure_ascii=False)}")
         for dec in _decs_for_uid(decs, cat["uid"]):
             did = _strip_val(dec["dec_id"])
             if did:
-                lines.append(f' {did}: "{dec["loc_name"]}"')
+                dec_name = json.dumps(dec["loc_name"], ensure_ascii=False)
+                lines.append(f" {did}: {dec_name}")
                 if _strip_val(dec.get("loc_desc", "")):
-                    lines.append(f' {did}_desc: "{_strip_val(dec["loc_desc"])}"')
+                    dec_desc = _strip_val(dec["loc_desc"])
+                    lines.append(
+                        f" {did}_desc: {json.dumps(dec_desc, ensure_ascii=False)}"
+                    )
     return "\n".join(lines) + "\n"
 
 
@@ -776,7 +784,7 @@ def build_income_spirit_snippet(
         f"\t}}\n"
         f"\n"
         f"\t# Localisation needed:\n"
-        f'\t# {idea_id}: "{spirit_name}"\n'
-        f'\t# {idea_id}_desc: "{spirit_desc}"\n'
+        f"\t# {idea_id}: {json.dumps(spirit_name, ensure_ascii=False)}\n"
+        f"\t# {idea_id}_desc: {json.dumps(spirit_desc, ensure_ascii=False)}\n"
         f'\t# {tooltip_key}: "$$[?{variable_name}|+3] from \u00a7Y${idea_id}$\u00a7!\\n"'  # noqa: E501
     )

--- a/src/hoi4cm/wizards/additional_income.py
+++ b/src/hoi4cm/wizards/additional_income.py
@@ -6,6 +6,7 @@
 
 """MD Additional Income wizard."""
 
+import json
 import os
 import tkinter as tk
 from tkinter import messagebox
@@ -579,7 +580,10 @@ def open_additional_income_wizard(app):
                 if to_write:
                     wf.append_text(
                         loc_path,
-                        "".join(f' {k}: "{v}"\n' for k, v in to_write.items()),
+                        "".join(
+                            f" {k}: {json.dumps(v, ensure_ascii=False)}\n"
+                            for k, v in to_write.items()
+                        ),
                         encoding="utf-8-sig",
                     )
                     output_lines.append(

--- a/src/hoi4cm/wizards/dyn_mod.py
+++ b/src/hoi4cm/wizards/dyn_mod.py
@@ -1183,7 +1183,7 @@ def open_dyn_mod_wizard(app):
 
         def add_loc(key, value):
             if key not in existing_keys:
-                new_loc_lines.append(f' {key}: "{value}"')
+                new_loc_lines.append(f" {key}: {json.dumps(value, ensure_ascii=False)}")
 
         add_loc(mid, name)
         add_loc(f"{mid}_desc", desc)

--- a/src/hoi4cm/wizards/national_spirit.py
+++ b/src/hoi4cm/wizards/national_spirit.py
@@ -1666,7 +1666,10 @@ def open_national_spirit_wizard(app):
                         MOD.loc_target.header() + "\n",
                         encoding="utf-8-sig",
                     )
-                loc_body = "".join(f' {k}: "{v}"\n' for k, v in to_add.items())
+                loc_body = "".join(
+                    f" {k}: {json.dumps(v, ensure_ascii=False)}\n"
+                    for k, v in to_add.items()
+                )
                 wf.append_text(loc_path, loc_body, encoding="utf-8-sig")
                 rel = os.path.relpath(loc_path, mod_root)
                 saved.append(rel + f"  (+{len(to_add)} keys)")

--- a/tests/test_loc.py
+++ b/tests/test_loc.py
@@ -67,6 +67,98 @@ def test_all_keys_already_present_returns_none():
     assert count == 0
 
 
+def test_existing_desc_is_rewritten_when_focus_desc_changes():
+    existing = (
+        "l_english:\n"
+        ' TST_alpha: "Tst Alpha"\n'
+        ' TST_alpha_desc: "Old description."\n'
+    )
+    focuses = [_focus("TST_alpha", desc="New description.")]
+    text, count = build_loc_yml(existing, focuses, "TST")
+    assert count == 1
+    assert ' TST_alpha_desc: "New description."\n' in text
+    assert "Old description." not in text
+    assert ' TST_alpha: "Tst Alpha"\n' in text
+
+
+def test_existing_title_is_never_rewritten():
+    existing = (
+        "l_english:\n"
+        ' TST_alpha: "Hand-Edited Title"\n'
+        ' TST_alpha_desc: "Old description."\n'
+    )
+    focuses = [_focus("TST_alpha", desc="New description.")]
+    text, count = build_loc_yml(existing, focuses, "TST")
+    assert count == 1
+    assert ' TST_alpha: "Hand-Edited Title"\n' in text
+    assert ' TST_alpha_desc: "New description."\n' in text
+
+
+def test_blank_desc_never_overwrites_existing_desc():
+    existing = (
+        "l_english:\n"
+        ' TST_alpha: "Tst Alpha"\n'
+        ' TST_alpha_desc: "Hand-written description."\n'
+    )
+    focuses = [_focus("TST_alpha", desc="")]
+    text, count = build_loc_yml(existing, focuses, "TST")
+    assert text is None
+    assert count == 0
+
+
+def test_desc_matching_existing_value_is_not_rewritten():
+    existing = (
+        "l_english:\n"
+        ' TST_alpha: "Tst Alpha"\n'
+        ' TST_alpha_desc: "Same description."\n'
+    )
+    focuses = [_focus("TST_alpha", desc="Same description.")]
+    text, count = build_loc_yml(existing, focuses, "TST")
+    assert text is None
+    assert count == 0
+
+
+def test_rewritten_desc_value_with_quote_is_escaped():
+    existing = (
+        "l_english:\n"
+        ' TST_alpha: "Tst Alpha"\n'
+        ' TST_alpha_desc: "Old description."\n'
+    )
+    focuses = [_focus("TST_alpha", desc='Say "hello".')]
+    text, count = build_loc_yml(existing, focuses, "TST")
+    assert count == 1
+    assert ' TST_alpha_desc: "Say \\"hello\\"."\n' in text
+
+
+def test_rewritten_desc_preserves_pluralization_suffix():
+    existing = (
+        "l_english:\n"
+        ' TST_alpha: "Tst Alpha"\n'
+        ' TST_alpha_desc:0 "Old description."\n'
+    )
+    focuses = [_focus("TST_alpha", desc="New description.")]
+    text, count = build_loc_yml(existing, focuses, "TST")
+    assert count == 1
+    assert ' TST_alpha_desc:0 "New description."\n' in text
+
+
+def test_rewrite_and_add_combine_in_one_pass():
+    existing = (
+        "l_english:\n"
+        ' TST_alpha: "Tst Alpha"\n'
+        ' TST_alpha_desc: "Old description."\n'
+    )
+    focuses = [
+        _focus("TST_alpha", desc="New description."),
+        _focus("TST_beta"),
+    ]
+    text, count = build_loc_yml(existing, focuses, "TST")
+    assert count == 3
+    assert ' TST_alpha_desc: "New description."\n' in text
+    assert ' TST_beta: "Tst Beta"\n' in text
+    assert ' TST_beta_desc: "Complete the Tst Beta national focus."\n' in text
+
+
 def test_existing_key_detection_handles_pluralization_suffix():
     # HOI4 loc files sometimes suffix the version number: `key:0 "val"`.
     existing = 'l_english:\n TST_alpha:0 "Tst Alpha"\n'

--- a/tests/test_wizard_generators_decision.py
+++ b/tests/test_wizard_generators_decision.py
@@ -250,6 +250,16 @@ def test_generate_decision_loc_yml_includes_descriptions():
     assert ' TAG_decision_desc: "Dec desc"' in out
 
 
+def test_generate_decision_loc_yml_escapes_quotes_in_values():
+    cats = [_cat(loc_name='My "Cat"', loc_desc='Say "hi".')]
+    decs = [_dec(loc_name='My "Decision"', loc_desc='Say "bye".')]
+    out = generate_decision_loc_yml(cats, decs)
+    assert ' TAG_cat: "My \\"Cat\\""' in out
+    assert ' TAG_cat_desc: "Say \\"hi\\"."' in out
+    assert ' TAG_decision: "My \\"Decision\\""' in out
+    assert ' TAG_decision_desc: "Say \\"bye\\"."' in out
+
+
 def test_generate_decision_loc_yml_uses_configured_language_header():
     out = generate_decision_loc_yml([_cat()], [_dec()], loc_language="german")
 

--- a/tests/test_wizard_generators_event.py
+++ b/tests/test_wizard_generators_event.py
@@ -224,6 +224,20 @@ def test_generate_event_loc_yml_uses_option_name_when_text_missing():
     assert ' ns.1.a: "ns.1.a"' in out
 
 
+def test_generate_event_loc_yml_escapes_quotes_in_values():
+    e = _make_event(
+        eid="ns.1",
+        title_text='The "Title"',
+        desc_text="What is happening.",
+        options=[
+            {"name": "ns.1.a", "text": 'Say "yes"', "effects": "", "ai_chance": "1"},
+        ],
+    )
+    out = generate_event_loc_yml([e])
+    assert ' ns.1.t: "The \\"Title\\""' in out
+    assert ' ns.1.a: "Say \\"yes\\""' in out
+
+
 def test_generate_event_loc_yml_empty_returns_empty_string():
     assert generate_event_loc_yml([]) == ""
 

--- a/tests/test_wizard_generators_income.py
+++ b/tests/test_wizard_generators_income.py
@@ -29,4 +29,17 @@ def test_build_income_spirit_snippet_emits_loc_hints():
     )
     assert '# TAG_idea: "My Spirit"' in out
     assert '# TAG_idea_desc: "My description."' in out
-    assert '# tag_money_tt: "$$[?TAG_money_var|+3] from §Y$TAG_idea$\u00a7!\\n"' in out
+    assert '# tag_money_tt: "$$[?TAG_money_var|+3] from §Y$TAG_idea$§!\\n"' in out
+
+
+def test_build_income_spirit_snippet_escapes_quotes_in_loc_hints():
+    out = build_income_spirit_snippet(
+        idea_id="TAG_idea",
+        country_tag="TAG",
+        variable_name="TAG_money_var",
+        tooltip_key="tag_money_tt",
+        spirit_name='My "Spirit"',
+        spirit_desc='Say "hi".',
+    )
+    assert '# TAG_idea: "My \\"Spirit\\""' in out
+    assert '# TAG_idea_desc: "Say \\"hi\\"."' in out

--- a/tests/test_wizard_generators_national_spirit.py
+++ b/tests/test_wizard_generators_national_spirit.py
@@ -177,6 +177,14 @@ def test_build_national_spirit_emits_loc_block():
     assert ' TAG_s_desc: "What it does."' in out
 
 
+def test_build_national_spirit_escapes_quotes_in_loc_values():
+    out = build_national_spirit_output(
+        mod_id="TAG_s", loc_name='My "Spirit"', loc_desc='Say "hi".'
+    )
+    assert ' TAG_s: "My \\"Spirit\\""' in out
+    assert ' TAG_s_desc: "Say \\"hi\\"."' in out
+
+
 def test_build_national_spirit_uses_configured_localisation_path():
     out = build_national_spirit_output(mod_id="TAG_s", loc_language="braz_por")
 


### PR DESCRIPTION
## Bottom line
Exporting a focus with an edited description now rewrites the existing `_desc` line instead of silently skipping it, and every wizard loc writer escapes values with `json.dumps`, so a description containing a quote no longer corrupts the .yml.

## Why
`build_loc_yml` only appended keys absent from the file; a filled-in Description exported as a no-op that looked successful. Wizard save paths spliced raw text into `key: "value"` lines.

## How
`_KEY_RE` now captures the quoted value; a non-empty `desc` that differs from the file's value is rewritten in place (titles are never touched, blank descs never overwrite). The raw splice was replaced in `national_spirit`, `dyn_mod`, `additional_income`, and the shared `_generators` module. Tests cover rewrite-on-change, title preservation, quote escaping, and `:N` suffix survival.

Closes #119
BLUF

https://claude.ai/code/session_01BVpKMsVYgRictZoYLh1WLw