### PR TITLE
Scan character IDs for effect autocomplete

### DIFF
--- a/src/hoi4cm/mod/context.py
+++ b/src/hoi4cm/mod/context.py
@@ -1,9 +1,9 @@
 """The ``ModContext`` class — mod asset discovery and image loading.
 
 When a mod is loaded, the context walks the mod's directory tree once,
-indexes GFX sprites, idea/decision/event IDs, dynamic modifiers, country
-tags, and MD money-system file paths. The App and every wizard read from
-this single instance (``MOD``).
+indexes GFX sprites, idea/decision/event IDs, character IDs, dynamic
+modifiers, country tags, and MD money-system file paths. The App and every
+wizard read from this single instance (``MOD``).
 
 The scanner is pure-Python: no tkinter. The image loader uses Pillow when
 available; without it ``get_image`` returns ``None`` and the rest of the
@@ -129,6 +129,7 @@ class ModContext:
         self.decision_ids = []  # all decision IDs
         self.decision_cats = []  # all decision category IDs
         self.dyn_mod_ids = []  # common/dynamic_modifiers/*
+        self.character_ids = []  # all character IDs
         self.country_tags = []  # TAG list
         self.variables = set()  # known variable names from set_variable/add_to_variable
         self.loaded = False
@@ -401,6 +402,23 @@ class ModContext:
         return out
 
     @staticmethod
+    def _extract_characters(src):
+        characters = ModContext._parse_text(src).get("characters", {})
+        if isinstance(characters, dict):
+            blocks = (characters,)
+        elif isinstance(characters, list):
+            blocks = characters
+        else:
+            blocks = ()
+        return [
+            character_id
+            for block in blocks
+            if isinstance(block, dict)
+            for character_id in block
+            if isinstance(character_id, str) and not character_id.startswith("_")
+        ]
+
+    @staticmethod
     def _extract_decision_ids(src):
         return [
             m.group(1)
@@ -457,6 +475,21 @@ class ModContext:
             for idea_id in results[p]:
                 seen[idea_id] = None
         self.idea_ids = list(seen)
+
+    def _scan_characters(self):
+        root = self.root
+        if not root:
+            return
+        d = os.path.join(root, "common", "characters")
+        if not os.path.isdir(d):
+            return
+        paths = self._txt_paths(d)
+        results = self._scan_files_cached("characters", paths, self._extract_characters)
+        seen = dict.fromkeys(self.character_ids)
+        for p in paths:
+            for character_id in results[p]:
+                seen[character_id] = None
+        self.character_ids = list(seen)
 
     def _scan_decisions(self):
         # Gather all candidate files per domain first; a single cache call per
@@ -619,6 +652,7 @@ class ModContext:
         self.decision_ids.clear()
         self.decision_cats.clear()
         self.dyn_mod_ids.clear()
+        self.character_ids.clear()
         self.country_tags.clear()
         self.variables.clear()
         self.loaded = False
@@ -640,6 +674,7 @@ class ModContext:
             ("Focus IDs", self._scan_national_focus),
             ("Events", self._scan_events),
             ("Ideas/Spirits", self._scan_ideas),
+            ("Characters", self._scan_characters),
             ("Decisions", self._scan_decisions),
             ("Dynamic Modifiers", self._scan_dyn_mods),
             ("Country Tags", self._scan_tags),

--- a/src/hoi4cm/ui/effects_panel.py
+++ b/src/hoi4cm/ui/effects_panel.py
@@ -9,6 +9,7 @@ imports the same shared list — always sees the current Millennium Dawn set.
 
 import json
 import tkinter as tk
+from typing import TYPE_CHECKING
 
 from hoi4cm.core import EFFECT_CATS, EFFECT_DEFS, tr
 from hoi4cm.mod import MOD
@@ -27,6 +28,12 @@ from hoi4cm.ui import (
     TEXT,
     TEXT_DIM,
 )
+
+
+def _augment_character_suggestions(suggestions, fname, *, loaded, character_ids):
+    if not loaded or fname not in ("character", "advisor"):
+        return suggestions
+    return sorted(set(suggestions).union(character_ids))
 
 
 def _effects_signature(focus, effects):
@@ -53,6 +60,10 @@ def _effects_signature(focus, effects):
 
 class EffectsMixin:
     """Effects tab, effect browser and parameter-form for :class:`App`."""
+
+    if TYPE_CHECKING:
+
+        def _get_mod_suggestions(self, etype: str, fname: str) -> list[str]: ...
 
     def _build_sidebar_effects(self, p, _make_scroll_panel):
         # ── TAB 2: Effects ─────────────────────────────────────────────
@@ -512,6 +523,14 @@ class EffectsMixin:
         for i, eff in enumerate(self.selected.effects):
             self._draw_eff_card(i, eff)
 
+    def _get_effect_suggestions(self, etype, fname):
+        return _augment_character_suggestions(
+            self._get_mod_suggestions(etype, fname),
+            fname,
+            loaded=MOD.loaded,
+            character_ids=MOD.character_ids,
+        )
+
     def _draw_eff_card(self, i, eff):
         etype = eff.get("type", "")
         defn = EFFECT_DEFS.get(etype, {})
@@ -699,7 +718,7 @@ class EffectsMixin:
                     )
                 else:
                     var = tk.StringVar(value=saved)
-                    suggestions = self._get_mod_suggestions(etype, fname)
+                    suggestions = self._get_effect_suggestions(etype, fname)
                     ent = tk.Entry(
                         ff,
                         textvariable=var,
@@ -723,7 +742,7 @@ class EffectsMixin:
                         self._attach_autocomplete(
                             ent,
                             var,
-                            lambda et=etype, fn=fname: self._get_mod_suggestions(
+                            lambda et=etype, fn=fname: self._get_effect_suggestions(
                                 et, fn
                             ),
                         )

--- a/tests/test_character_scanner.py
+++ b/tests/test_character_scanner.py
@@ -1,0 +1,105 @@
+"""Character scanner and effect autocomplete coverage."""
+
+import os
+
+import pytest
+
+from hoi4cm.mod import ModContext
+from hoi4cm.mod import scan_cache as scan_cache_mod
+from hoi4cm.ui.effects_panel import _augment_character_suggestions
+
+
+@pytest.fixture(autouse=True)
+def isolate_scan_cache(tmp_path_factory, monkeypatch):
+    monkeypatch.setattr(
+        scan_cache_mod, "STATE_DIR", str(tmp_path_factory.mktemp("hoi4cm_state"))
+    )
+
+
+def test_extract_characters_returns_only_direct_root_keys():
+    source = """
+    characters = {
+        ALICE = {
+            advisor = {
+                idea_token = nested_idea
+                portrait = nested_portrait
+                role = { nested_role = { } }
+                traits = { nested_trait = { } }
+            }
+        }
+        BOB = {
+            portraits = { nested_portrait = portrait_value }
+        }
+    }
+    """
+
+    assert ModContext._extract_characters(source) == ["ALICE", "BOB"]
+
+
+def test_scan_characters_deduplicates_in_file_order_and_resets(tmp_path):
+    characters_dir = tmp_path / "common" / "characters"
+    characters_dir.mkdir(parents=True)
+    (characters_dir / "a.txt").write_text("characters = { ALPHA = { } SHARED = { } }")
+    (characters_dir / "b.txt").write_text("characters = { SHARED = { } BETA = { } }")
+    context = ModContext()
+    context.character_ids = ["STALE"]
+
+    context.scan(str(tmp_path))
+
+    assert context.character_ids == ["ALPHA", "SHARED", "BETA"]
+
+    context.scan(str(tmp_path / "empty"))
+
+    assert context.character_ids == []
+
+
+def test_scan_characters_uses_file_cache(tmp_path, monkeypatch):
+    characters_dir = tmp_path / "common" / "characters"
+    characters_dir.mkdir(parents=True)
+    character_file = characters_dir / "characters.txt"
+    character_file.write_text("characters = { ALPHA = { } }")
+    context = ModContext()
+    context.scan(str(tmp_path))
+
+    reads = []
+    original_read = context._read
+    monkeypatch.setattr(
+        context,
+        "_read",
+        lambda path: (reads.append(path), original_read(path))[1],
+    )
+
+    context.scan(str(tmp_path))
+    assert reads == []
+
+    character_file.write_text("characters = { BETA = { } }")
+    stat = character_file.stat()
+    os.utime(character_file, (stat.st_atime, stat.st_mtime + 10))
+    context.scan(str(tmp_path))
+
+    assert reads == [str(character_file)]
+    assert context.character_ids == ["BETA"]
+
+
+def test_augment_character_suggestions_sorts_only_character_fields():
+    base = ["zeta", "alpha"]
+    character_ids = ["beta", "alpha"]
+
+    assert _augment_character_suggestions(
+        base, "character", loaded=True, character_ids=character_ids
+    ) == ["alpha", "beta", "zeta"]
+    assert _augment_character_suggestions(
+        base, "advisor", loaded=True, character_ids=character_ids
+    ) == ["alpha", "beta", "zeta"]
+    assert (
+        _augment_character_suggestions(
+            base, "country", loaded=True, character_ids=character_ids
+        )
+        is base
+    )
+    assert (
+        _augment_character_suggestions(
+            base, "character", loaded=False, character_ids=character_ids
+        )
+        is base
+    )


### PR DESCRIPTION
## Bottom line

Loading a mod now discovers character IDs from `common/characters` and offers them in character and advisor effect fields.

## How

The scanner uses the existing per-file cache, preserves file order, removes duplicates, and clears stale IDs between mod loads. Character authoring remains tracked separately in #141.

Closes #37

BLUF