### PR TITLE
Carry canvas moves into extra-tree raw export coords

### DIFF
--- a/src/hoi4cm/focus_tree/codec.py
+++ b/src/hoi4cm/focus_tree/codec.py
@@ -252,13 +252,7 @@ def render_focus_body(
     elif completion_reward_policy == "main":
         out.append(f"{inner_indent}# TODO: add effects")
     elif completion_reward_policy == "extra":
-        out.extend(
-            (
-                f'{inner_indent}log = "[GetDateText]: [This.GetName]: '
-                f'focus {focus.name} executed"',
-                f"{inner_indent}# TODO: add effects",
-            )
-        )
+        pass
     else:
         out.append(f"{inner_indent}# add effects here")
     out.append(f"{indent}}}")

--- a/src/hoi4cm/models/document.py
+++ b/src/hoi4cm/models/document.py
@@ -159,6 +159,16 @@ class FocusDocument(MutableMapping[int, Focus]):
         old = (focus.x, focus.y)
         if old == (x, y):
             return True
+        dgx, dgy = x - old[0], y - old[1]
+        # Extra-tree raw/relative export coords track the canvas move so a
+        # dragged (or sidebar-edited) focus doesn't re-export its stale file
+        # position; see _render_coordinates in focus_tree/codec.py.
+        if getattr(focus, "_raw_gx", None) is not None:
+            focus._raw_gx += dgx
+            focus._raw_gy += dgy
+        if getattr(focus, "_rel_dx", None) is not None:
+            focus._rel_dx += dgx
+            focus._rel_dy += dgy
         focus.x, focus.y = x, y
         # Only occupied_positions depends on x/y, so update it in place rather
         # than rebuilding every index. This keeps a drag cheap on a big tree.

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -139,6 +139,32 @@ def test_move_updates_positions_without_full_rebuild():
     _assert_indexes(document)
 
 
+def test_move_shifts_raw_and_relative_export_coords():
+    """Issue #115: a canvas move must carry through to the extra-tree raw
+    coordinates, not just the plain x/y used by the main-tree exporter."""
+    document = FocusDocument((_focus(1, x=0, y=0), _focus(2, x=1, y=1)))
+    root, child = document[1], document[2]
+    root._raw_gx, root._raw_gy = 0, 0
+    child._raw_gx, child._raw_gy = 1, 1
+    child._rel_dx, child._rel_dy = 1, 1
+    child.relative_position_id = root.name
+
+    assert document.move(child.id, 4, -1)
+
+    assert (child._raw_gx, child._raw_gy) == (4, -1)
+    assert (child._rel_dx, child._rel_dy) == (4, -1)
+    assert (root._raw_gx, root._raw_gy) == (0, 0)
+
+
+def test_move_leaves_focuses_without_raw_coords_untouched():
+    document = FocusDocument((_focus(1, x=0, y=0),))
+
+    assert document.move(1, 5, 5)
+
+    assert not hasattr(document[1], "_raw_gx")
+    assert not hasattr(document[1], "_rel_dx")
+
+
 def test_position_free_respects_except_id_and_occupants():
     document = FocusDocument((_focus(1, x=0, y=0), _focus(2, x=1, y=1)))
 

--- a/tests/test_focus_tree_roundtrip.py
+++ b/tests/test_focus_tree_roundtrip.py
@@ -15,7 +15,7 @@ from hoi4cm.core import read_file
 from hoi4cm.focus_tree.build import build_focuses
 from hoi4cm.focus_tree.export import export_focus_tree
 from hoi4cm.focus_tree.parse import parse_focus_tree
-from hoi4cm.models import Focus
+from hoi4cm.models import Focus, FocusDocument
 
 FIX_DIR = os.path.join(os.path.dirname(__file__), "fixtures", "focus_trees")
 
@@ -451,6 +451,71 @@ focus_tree = {
     assert "\treset_on_civilwar = no" in t1
     assert "base = 0" in t1
     assert "factor = 0" not in t1  # canned block must not appear alongside it
+
+
+def test_extra_tree_export_reflects_canvas_move():
+    """Issue #115: a canvas move (drag / sidebar X-Y edit) on an extra-tree
+    focus must be reflected in the exported raw/relative coordinates, not
+    the stale values captured at load."""
+    src = """\
+focus_tree = {
+\tid = TST_shared_tree
+\tcontinuous_focus_position = { x = 0 y = 0 }
+\tfocus = {
+\t\tid = TST_root
+\t\tx = 0
+\t\ty = 0
+\t\tcompletion_reward = {
+\t\t\tadd_political_power = 1
+\t\t}
+\t}
+\tfocus = {
+\t\tid = TST_child
+\t\tx = 1
+\t\ty = 1
+\t\trelative_position_id = TST_root
+\t\tcompletion_reward = {
+\t\t\tadd_political_power = 1
+\t\t}
+\t}
+}
+"""
+    parsed = parse_focus_tree(src, "/tmp/x.txt")
+    document = FocusDocument(build_focuses(parsed, tree_idx=1))
+    child = document.by_name["TST_child"]
+
+    assert document.move(child.id, child.x + 3, child.y - 2)
+
+    assert (child._raw_gx, child._raw_gy) == (4, -1)
+    assert (child._rel_dx, child._rel_dy) == (4, -1)
+
+    text = export_focus_tree(
+        list(document.values()),
+        _info(parsed, "shared"),
+        focus_lookup=dict(document.items()),
+        effect_renderer=raw_block_renderer,
+    )
+    assert "relative_position_id = TST_root" in text
+    assert "x = 4" in text
+    assert "y = -1" in text
+
+
+def test_extra_tree_export_empty_completion_reward_omits_todo_block():
+    """Issue #115: an extra-tree focus with no completion_reward must not
+    gain a synthesized log line + TODO comment on export."""
+    focus = Focus(0, 0)
+    focus.name = "TST_root"
+    info = _extra_tree_info()
+
+    text = export_focus_tree(
+        [focus],
+        info,
+        focus_lookup={focus.id: focus},
+        effect_renderer=raw_block_renderer,
+    )
+    assert "completion_reward = {\n\t\t}" in text
+    assert "TODO" not in text
+    assert "executed" not in text
 
 
 # ── Fixture-file round-trips (see tests/fixtures/focus_trees/) ────────────


### PR DESCRIPTION
## Bottom line
Dragging or sidebar-editing an extra-tree (shared/joint) focus now reaches the exported `.txt`. `FocusDocument.move` shifts `_raw_gx`/`_raw_gy` and `_rel_dx`/`_rel_dy` by the move delta, the single chokepoint both canvas drag and sidebar X/Y edits go through. Empty extra-tree `completion_reward` re-exports as an empty block, not a synthesized log line plus `# TODO: add effects`.

## Why
Update-on-move composes with the load-time `original_tag` offset (only the incremental delta is applied) and undo already snapshots the raw fields, so undo/redo of a move stays correct. Main trees export canvas coords and never read these fields, so they are unaffected.

Closes #115

https://claude.ai/code/session_01LFnUPcqcmQfXYMtd5TWLNK