### PR TITLE
Virtualize the Loaded Trees sidebar

### DIFF
--- a/hoi4_content_maker.py
+++ b/hoi4_content_maker.py
@@ -134,6 +134,7 @@ from hoi4cm.ui.checklist import (
 from hoi4cm.ui.effects_panel import EffectsMixin
 from hoi4cm.ui.focus_list import FocusListCache, FocusListItem, VirtualFocusList
 from hoi4cm.ui.gfx_browser import open_focus_icon_browser
+from hoi4cm.ui.loaded_trees import LoadedTreeRowItem, VirtualLoadedTreesList
 from hoi4cm.ui.menubar import build_menubar
 from hoi4cm.ui.mod_loading import ModLoadingMixin
 from hoi4cm.ui.settings_dialog import open_settings
@@ -204,6 +205,7 @@ def _apply_tk_dpi_scaling(root):
 class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[misc]
     CANVAS_MIN_SIZE = 10
     CANVAS_EXPAND_STEP = 5
+    TREE_META_REF_CAP = 50
 
     def __init__(self):
         log.info("App.__init__: calling tk.Tk.__init__...")
@@ -1139,44 +1141,43 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
             w.destroy()
         for w in self._tree_meta_jf_box.winfo_children():
             w.destroy()
-        sflist = getattr(self, "_shared_focuses", [])
-        jflist = getattr(self, "_joint_focuses", [])
-        if sflist:
-            for sf in sflist:
-                tk.Label(
-                    self._tree_meta_sf_box,
-                    text=f"  {sf}",
-                    bg=BG_CARD,
-                    fg="#86efac",
-                    font=("Courier", 8),
-                    anchor="w",
-                ).pack(fill="x", padx=2, pady=1)
-        else:
+        self._fill_tree_meta_box(
+            self._tree_meta_sf_box, getattr(self, "_shared_focuses", []), "#86efac"
+        )
+        self._fill_tree_meta_box(
+            self._tree_meta_jf_box, getattr(self, "_joint_focuses", []), "#fbbf24"
+        )
+
+    def _fill_tree_meta_box(self, box, refs, color):
+        """Render up to TREE_META_REF_CAP ref labels into box, plus a "+N more"."""
+        if not refs:
             tk.Label(
-                self._tree_meta_sf_box,
+                box,
                 text=tr("common.none_parenthesized", "  (none)"),
                 bg=BG_CARD,
                 fg=TEXT_DIM,
                 font=("Helvetica", 8, "italic"),
             ).pack(anchor="w", padx=2)
-        if jflist:
-            for jf in jflist:
-                tk.Label(
-                    self._tree_meta_jf_box,
-                    text=f"  {jf}",
-                    bg=BG_CARD,
-                    fg="#fbbf24",
-                    font=("Courier", 8),
-                    anchor="w",
-                ).pack(fill="x", padx=2, pady=1)
-        else:
+            return
+        shown = refs[: self.TREE_META_REF_CAP]
+        for ref in shown:
             tk.Label(
-                self._tree_meta_jf_box,
-                text=tr("common.none_parenthesized", "  (none)"),
+                box,
+                text=f"  {ref}",
+                bg=BG_CARD,
+                fg=color,
+                font=("Courier", 8),
+                anchor="w",
+            ).pack(fill="x", padx=2, pady=1)
+        hidden = len(refs) - len(shown)
+        if hidden > 0:
+            tk.Label(
+                box,
+                text=tr("sidebar.tree_refs_more", "  +{count} more", count=hidden),
                 bg=BG_CARD,
                 fg=TEXT_DIM,
                 font=("Helvetica", 8, "italic"),
-            ).pack(anchor="w", padx=2)
+            ).pack(fill="x", padx=2, pady=1)
 
     # ── SIDEBAR ──────────────────────────────────────────────────
     def _build_sidebar(self, sb):
