### PR TITLE
Keep Tk test windows off the screen

### DIFF
--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -174,6 +174,21 @@ widget test out of the run and still report green: before Xvfb landed, 18
 tests skipped in CI and nobody saw it. Locally the variable is unset, so a
 headless dev box still skips cleanly.
 
+On a dev box that *does* have a display, the run used to map a window per
+widget test and cover the desktop for the length of the suite. It no longer
+does: `tests/conftest.py` withdraws the `tk_root` and every `Toplevel` built
+during a test, and turns `grab_set` into a no-op (Tk refuses to grab a
+window that is not viewable). The widget tree is built exactly the same
+way, it just never gets drawn.
+
+A handful of tests need the real thing, either because they measure
+geometry or because they generate pointer and key events that only land on
+a mapped window. Those carry `@pytest.mark.visible_tk` and get an ordinary
+visible root. `tests/test_canvas_tk.py`'s `mapped_canvas` fixture does the
+same job by calling `deiconify()` itself, and fails loudly if the canvas
+still has no size. To watch a whole run happen on screen, set
+`HOI4CM_SHOW_TK=1`.
+
 Widget tests are still the expensive kind, so the split stands: put logic
 in a pure function and test it headlessly wherever that's possible. Every
 pure module (`focus_tree/`, `models/`, `script/`, `mod/`, `data/`, all of

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,9 @@
 """Shared fixtures.
 
-Only one thing needs to be shared: every widget test needs a Tk root, and
-the "no display" skip has to be loud in CI (which runs under Xvfb) instead
-of quietly dropping every widget test from the run.
+Two things need to be shared: every widget test needs a Tk root, and the
+"no display" skip has to be loud in CI (which runs under Xvfb) instead of
+quietly dropping every widget test from the run. The rest of this module
+keeps those windows off the screen on a machine that has a real desktop.
 """
 
 import os
@@ -17,8 +18,50 @@ except ImportError:
     tk = None
 
 
+def _hidden() -> bool:
+    return os.environ.get("HOI4CM_SHOW_TK") != "1"
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "visible_tk: test needs its windows mapped (real geometry, real events)",
+    )
+
+
+@pytest.fixture(autouse=True)
+def hide_tk_windows(request, monkeypatch):
+    """Withdraw every Toplevel the test creates.
+
+    The widget tests need a display, but almost none of them need the windows
+    drawn; left alone the suite maps a thousand roots and dialogs over
+    whatever else is on screen. `grab_set` refuses to run on a window that is
+    not viewable, so it becomes a no-op while the windows are hidden. Tests
+    that measure geometry or generate real pointer events opt out with
+    `@pytest.mark.visible_tk`, and `HOI4CM_SHOW_TK=1` opts the whole run out.
+    """
+    if tk is None or not _hidden() or request.node.get_closest_marker("visible_tk"):
+        return
+
+    toplevel_init = tk.Toplevel.__init__
+    grab_set = tk.Misc.grab_set
+
+    def hidden_init(self, *args, **kwargs):
+        toplevel_init(self, *args, **kwargs)
+        self.withdraw()
+
+    def optional_grab_set(self):
+        try:
+            grab_set(self)
+        except tk.TclError:
+            pass
+
+    monkeypatch.setattr(tk.Toplevel, "__init__", hidden_init)
+    monkeypatch.setattr(tk.Misc, "grab_set", optional_grab_set)
+
+
 @pytest.fixture
