### PR TITLE
Scope Load All fit-all to the main tree

### DIFF
--- a/hoi4_content_maker.py
+++ b/hoi4_content_maker.py
@@ -5019,9 +5019,10 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
                         "Cancelled. Loaded files were kept.",
                     )
                 messagebox.showinfo(tr("load_all.title", "Load All Trees"), msg)
-                # Zoom to fit all focuses
+                # Fit the main tree only: fitting every loaded focus would
+                # zoom out far enough to defeat viewport culling (#113).
                 if ok:
-                    self._fit_all()
+                    self._fit_all(tree_idx=0)
 
             def on_error(exc):
                 # _batch_load_trees_worker catches per-file errors internally,

--- a/src/hoi4cm/ui/canvas.py
+++ b/src/hoi4cm/ui/canvas.py
@@ -1741,12 +1741,24 @@ class CanvasMixin:
         self._grid_key = None
         self._redraw_now(RedrawChannel.VIEW, reason="minimap-pan")
 
-    def _fit_all(self):
-        """Fit all focuses into view by resetting pan/zoom."""
+    def _fit_all(self, *, tree_idx=None):
+        """Fit focuses into view by resetting pan/zoom.
+
+        ``tree_idx``, if given, restricts the fitted bbox to one tree (e.g.
+        0 for the main tree) instead of every loaded focus. Loading dozens
+        of extra trees at once and still fitting all of them would zoom out
+        far enough that nothing is left outside the viewport for culling to
+        cull.
+        """
         if not self.focuses:
             return
-        xs = [f.x for f in self.focuses.values()]
-        ys = [f.y for f in self.focuses.values()]
+        focuses = list(self.focuses.values())
+        if tree_idx is not None:
+            scoped = [f for f in focuses if f.tree_idx == tree_idx]
+            if scoped:
+                focuses = scoped
+        xs = [f.x for f in focuses]
+        ys = [f.y for f in focuses]
         if not xs:
             return
         cw = self.cv.winfo_width() or 800

--- a/tests/test_canvas_tk.py
+++ b/tests/test_canvas_tk.py
@@ -16,6 +16,7 @@ from hoi4cm.models.document import FocusDocument
 from hoi4cm.ui.canvas import CanvasMixin
 from hoi4cm.ui.canvas_scheduler import RedrawChannel
 from hoi4cm.ui.theme import XGRID, YGRID
+from hoi4cm.ui.viewport import focus_visible, visible_world_rect
 
 FAR_RECT = (0.0, 0.0, 10.0, 10.0)
 NEAR_RECT = (490.0, 490.0, 510.0, 510.0)
@@ -63,6 +64,7 @@ class _FakeApp(CanvasMixin):
         self._refresh_tree_meta_panel = lambda: None
         self._refresh_loaded_trees_panel = lambda: None
         self._invalidate_focus_list_structure = lambda: None
+        self._update_statusbar = lambda: None
         self._reset_canvas_bounds()
 
     def _get_tree_badge(self, tree_idx):
@@ -162,6 +164,46 @@ def test_low_zoom_uses_three_item_focus_lod(tk_root):
 
     assert len(app._focus_bundles[focus.id].items) == 3
     assert app._focus_bundles[focus.id].lod == "compact"
+
+
+def test_fit_all_scoped_to_main_tree_keeps_other_trees_culled(mapped_canvas):
+    app = _FakeApp(mapped_canvas)
+    main_focus = Focus(x=0, y=0)
+    extra_focus = Focus(x=10, y=4)
+    extra_focus.tree_idx = 1
+    app.focuses = {main_focus.id: main_focus, extra_focus.id: extra_focus}
+
+    app._fit_all(tree_idx=0)
+
+    rect = visible_world_rect(app.offset[0], app.offset[1], app.zoom, GRID_W, GRID_H)
+    assert focus_visible(main_focus.x, main_focus.y, rect)
+    assert not focus_visible(extra_focus.x, extra_focus.y, rect)
+
+
+def test_fit_all_without_scope_still_fits_every_tree(mapped_canvas):
+    app = _FakeApp(mapped_canvas)
+    main_focus = Focus(x=0, y=0)
+    extra_focus = Focus(x=10, y=4)
+    extra_focus.tree_idx = 1
+    app.focuses = {main_focus.id: main_focus, extra_focus.id: extra_focus}
+
+    app._fit_all()
+
+    rect = visible_world_rect(app.offset[0], app.offset[1], app.zoom, GRID_W, GRID_H)
+    assert focus_visible(main_focus.x, main_focus.y, rect)
+    assert focus_visible(extra_focus.x, extra_focus.y, rect)
+
+
+def test_fit_all_falls_back_to_every_focus_when_scope_is_empty(mapped_canvas):
+    app = _FakeApp(mapped_canvas)
+    extra_focus = Focus(x=10, y=4)
+    extra_focus.tree_idx = 1
+    app.focuses = {extra_focus.id: extra_focus}
+
+    app._fit_all(tree_idx=0)
+
+    rect = visible_world_rect(app.offset[0], app.offset[1], app.zoom, GRID_W, GRID_H)
+    assert focus_visible(extra_focus.x, extra_focus.y, rect)
 
 
 def test_wheel_redraw_requests_share_one_tk_job(tk_root, monkeypatch):


### PR DESCRIPTION
## Bottom line
Load All Trees no longer calls an unscoped `_fit_all`. It fits only the main tree (`tree_idx == 0`), so the default view keeps most loaded focuses off-viewport and culling stays effective.

## How
- `_fit_all` takes a keyword-only `tree_idx`; when given, the fitted bbox is restricted to that tree, falling back to all focuses when the scoped set is empty. No-arg callers are unchanged.
- Three new Tk tests pin: scoped fit culls extra-tree focuses, unscoped fit still fits everything, empty scope falls back.

Closes #113

https://claude.ai/code/session_01LFnUPcqcmQfXYMtd5TWLNK