@@ -1192,9 +1193,27 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
             font=("Helvetica", 7, "bold"),
             anchor="w",
         ).pack(fill="x", padx=4, pady=(3, 0))
-        self._loaded_trees_inner = tk.Frame(sb, bg=BG_PANEL)
-        self._loaded_trees_inner.pack(fill="x")
-        tk.Frame(sb, bg=BORDER_G, height=1).pack(fill="x")
+        self._loaded_trees_empty = tk.Label(
+            _lt_outer,
+            text=tr("sidebar.no_extra_trees", "  No extra trees loaded"),
+            bg=BG_PANEL,
+            fg=TEXT_DIM,
+            font=("Helvetica", 8, "italic"),
+            anchor="w",
+        )
+        # Fixed-height box (~3 rows before scrolling); wraps the pooled list
+        # instead of sizing it directly since Frame.configure(height=...)
+        # collides with _PooledList's own "_configure" Configure-event handler.
+        self._loaded_trees_box = tk.Frame(sb, bg=BG_DARK, height=150)
+        self._loaded_trees_box.pack_propagate(False)
+        self._loaded_trees_inner = VirtualLoadedTreesList(
+            self._loaded_trees_box,
+            on_export=self._export_extra_tree,
+            on_unload=self._unload_extra_tree,
+        )
+        self._loaded_trees_inner.pack(fill="both", expand=True)
+        self._loaded_trees_border = tk.Frame(sb, bg=BORDER_G, height=1)
+        self._loaded_trees_border.pack(fill="x")
         self._refresh_loaded_trees_panel()
 
         # ── Tree Meta Panel (shared/joint focuses) ────────────────────
@@ -4622,85 +4641,30 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
         """Rebuild the Loaded Trees panel list in the sidebar."""
         if not hasattr(self, "_loaded_trees_inner"):
             return
-        for w in self._loaded_trees_inner.winfo_children():
-            w.destroy()
-        if not self._extra_trees:
-            tk.Label(
-                self._loaded_trees_inner,
-                text=tr("sidebar.no_extra_trees", "  No extra trees loaded"),
-                bg=BG_PANEL,
-                fg=TEXT_DIM,
-                font=("Helvetica", 8, "italic"),
-                anchor="w",
-            ).pack(fill="x", padx=4, pady=2)
-            return
+        if self._extra_trees:
+            self._loaded_trees_empty.pack_forget()
+            self._loaded_trees_box.pack(fill="x", before=self._loaded_trees_border)
+        else:
+            self._loaded_trees_box.pack_forget()
+            self._loaded_trees_empty.pack(fill="x", padx=4, pady=2)
+        items = []
         for idx, et in enumerate(self._extra_trees, start=1):
             badge_txt, badge_col = self._get_tree_badge(idx)