-def tk_root():
+def tk_root(request):
     """A live Tk root, destroyed after the test.
 
     Skips when no display is reachable (or tkinter itself is missing), so the
@@ -37,6 +80,8 @@ def tk_root():
         if os.environ.get("HOI4CM_REQUIRE_TK") == "1":
             pytest.fail(f"HOI4CM_REQUIRE_TK=1 but Tk is unavailable: {exc}")
         pytest.skip("Tk display is unavailable")
+    if _hidden() and not request.node.get_closest_marker("visible_tk"):
+        root.withdraw()
     try:
         yield root
     finally:

--- a/tests/test_checklist.py
+++ b/tests/test_checklist.py
@@ -348,6 +348,7 @@ def test_tk_checklist_custom_loaded_marker(tk_root) -> None:
     assert checklist._rows[1].marker.cget("text") == "（已加载）"
 
 
+@pytest.mark.visible_tk
 def test_tk_checklist_shrinks_pool_on_smaller_viewport(tk_root) -> None:
     tk_root.geometry("340x200")
     checklist = VirtualChecklist(tk_root, type_choices=TYPE_CHOICES)

--- a/tests/test_focus_list.py
+++ b/tests/test_focus_list.py
@@ -159,6 +159,7 @@ def test_pool_always_holds_every_visible_row(
         assert len(visible) <= pool, f"top={top}"
 
 
+@pytest.mark.visible_tk
 def test_tk_list_reuses_bounded_pool_and_updates_only_selected_rows(tk_root) -> None:
     selected: list[Hashable] = []
     tk_root.geometry("220x180")

--- a/tests/test_scrollable_dropdown.py
+++ b/tests/test_scrollable_dropdown.py
@@ -9,6 +9,8 @@ a scrollable Listbox popup sized to the screen.
 
 import tkinter as tk
 
+import pytest
+
 from hoi4cm.ui import ScrollableDropdown
 from hoi4cm.wizards.national_spirit import open_national_spirit_wizard
 
@@ -60,6 +62,7 @@ def test_open_popup_lists_every_item_in_a_capped_listbox(tk_root):
     popup.destroy()
 
 
+@pytest.mark.visible_tk
 def test_popup_geometry_stays_on_screen(tk_root):
     dd, _var = _make(tk_root)
     popup, lb = _open(dd)
@@ -87,6 +90,7 @@ def test_wheel_scrolls_without_committing_or_closing(tk_root):
     popup.destroy()
 
 
+@pytest.mark.visible_tk
 def test_arrow_keys_move_highlight_without_committing(tk_root):
     dd, var = _make(tk_root)
     popup, lb = _open(dd)
@@ -102,6 +106,7 @@ def test_arrow_keys_move_highlight_without_committing(tk_root):
     popup.destroy()
 
 
+@pytest.mark.visible_tk
 def test_return_commits_highlighted_entry_and_closes(tk_root):
     dd, var = _make(tk_root)
     popup, lb = _open(dd)
@@ -115,6 +120,7 @@ def test_return_commits_highlighted_entry_and_closes(tk_root):
     assert not popup.winfo_exists()
 
 
+@pytest.mark.visible_tk
 def test_escape_closes_without_committing(tk_root):
     dd, var = _make(tk_root)
     popup, lb = _open(dd)
@@ -127,6 +133,7 @@ def test_escape_closes_without_committing(tk_root):
     assert not popup.winfo_exists()
 
 
+@pytest.mark.visible_tk
 def test_click_release_commits_clicked_entry(tk_root):
     dd, var = _make(tk_root)
     popup, lb = _open(dd)


### PR DESCRIPTION
## Bottom line

`pytest` no longer opens a window for every widget test. `tests/conftest.py` withdraws the `tk_root` and every `Toplevel` a test builds, so the suite runs invisibly on a machine with a display.

## Why

The suite has ~1100 tests and the widget ones each mapped at least one window. A local run covered the desktop for its whole length.

## How

- An autouse fixture patches `tk.Toplevel.__init__` to withdraw on creation and turns `grab_set` into a no-op, since Tk refuses to grab a window that is not viewable. Nothing about the widget tree changes, it just never gets drawn.
- Seven tests measure real geometry or generate pointer and key events that only land on a mapped window. They carry `@pytest.mark.visible_tk` and get a normal visible root. `test_canvas_tk.py`'s `mapped_canvas` already did the same thing with an explicit `deiconify()`.
- `HOI4CM_SHOW_TK=1` opts a whole run out.
- CI is unaffected: it still runs under `xvfb-run -a` with `HOI4CM_REQUIRE_TK=1`.

1113 passed, same as before the change.

BLUF