-            row = tk.Frame(
-                self._loaded_trees_inner,
-                bg=BG_CARD,
-                highlightthickness=1,
-                highlightbackground=BORDER_G,
+            items.append(
+                LoadedTreeRowItem(
+                    tree_idx=idx,
+                    badge_text=badge_txt,
+                    badge_color=badge_col,
+                    tree_id=et["tree_id"],
+                    summary=tr(
+                        "sidebar.loaded_tree_summary",
+                        "  {file}  -  {count} focuses",
+                        file=os.path.basename(et["file_path"]),
+                        count=len(et["focus_ids"]),
+                    ),
+                )
             )
-            row.pack(fill="x", padx=4, pady=2)
-            tk.Label(
-                row,
-                text=f" [{badge_txt}]",
-                bg=badge_col,
-                fg="#000000",
-                font=("Courier", 8, "bold"),
-                padx=4,
-                pady=2,
-            ).pack(side="left")
-            info_f = tk.Frame(row, bg=BG_CARD)
-            info_f.pack(side="left", fill="x", expand=True)
-            tk.Label(
-                info_f,
-                text=et["tree_id"],
-                bg=BG_CARD,
-                fg=TEXT,
-                font=("Courier", 8, "bold"),
-                anchor="w",
-            ).pack(fill="x", padx=4, pady=(2, 0))
-            tk.Label(
-                info_f,
-                text=tr(
-                    "sidebar.loaded_tree_summary",
-                    "  {file}  -  {count} focuses",
-                    file=os.path.basename(et["file_path"]),
-                    count=len(et["focus_ids"]),
-                ),
-                bg=BG_CARD,
-                fg=TEXT_DIM,
-                font=("Helvetica", 7),
-                anchor="w",
-            ).pack(fill="x", padx=4, pady=(0, 2))
-            btn_f = tk.Frame(row, bg=BG_CARD)
-            btn_f.pack(side="right", padx=2)
-            tk.Button(
-                btn_f,
-                text=tr("common.save", "Save"),
-                command=lambda i=idx: self._export_extra_tree(i),
-                bg=BG_CARD,
-                fg=BLUE,
-                font=("Helvetica", 8),
-                relief="flat",
-                padx=4,
-                pady=1,
-                cursor="hand2",
-            ).pack(pady=(4, 0))
-            tk.Button(
-                btn_f,
-                text="✕",
-                command=lambda i=idx: self._unload_extra_tree(i),
-                bg=BG_CARD,
-                fg=TEXT_DIM,
-                font=("Helvetica", 8),
-                relief="flat",
-                padx=4,
-                pady=1,
-                cursor="hand2",
-            ).pack(pady=(0, 4))
+        self._loaded_trees_inner.set_items(items)
 
     def _export_extra_tree(
         self,

--- a/locales/en.json
+++ b/locales/en.json
@@ -30,6 +30,7 @@
   "sidebar.no_extra_trees": "  No extra trees loaded",
   "sidebar.loaded_tree_summary": "  {file}  -  {count} focuses",
   "sidebar.tree_references": "  TREE REFERENCES",
+  "sidebar.tree_refs_more": "  +{count} more",
   "sidebar.focus_properties": "  FOCUS PROPERTIES",
   "sidebar.no_selection": "\n\n  Click a focus to\n  edit its properties.\n\n  Right-click the canvas\n  to create a new focus.",
   "tab.properties": "Properties",

--- a/locales/zh_CN.json
+++ b/locales/zh_CN.json
@@ -30,6 +30,7 @@
   "sidebar.no_extra_trees": "  未加载额外国策树",
   "sidebar.loaded_tree_summary": "  {file}  -  {count} 个国策",
   "sidebar.tree_references": "  国策树引用",
+  "sidebar.tree_refs_more": "  +{count} 更多",
   "sidebar.focus_properties": "  国策属性",
   "sidebar.no_selection": "\n\n  点击一个国策\n  编辑它的属性。\n\n  右键点击画布\n  创建新国策。",
   "tab.properties": "属性",

--- a/src/hoi4cm/ui/loaded_trees.py
+++ b/src/hoi4cm/ui/loaded_trees.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import tkinter as tk
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from hoi4cm.core.i18n import tr
+from hoi4cm.ui.focus_list import _PooledList
+from hoi4cm.ui.theme import BG_CARD, BG_DARK, BLUE, BORDER_G, TEXT, TEXT_DIM
+
+
+@dataclass(frozen=True)
+class LoadedTreeRowItem:
+    """One rendered row of the sidebar's Loaded Trees panel."""
+
+    tree_idx: int
+    badge_text: str
+    badge_color: str
+    tree_id: str
+    summary: str
+
+
+class _LoadedTreeRow:
+    def __init__(
+        self,
+        master: tk.Canvas,
+        on_export: Callable[[int], None],
+        on_unload: Callable[[int], None],
+    ) -> None:
+        self.tree_idx: int | None = None
+        self._on_export = on_export
+        self._on_unload = on_unload
+        self.frame = tk.Frame(
+            master,
+            bg=BG_CARD,
+            highlightthickness=1,
+            highlightbackground=BORDER_G,
+        )
+        self.badge = tk.Label(
+            self.frame,
+            bg=BG_CARD,
+            fg="#000000",
+            font=("Courier", 8, "bold"),
+            padx=4,
+            pady=2,
+        )
+        self.badge.pack(side="left")
+        info_f = tk.Frame(self.frame, bg=BG_CARD)
+        info_f.pack(side="left", fill="x", expand=True)
+        self.id_label = tk.Label(
+            info_f,
+            bg=BG_CARD,
+            fg=TEXT,
+            font=("Courier", 8, "bold"),
+            anchor="w",
+        )
+        self.id_label.pack(fill="x", padx=4, pady=(2, 0))
+        self.summary_label = tk.Label(
+            info_f,
+            bg=BG_CARD,
+            fg=TEXT_DIM,
+            font=("Helvetica", 7),
+            anchor="w",
+        )
+        self.summary_label.pack(fill="x", padx=4, pady=(0, 2))
+        btn_f = tk.Frame(self.frame, bg=BG_CARD)
+        btn_f.pack(side="right", padx=2)
+        self.save_btn = tk.Button(
+            btn_f,
+            text=tr("common.save", "Save"),
+            command=self._export,
+            bg=BG_CARD,
+            fg=BLUE,
+            font=("Helvetica", 8),
+            relief="flat",
+            padx=4,
+            pady=1,
+            cursor="hand2",
+        )
+        self.save_btn.pack(pady=(4, 0))
+        self.unload_btn = tk.Button(
+            btn_f,
+            text="✕",
+            command=self._unload,
+            bg=BG_CARD,
+            fg=TEXT_DIM,
+            font=("Helvetica", 8),
+            relief="flat",
+            padx=4,
+            pady=1,
+            cursor="hand2",
+        )
+        self.unload_btn.pack(pady=(0, 4))
+
+    def show(self, item: LoadedTreeRowItem) -> None:
+        self.tree_idx = item.tree_idx
+        self.badge.config(text=f" [{item.badge_text}]", bg=item.badge_color)
+        self.id_label.config(text=item.tree_id)
+        self.summary_label.config(text=item.summary)
+
+    def clear(self) -> None:
+        self.tree_idx = None
+
+    def _export(self) -> None:
+        if self.tree_idx is not None:
+            self._on_export(self.tree_idx)
+
+    def _unload(self) -> None:
+        if self.tree_idx is not None:
+            self._on_unload(self.tree_idx)
+
+
+class VirtualLoadedTreesList(_PooledList[_LoadedTreeRow]):
+    """Virtualized sidebar "Loaded Trees" list.
+
+    Rows (badge + tree id + focus count + Save/Unload) are pooled and
+    recycled, so a project with thousands of extra trees only ever builds
+    the handful of rows that fit the sidebar's fixed-height viewport.
+    """
+
+    def __init__(
+        self,
+        master,
+        *,
+        on_export: Callable[[int], None],
+        on_unload: Callable[[int], None],
+        row_height: int = 48,
+        overscan_rows: int = 2,
+        background: str = BG_DARK,
+    ) -> None:
+        self._on_export = on_export
+        self._on_unload = on_unload
+        super().__init__(
+            master,
+            row_height=row_height,
+            overscan_rows=overscan_rows,
+            background=background,
+        )
+
+    def _make_row(self) -> _LoadedTreeRow:
+        return _LoadedTreeRow(self.canvas, self._on_export, self._on_unload)
+
+    def _render(self, row: _LoadedTreeRow, item: LoadedTreeRowItem, index: int) -> None:
+        row.show(item)
+
+    def _unrender(self, row: _LoadedTreeRow) -> None:
+        row.clear()
+
+
+__all__ = ["LoadedTreeRowItem", "VirtualLoadedTreesList"]

--- a/tests/test_loaded_trees_panel.py
+++ b/tests/test_loaded_trees_panel.py
@@ -1,0 +1,151 @@
+"""Tests for the sidebar's virtualized Loaded Trees panel (issue #114).
+
+_refresh_loaded_trees_panel used to destroy and rebuild a Frame + several
+Labels/Buttons per extra tree on every call. These tests pin the pooled
+replacement: building rows for thousands of extra trees must not scale
+widget construction with the tree count, and the shared/joint reference
+lists in the Tree Meta panel must stay capped rather than growing one Label
+per reference.
+"""
+
+import tkinter as tk
+from unittest.mock import Mock
+
+import hoi4_content_maker as app_module
+from hoi4cm.ui.loaded_trees import VirtualLoadedTreesList
+
+
+def _tree(i: int) -> dict:
+    return {
+        "type": "shared",
+        "tree_id": f"TREE_{i:04d}",
+        "file_path": f"/mods/tree_{i:04d}.txt",
+        "focus_ids": {f"f{i}_0", f"f{i}_1"},
+    }
+
+
+def _count_widgets(widget) -> int:
+    return 1 + sum(_count_widgets(w) for w in widget.winfo_children())
+
+
+class _LoadedTreesHost:
+    """Bare host exposing just what _refresh_loaded_trees_panel touches."""
+
+    _get_tree_badge = app_module.App._get_tree_badge
+
+    def __init__(self, master, on_export, on_unload):
+        self._loaded_trees_empty = tk.Label(master)
+        self._loaded_trees_box = tk.Frame(master, height=150)
+        self._loaded_trees_box.pack_propagate(False)
+        self._loaded_trees_inner = VirtualLoadedTreesList(
+            self._loaded_trees_box, on_export=on_export, on_unload=on_unload
+        )
+        self._loaded_trees_inner.pack(fill="both", expand=True)
+        self._loaded_trees_border = tk.Frame(master, height=1)
+        self._loaded_trees_border.pack(fill="x")
+        self._extra_trees: list = []
+
+
+def test_refresh_loaded_trees_panel_pools_rows_for_thousands_of_trees(tk_root):
+    """The issue's blowup: N extra trees must not construct N*k widgets."""
+    tk_root.geometry("340x200")
+    host = _LoadedTreesHost(tk_root, Mock(), Mock())
+    host._extra_trees = [_tree(i) for i in range(3_000)]
+
+    app_module.App._refresh_loaded_trees_panel(host)
+    tk_root.update()
+    host._loaded_trees_inner.refresh()
+
+    panel = host._loaded_trees_inner
+    assert panel.filtered_count == 3_000
+    assert panel.pool_size < 30
+    assert _count_widgets(panel) < 250
+
+
+def test_refresh_loaded_trees_panel_renders_row_content_and_wires_buttons(tk_root):
+    tk_root.geometry("340x200")
+    on_export, on_unload = Mock(), Mock()
+    host = _LoadedTreesHost(tk_root, on_export, on_unload)
+    host._extra_trees = [_tree(0), _tree(1)]
+
+    app_module.App._refresh_loaded_trees_panel(host)
+    tk_root.update()
+    host._loaded_trees_inner.refresh()
+
+    row0 = host._loaded_trees_inner._rows[0]
+    assert row0.tree_idx == 1
+    assert row0.badge.cget("text") == " [S]"
+    assert row0.id_label.cget("text") == "TREE_0000"
+    assert "2 focuses" in row0.summary_label.cget("text")
+
+    row0.save_btn.invoke()
+    on_export.assert_called_once_with(1)
+    row0.unload_btn.invoke()
+    on_unload.assert_called_once_with(1)
+
+
+def test_refresh_loaded_trees_panel_toggles_empty_placeholder(tk_root):
+    host = _LoadedTreesHost(tk_root, Mock(), Mock())
+
+    app_module.App._refresh_loaded_trees_panel(host)
+    assert host._loaded_trees_empty.winfo_manager() == "pack"
+    assert host._loaded_trees_box.winfo_manager() == ""
+
+    host._extra_trees = [_tree(0)]
+    app_module.App._refresh_loaded_trees_panel(host)
+    assert host._loaded_trees_empty.winfo_manager() == ""
+    assert host._loaded_trees_box.winfo_manager() == "pack"
+
+    host._extra_trees = []
+    app_module.App._refresh_loaded_trees_panel(host)
+    assert host._loaded_trees_empty.winfo_manager() == "pack"
+    assert host._loaded_trees_box.winfo_manager() == ""
+
+
+class _CapHost:
+    TREE_META_REF_CAP = app_module.App.TREE_META_REF_CAP
+
+
+def test_fill_tree_meta_box_caps_long_ref_lists(tk_root):
+    box = tk.Frame(tk_root)
+    refs = [f"SF_{i}" for i in range(500)]
+
+    app_module.App._fill_tree_meta_box(_CapHost(), box, refs, "#86efac")
+
+    cap = app_module.App.TREE_META_REF_CAP
+    children = box.winfo_children()
+    assert len(children) == cap + 1  # capped refs + one "+N more" label
+    assert children[0].cget("text") == "  SF_0"
+    assert children[-1].cget("text") == f"  +{500 - cap} more"
+
+
+def test_fill_tree_meta_box_empty_shows_none(tk_root):
+    box = tk.Frame(tk_root)
+
+    app_module.App._fill_tree_meta_box(_CapHost(), box, [], "#86efac")
+
+    children = box.winfo_children()
+    assert len(children) == 1
+    assert children[0].cget("text") == "  (none)"
+
+
+def test_refresh_tree_meta_panel_rebuilds_without_accumulating_widgets(tk_root):
+    class _MetaHost:
+        _fill_tree_meta_box = app_module.App._fill_tree_meta_box
+        TREE_META_REF_CAP = app_module.App.TREE_META_REF_CAP
+
+        def __init__(self):
+            self._tree_meta_sf_box = tk.Frame(tk_root)
+            self._tree_meta_jf_box = tk.Frame(tk_root)
+            self._shared_focuses = ["MD_shared"]
+            self._joint_focuses = ["MD_joint"]
+
+    host = _MetaHost()
+    app_module.App._refresh_tree_meta_panel(host)
+    assert host._tree_meta_sf_box.winfo_children()[0].cget("text") == "  MD_shared"
+    assert host._tree_meta_jf_box.winfo_children()[0].cget("text") == "  MD_joint"
+
+    host._shared_focuses = ["MD_other"]
+    app_module.App._refresh_tree_meta_panel(host)
+    assert len(host._tree_meta_sf_box.winfo_children()) == 1
+    assert host._tree_meta_sf_box.winfo_children()[0].cget("text") == "  MD_other"


### PR DESCRIPTION
## Bottom line
The Loaded Trees panel no longer rebuilds one Frame plus several Labels and Buttons per extra tree on the Tk thread. Rows are pooled through a new `VirtualLoadedTreesList` (built on the existing `_PooledList`), and the Tree Meta shared/joint ref lists cap at 50 labels with a "+N more" tail.

## How
- `src/hoi4cm/ui/loaded_trees.py`: `LoadedTreeRowItem` + `VirtualLoadedTreesList`, same shape as `VirtualChecklist`.
- `_refresh_loaded_trees_panel` builds lightweight row items and calls `set_items()`; an empty-state label and a fixed-height (~3 row) scrolling box replace the grow-forever frame.
- Pinning test builds 3000 extra-tree rows and asserts pool size < 30 and total widgets < 250; more tests cover row content, button wiring, empty toggle, and the meta ref cap.

Closes #114

https://claude.ai/code/session_01LFnUPcqcmQfXYMtd5TWLNK