### PR TITLE
Add trigger catalogue and picker

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -10,8 +10,8 @@
   caches. Re-exported flat through `core/__init__.py` (the "facade", see
   below). Everything else in the package can depend on `core`; core submodules
   other than the facade depend on nothing else in `hoi4cm`.
-- **`data/`**: static tables: `EFFECT_DEFS`/`MODIFIER_DEFS` and the MD
-  building/resource cost tables. No logic beyond lookup helpers.
+- **`data/`**: static tables: `EFFECT_DEFS`/`MODIFIER_DEFS`/`TRIGGER_DEFS` and
+  the MD building/resource cost tables. No logic beyond lookup helpers.
 - **`models/`**: `Focus`, the plain-data class behind every canvas item.
   `to_dict`/`from_dict` for JSON round-trips (autosave, tree files).
 - **`script/`**: low-level HOI4 script marshalling: `dict_to_raw`,
@@ -37,7 +37,8 @@
   below).
 - **`wizards/`**: the five `open_*_wizard(app)` entry points (decision,
   event, national spirit, dynamic modifier, additional income) plus
-  `_shared.py` for cross-wizard state. The package `__init__` resolves the
+  `_shared.py` for cross-wizard state, including shared effect/trigger pickers.
+  The package `__init__` resolves the
   five names through a module-level `__getattr__`, so importing one wizard
   doesn't load the other four; keep it that way when adding a sixth. See
   `wizards.md`.

--- a/hoi4_content_maker.py
+++ b/hoi4_content_maker.py
@@ -149,6 +149,7 @@ from hoi4cm.ui.mod_loading import ModLoadingMixin  # noqa: E402
 from hoi4cm.ui.settings_dialog import open_settings  # noqa: E402
 from hoi4cm.ui.toolbar import build_toolbar_row2  # noqa: E402
 from hoi4cm.ui.tree_badges import build_tree_badges  # noqa: E402
+from hoi4cm.wizards._shared import open_trigger_picker  # noqa: E402
 
 log_startup()
 
@@ -1774,6 +1775,20 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
             )
             trig_text.pack(fill="x", padx=4, pady=(0, 2))
             trig_text.insert("1.0", off.get("trigger", ""))
+            tk.Button(
+                row,
+                text=tr("trigger_picker.button", "+ Insert trigger"),
+                command=lambda tw=trig_text: open_trigger_picker(self, tw),
+                bg=BG_PANEL,
+                fg=BLUE,
+                relief="flat",
+                font=("Helvetica", 8),
+                cursor="hand2",
+                padx=6,
+                pady=1,
+                highlightthickness=1,
+                highlightbackground=BORDER_G,
+            ).pack(anchor="e", padx=4, pady=(0, 2))
             tk.Label(
                 row, text="}", bg=BG_CARD, fg=TEXT_DIM, font=("Courier", 8), anchor="w"
             ).pack(fill="x", padx=4)
@@ -2084,6 +2099,20 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
             undo=True,
         )
         t.pack(fill="x")
+        tk.Button(
+            hdr,
+            text=tr("trigger_picker.button", "+ Insert trigger"),
+            command=lambda tw=t: open_trigger_picker(self, tw),
+            bg=BG_CARD,
+            fg=BLUE,
+            relief="flat",
+            font=("Helvetica", 8),
+            cursor="hand2",
+            padx=6,
+            pady=1,
+            highlightthickness=1,
+            highlightbackground=BORDER_G,
+        ).pack(side="right", padx=(4, 0))
         return t
 
     def _sb_check(self, parent, label, default):

--- a/src/hoi4cm/core/__init__.py
+++ b/src/hoi4cm/core/__init__.py
@@ -7,10 +7,13 @@ from hoi4cm.data import (
     MD_RESOURCE_COST_PER_UNIT,
     MODIFIER_CATS,
     MODIFIER_DEFS,
+    TRIGGER_CATS,
+    TRIGGER_DEFS,
     effects_in_cat,
     md_building_cost_hint,
     md_resource_cost_hint,
     modifiers_in_cat,
+    triggers_in_cat,
 )
 from hoi4cm.focus_tree import (
     BuildContext,
@@ -88,6 +91,8 @@ __all__ = [
     "MD_RESOURCE_COST_PER_UNIT",
     "MODIFIER_CATS",
     "MODIFIER_DEFS",
+    "TRIGGER_CATS",
+    "TRIGGER_DEFS",
     "ParsedFocusTree",
     "UndoStack",
     "add_error",
@@ -135,4 +140,5 @@ __all__ = [
     "set_language",
     "show_splash",
     "tr",
+    "triggers_in_cat",
 ]

--- a/src/hoi4cm/data/__init__.py
+++ b/src/hoi4cm/data/__init__.py
@@ -12,6 +12,7 @@ from .effects import (
     md_resource_cost_hint,
     modifiers_in_cat,
 )
+from .triggers import TRIGGER_CATS, TRIGGER_DEFS, triggers_in_cat
 
 __all__ = [
     "EFFECT_DEFS",
@@ -24,4 +25,7 @@ __all__ = [
     "MD_RESOURCE_COST_PER_UNIT",
     "md_building_cost_hint",
     "md_resource_cost_hint",
+    "TRIGGER_DEFS",
+    "TRIGGER_CATS",
+    "triggers_in_cat",
 ]

--- a/src/hoi4cm/data/triggers.py
+++ b/src/hoi4cm/data/triggers.py
@@ -1,0 +1,214 @@
+"""Vanilla Hearts of Iron IV trigger catalogue.
+
+Entries use the same shape as :data:`hoi4cm.data.effects.EFFECT_DEFS`:
+``label``, ``cat`` and a list of ``(name, widget, default, hint)`` fields.
+The table is intentionally limited to frequently used vanilla script triggers;
+mod-specific scripted triggers remain available through the raw text area.
+"""
+
+# ruff: noqa: E501
+
+# fmt: off
+TRIGGER_DEFS = {
+    # ── Logic and script ───────────────────────────────────────────────────
+    "always": {"label": "Always", "cat": "Logic", "fields": [], "_note": "Always true."},
+    "never": {"label": "Never", "cat": "Logic", "fields": [], "_note": "Always false."},
+    "AND": {"label": "All of (AND)", "cat": "Logic", "fields": [("conditions", "multiline", "always = yes", "Every condition in the block must be true.")], "_block": True},
+    "OR": {"label": "Any of (OR)", "cat": "Logic", "fields": [("conditions", "multiline", "always = yes", "At least one condition in the block must be true.")], "_block": True},
+    "NOR": {"label": "None of (NOR)", "cat": "Logic", "fields": [("conditions", "multiline", "always = yes", "Every condition in the block must be false.")], "_block": True},
+    "NAND": {"label": "Not all of (NAND)", "cat": "Logic", "fields": [("conditions", "multiline", "always = yes", "The block must not have all conditions true.")], "_block": True},
+    "NOT": {"label": "Not", "cat": "Logic", "fields": [("condition", "multiline", "always = yes", "The condition in the block must be false.")], "_block": True},
+    "has_dlc": {"label": "Has DLC", "cat": "Logic", "fields": [("dlc", "entry", "Together for Victory", "DLC name or DLC identifier.")]},
+    "has_game_rule": {"label": "Has Game Rule", "cat": "Logic", "fields": [("rule", "entry", "rule_id", "Game rule key."), ("value", "entry", "option", "Selected rule option.")]},
+    "has_global_flag": {"label": "Has Global Flag", "cat": "Script", "fields": [("flag", "entry", "my_global_flag", "Global flag name.")]},
+    "has_country_flag": {"label": "Has Country Flag", "cat": "Script", "fields": [("flag", "entry", "my_country_flag", "Country flag name.")]},
+    "has_state_flag": {"label": "Has State Flag", "cat": "Script", "fields": [("flag", "entry", "my_state_flag", "State flag name.")]},
+    "has_province_flag": {"label": "Has Province Flag", "cat": "Script", "fields": [("flag", "entry", "my_province_flag", "Province flag name.")]},
+    "has_variable": {"label": "Has Variable", "cat": "Script", "fields": [("variable", "entry", "my_variable", "Saved script variable name.")]},
+    "check_variable": {"label": "Check Variable", "cat": "Script", "fields": [("variable", "entry", "my_variable", "Variable name."), ("comparison", "entry", "> 0", "Comparison, for example > 5 or = 10.")]},
+    "check_variable_in_range": {"label": "Variable In Range", "cat": "Script", "fields": [("variable", "entry", "my_variable", "Variable name."), ("range", "entry", "0..10", "Inclusive range.")]},
+    "has_scripted_trigger": {"label": "Has Scripted Trigger", "cat": "Script", "fields": [("trigger", "entry", "my_scripted_trigger", "Scripted trigger name.")]},
+    "has_completed_focus": {"label": "Has Completed Focus", "cat": "Focus", "fields": [("focus", "entry", "TAG_focus_id", "Focus ID, usually with the country tag.")]},
+    "has_focus_tree": {"label": "Has Focus Tree", "cat": "Focus", "fields": [("tree", "entry", "focus_tree_id", "Focus tree name.")]},
+    "has_completed_focus_on": {"label": "Country Has Completed Focus", "cat": "Focus", "fields": [("country", "entry", "GER", "Country tag."), ("focus", "entry", "GER_focus_id", "Focus ID.")]},
+    "is_historical_focus_on": {"label": "Historical Focus Is On", "cat": "Focus", "fields": [("focus", "entry", "GER_focus_id", "Focus ID.")]},
+    "has_war": {"label": "Has A War", "cat": "Diplomacy", "fields": [("value", "dropdown:yes,no", "yes", "Whether this country is at war.")]},
+    "has_war_with": {"label": "Has War With", "cat": "Diplomacy", "fields": [("country", "entry", "GER", "Country tag or scope.")]},
+    "has_offensive_war": {"label": "Has Offensive War", "cat": "Diplomacy", "fields": [("value", "dropdown:yes,no", "yes", "Whether this country has an offensive war.")]},
+    "has_defensive_war": {"label": "Has Defensive War", "cat": "Diplomacy", "fields": [("value", "dropdown:yes,no", "yes", "Whether this country has a defensive war.")]},
+    "has_annex_war": {"label": "Has Annex War", "cat": "Diplomacy", "fields": [("value", "dropdown:yes,no", "yes", "Whether this country has an annexation war goal.")]},
+    "has_capitulated": {"label": "Has Capitulated", "cat": "War", "fields": [("value", "dropdown:yes,no", "yes", "Whether this country has capitulated.")]},
+    "is_capitulated": {"label": "Is Capitulated", "cat": "War", "fields": [("value", "dropdown:yes,no", "yes", "Whether this country is capitulated.")]},
+    "is_in_faction": {"label": "Is In A Faction", "cat": "Diplomacy", "fields": [("value", "dropdown:yes,no", "yes", "Whether this country belongs to a faction.")]},
+    "is_faction_leader": {"label": "Is Faction Leader", "cat": "Diplomacy", "fields": [("value", "dropdown:yes,no", "yes", "Whether this country leads its faction.")]},
+    "faction_exists": {"label": "Faction Exists", "cat": "Diplomacy", "fields": [("faction", "entry", "faction_id", "Faction name or identifier.")]},
+    "has_subject": {"label": "Has Subject", "cat": "Diplomacy", "fields": [("country", "entry", "GER", "Subject country tag, or a subject block.")]},
+    "has_overlord": {"label": "Has Overlord", "cat": "Diplomacy", "fields": [("country", "entry", "GER", "Overlord country tag or scope.")]},
+    "is_subject": {"label": "Is A Subject", "cat": "Diplomacy", "fields": [("value", "dropdown:yes,no", "yes", "Whether this country is any kind of subject.")]},
+    "is_subject_of": {"label": "Is Subject Of", "cat": "Diplomacy", "fields": [("country", "entry", "GER", "Overlord country tag or scope.")]},
+    "is_puppet": {"label": "Is A Puppet", "cat": "Diplomacy", "fields": [("value", "dropdown:yes,no", "yes", "Whether this country is a puppet.")]},
+    "is_integrated_puppet": {"label": "Is An Integrated Puppet", "cat": "Diplomacy", "fields": [("value", "dropdown:yes,no", "yes", "Whether this country is an integrated puppet.")]},
+    "is_colony": {"label": "Is A Colony", "cat": "Diplomacy", "fields": [("value", "dropdown:yes,no", "yes", "Whether this country is a colony.")]},
+    "is_dominion": {"label": "Is A Dominion", "cat": "Diplomacy", "fields": [("value", "dropdown:yes,no", "yes", "Whether this country is a dominion.")]},
+    "is_overlord": {"label": "Is An Overlord", "cat": "Diplomacy", "fields": [("value", "dropdown:yes,no", "yes", "Whether this country has a subject.")]},
+    "has_guarantee": {"label": "Has A Guarantee", "cat": "Diplomacy", "fields": [("country", "entry", "POL", "Country tag being guaranteed.")]},
+    "is_guaranteed_by": {"label": "Is Guaranteed By", "cat": "Diplomacy", "fields": [("country", "entry", "ENG", "Country tag providing the guarantee.")]},
+    "is_guaranteeing": {"label": "Is Guaranteeing", "cat": "Diplomacy", "fields": [("country", "entry", "POL", "Country tag being guaranteed.")]},
+    "is_neighbor_of": {"label": "Is Neighbor Of", "cat": "Diplomacy", "fields": [("country", "entry", "GER", "Country tag or scope.")]},
+    "is_in_faction_with": {"label": "Is In Faction With", "cat": "Diplomacy", "fields": [("country", "entry", "GER", "Country tag or scope.")]},
+    "is_ally_with": {"label": "Is Allied With", "cat": "Diplomacy", "fields": [("country", "entry", "GER", "Country tag or scope.")]},
+    "is_ally": {"label": "Is An Ally", "cat": "Diplomacy", "fields": [("country", "entry", "GER", "Country tag or scope.")]},
+    "is_enemy": {"label": "Is An Enemy", "cat": "Diplomacy", "fields": [("country", "entry", "GER", "Country tag or scope.")]},
+    "is_friend": {"label": "Is A Friend", "cat": "Diplomacy", "fields": [("country", "entry", "GER", "Country tag or scope.")]},
+    "has_truce": {"label": "Has A Truce", "cat": "Diplomacy", "fields": [("country", "entry", "GER", "Country tag or scope.")]},
+    "has_non_aggression_pact_with": {"label": "Has Non-Aggression Pact With", "cat": "Diplomacy", "fields": [("country", "entry", "GER", "Country tag or scope.")]},
+    "has_military_access_to": {"label": "Has Military Access To", "cat": "Diplomacy", "fields": [("country", "entry", "GER", "Country tag or scope.")]},
+    "has_military_access": {"label": "Has Military Access", "cat": "Diplomacy", "fields": [("value", "dropdown:yes,no", "yes", "Whether another country has access here.")]},
+    "has_attache": {"label": "Has Attaché", "cat": "Diplomacy", "fields": [("country", "entry", "GER", "Country tag with the attaché.")]},
+    "has_send_volunteers": {"label": "Has Sent Volunteers", "cat": "Diplomacy", "fields": [("country", "entry", "GER", "Country tag receiving volunteers.")]},
+    "has_sent_volunteers": {"label": "Has Sent Volunteers (Alias)", "cat": "Diplomacy", "fields": [("country", "entry", "GER", "Country tag receiving volunteers.")]},
+    "has_license": {"label": "Has A License", "cat": "Diplomacy", "fields": [("country", "entry", "GER", "Country tag that granted the license.")]},
+    "has_opinion": {"label": "Has Opinion", "cat": "Diplomacy", "fields": [("country", "entry", "GER", "Country tag or scope."), ("value", "entry", "> 50", "Opinion comparison.")]},
+    "has_relation_modifier": {"label": "Has Relation Modifier", "cat": "Diplomacy", "fields": [("country", "entry", "GER", "Other country tag or scope."), ("modifier", "entry", "improved_relations", "Relation modifier name.")]},
+    "can_declare_war_on": {"label": "Can Declare War On", "cat": "Diplomacy", "fields": [("country", "entry", "GER", "Country tag or scope.")]},
+    "has_war_together_with": {"label": "Has War Together With", "cat": "Diplomacy", "fields": [("country", "entry", "GER", "Country tag or scope.")]},
+
+    # ── Politics and country ───────────────────────────────────────────────
+    "has_government": {"label": "Has Government", "cat": "Politics", "fields": [("ideology", "dropdown:democratic,fascism,communism,neutrality", "democratic", "Ruling ideology group.")]},
+    "has_ideology": {"label": "Has Ideology", "cat": "Politics", "fields": [("ideology", "entry", "democratic", "Ideology key.")]},
+    "has_ideology_group": {"label": "Has Ideology Group", "cat": "Politics", "fields": [("ideology", "dropdown:democratic,fascism,communism,neutrality", "democratic", "Ideology group.")]},
+    "has_political_power": {"label": "Has Political Power", "cat": "Politics", "fields": [("amount", "entry", "> 50", "Political power comparison.")]},
+    "has_stability": {"label": "Has Stability", "cat": "Politics", "fields": [("amount", "entry", "> 0.5", "Stability comparison from 0 to 1.")]},
+    "has_war_support": {"label": "Has War Support", "cat": "Politics", "fields": [("amount", "entry", "> 0.5", "War support comparison from 0 to 1.")]},
+    "has_elections": {"label": "Has Elections", "cat": "Politics", "fields": [("value", "dropdown:yes,no", "yes", "Whether elections are active.")]},
+    "elections_allowed": {"label": "Elections Allowed", "cat": "Politics", "fields": [("value", "dropdown:yes,no", "yes", "Whether elections are allowed.")]},
+    "has_country_leader": {"label": "Has Country Leader", "cat": "Politics", "fields": [("leader", "entry", "character_id", "Leader character ID.")]},
+    "has_character": {"label": "Has Character", "cat": "Politics", "fields": [("character", "entry", "character_id", "Character ID.")]},
+    "has_trait": {"label": "Has Trait", "cat": "Politics", "fields": [("trait", "entry", "trait_id", "Character or country trait.")]},
+    "has_legitimacy": {"label": "Has Legitimacy", "cat": "Politics", "fields": [("amount", "entry", "> 50", "Legitimacy comparison.")]},
+    "has_party_popularity": {"label": "Has Party Popularity", "cat": "Politics", "fields": [("ideology", "entry", "democratic", "Ideology key."), ("amount", "entry", "> 0.5", "Popularity comparison from 0 to 1.")]},
+    "has_country_modifier": {"label": "Has Country Modifier", "cat": "Politics", "fields": [("modifier", "entry", "my_modifier", "Country modifier name.")]},
+    "has_dynamic_modifier": {"label": "Has Dynamic Modifier", "cat": "Politics", "fields": [("modifier", "entry", "my_modifier", "Dynamic modifier name.")]},
+    "has_idea": {"label": "Has National Spirit", "cat": "Politics", "fields": [("idea", "entry", "my_spirit", "National spirit or idea ID.")]},
+    "has_idea_with_trait": {"label": "Has Idea With Trait", "cat": "Politics", "fields": [("trait", "entry", "idea_trait", "Idea trait name.")]},
+    "has_manpower": {"label": "Has Manpower", "cat": "Politics", "fields": [("amount", "entry", "> 10000", "Available manpower comparison.")]},
+    "has_available_manpower": {"label": "Has Available Manpower", "cat": "Politics", "fields": [("amount", "entry", "> 10000", "Available manpower comparison.")]},
+    "is_major": {"label": "Is A Major", "cat": "Politics", "fields": [("value", "dropdown:yes,no", "yes", "Whether this is a major country.")]},
+    "is_ai": {"label": "Is AI Controlled", "cat": "Politics", "fields": [("value", "dropdown:yes,no", "yes", "Whether this country is controlled by the AI.")]},
+    "country_exists": {"label": "Country Exists", "cat": "Politics", "fields": [("country", "entry", "GER", "Country tag.")]},
+    "tag": {"label": "Has Country Tag", "cat": "Politics", "fields": [("country", "entry", "GER", "Country tag to compare.")]},
+
+    # ── Military and equipment ─────────────────────────────────────────────
+    "has_army_experience": {"label": "Has Army Experience", "cat": "Military", "fields": [("amount", "entry", "> 10", "Army experience comparison.")]},
+    "has_navy_experience": {"label": "Has Navy Experience", "cat": "Military", "fields": [("amount", "entry", "> 10", "Navy experience comparison.")]},
+    "has_air_experience": {"label": "Has Air Experience", "cat": "Military", "fields": [("amount", "entry", "> 10", "Air experience comparison.")]},
+    "has_army": {"label": "Has An Army", "cat": "Military", "fields": [("value", "dropdown:yes,no", "yes", "Whether this country has an army.")]},
+    "has_navy": {"label": "Has A Navy", "cat": "Military", "fields": [("value", "dropdown:yes,no", "yes", "Whether this country has a navy.")]},
+    "has_air_force": {"label": "Has An Air Force", "cat": "Military", "fields": [("value", "dropdown:yes,no", "yes", "Whether this country has an air force.")]},
+    "has_equipment": {"label": "Has Equipment", "cat": "Military", "fields": [("equipment", "multiline", "type = infantry_equipment\namount > 100", "Equipment type and amount comparison." )], "_block": True},
+    "has_equipment_ratio": {"label": "Has Equipment Ratio", "cat": "Military", "fields": [("equipment", "multiline", "type = infantry_equipment\nratio > 0.5", "Equipment type and ratio comparison." )], "_block": True},
+    "has_equipment_production": {"label": "Has Equipment Production", "cat": "Military", "fields": [("equipment", "entry", "infantry_equipment", "Equipment type.")]},
+    "has_stockpile": {"label": "Has Stockpile", "cat": "Military", "fields": [("equipment", "entry", "infantry_equipment", "Equipment type."), ("amount", "entry", "> 100", "Stockpile comparison.")]},
+    "has_unit": {"label": "Has Unit", "cat": "Military", "fields": [("unit", "entry", "unit_id", "Unit or division identifier.")]},
+    "has_unit_leader": {"label": "Has Unit Leader", "cat": "Military", "fields": [("leader", "entry", "character_id", "Unit leader character ID.")]},
+    "has_unit_leader_trait": {"label": "Has Unit Leader Trait", "cat": "Military", "fields": [("trait", "entry", "trait_id", "Unit leader trait.")]},
+    "has_division_template": {"label": "Has Division Template", "cat": "Military", "fields": [("template", "entry", "Infantry Division", "Division template name.")]},
+    "has_template": {"label": "Has Template", "cat": "Military", "fields": [("template", "entry", "Infantry Division", "Division template name.")]},
+    "num_of_divisions": {"label": "Number Of Divisions", "cat": "Military", "fields": [("amount", "entry", "> 10", "Division count comparison.")]},
+    "num_of_controlled_states": {"label": "Number Of Controlled States", "cat": "Military", "fields": [("amount", "entry", "> 5", "Controlled state count comparison.")]},
+    "num_of_owned_states": {"label": "Number Of Owned States", "cat": "Military", "fields": [("amount", "entry", "> 5", "Owned state count comparison.")]},
+    "num_of_combat_units": {"label": "Number Of Combat Units", "cat": "Military", "fields": [("amount", "entry", "> 10", "Combat unit count comparison.")]},
+    "army_strength": {"label": "Army Strength", "cat": "Military", "fields": [("amount", "entry", "> 0.5", "Army strength ratio comparison.")]},
+    "navy_strength": {"label": "Navy Strength", "cat": "Military", "fields": [("amount", "entry", "> 0.5", "Navy strength ratio comparison.")]},
+    "air_strength": {"label": "Air Strength", "cat": "Military", "fields": [("amount", "entry", "> 0.5", "Air strength ratio comparison.")]},
+    "strength_ratio": {"label": "Strength Ratio", "cat": "Military", "fields": [("comparison", "multiline", "tag = GER\nratio > 0.5", "Country tag and relative strength comparison.")], "_block": True},
+    "has_nukes": {"label": "Has Nuclear Weapons", "cat": "Military", "fields": [("amount", "entry", "> 0", "Number of nuclear weapons comparison.")]},
+    "num_of_nukes": {"label": "Number Of Nuclear Weapons", "cat": "Military", "fields": [("amount", "entry", "> 0", "Nuclear weapon count comparison.")]},
+    "has_tech": {"label": "Has Technology", "cat": "Research", "fields": [("technology", "entry", "infantry_weapons", "Technology ID.")]},
+    "has_technology": {"label": "Has Technology (Alias)", "cat": "Research", "fields": [("technology", "entry", "infantry_weapons", "Technology ID.")]},
+    "has_research_slot": {"label": "Has Research Slot", "cat": "Research", "fields": [("amount", "entry", "> 3", "Research slot count comparison.")]},
+    "num_of_research_slots": {"label": "Number Of Research Slots", "cat": "Research", "fields": [("amount", "entry", "> 3", "Research slot count comparison.")]},
+
+    # ── Economy and resources ──────────────────────────────────────────────
+    "num_of_civilian_factories": {"label": "Number Of Civilian Factories", "cat": "Economy", "fields": [("amount", "entry", "> 10", "Civilian factory count comparison.")]},
+    "num_of_military_factories": {"label": "Number Of Military Factories", "cat": "Economy", "fields": [("amount", "entry", "> 10", "Military factory count comparison.")]},
+    "num_of_naval_factories": {"label": "Number Of Naval Factories", "cat": "Economy", "fields": [("amount", "entry", "> 5", "Dockyard count comparison.")]},
+    "num_of_factories": {"label": "Number Of Factories", "cat": "Economy", "fields": [("amount", "entry", "> 10", "Factory count comparison.")]},
+    "num_of_buildings": {"label": "Number Of Buildings", "cat": "Economy", "fields": [("comparison", "multiline", "type = industrial_complex\namount > 5", "Building type and count comparison.")], "_block": True},
+    "has_civilian_factory": {"label": "Has Civilian Factory", "cat": "Economy", "fields": [("amount", "entry", "> 0", "Civilian factory count comparison.")]},
+    "has_military_factory": {"label": "Has Military Factory", "cat": "Economy", "fields": [("amount", "entry", "> 0", "Military factory count comparison.")]},
+    "has_naval_factory": {"label": "Has Naval Factory", "cat": "Economy", "fields": [("amount", "entry", "> 0", "Dockyard count comparison.")]},
+    "has_resources": {"label": "Has Resources", "cat": "Economy", "fields": [("resources", "multiline", "steel > 10", "Resource amount comparison.")], "_block": True},
+    "has_resource": {"label": "Has Resource", "cat": "Economy", "fields": [("resource", "multiline", "type = steel\namount > 10", "Resource type and amount comparison.")], "_block": True},
+    "has_building": {"label": "Has Building", "cat": "Economy", "fields": [("building", "multiline", "type = industrial_complex\nlevel > 0", "Building type and level comparison.")], "_block": True},
+    "has_available_building_slots": {"label": "Has Available Building Slots", "cat": "Economy", "fields": [("slots", "multiline", "building = industrial_complex\namount > 0", "Building type and available slot comparison.")], "_block": True},
+    "has_market": {"label": "Has Access To Market", "cat": "Economy", "fields": [("country", "entry", "GER", "Market country tag or scope.")]},
+    "has_trade_agreement_with": {"label": "Has Trade Agreement With", "cat": "Economy", "fields": [("country", "entry", "GER", "Country tag or scope.")]},
+
+    # ── State, province and map ─────────────────────────────────────────────
+    "owns_state": {"label": "Owns State", "cat": "State", "fields": [("state", "entry", "64", "State ID.")]},
+    "controls_state": {"label": "Controls State", "cat": "State", "fields": [("state", "entry", "64", "State ID.")]},
+    "is_core_of": {"label": "Is Core Of", "cat": "State", "fields": [("country", "entry", "GER", "Country tag or scope.")]},
+    "is_claimed_by": {"label": "Is Claimed By", "cat": "State", "fields": [("country", "entry", "GER", "Country tag or scope.")]},
+    "is_owned_by": {"label": "Is Owned By", "cat": "State", "fields": [("country", "entry", "GER", "Country tag or scope.")]},
+    "is_controlled_by": {"label": "Is Controlled By", "cat": "State", "fields": [("country", "entry", "GER", "Country tag or scope.")]},
+    "is_fully_owned_by": {"label": "Is Fully Owned By", "cat": "State", "fields": [("country", "entry", "GER", "Country tag or scope.")]},
+    "is_fully_controlled_by": {"label": "Is Fully Controlled By", "cat": "State", "fields": [("country", "entry", "GER", "Country tag or scope.")]},
+    "has_state_category": {"label": "Has State Category", "cat": "State", "fields": [("category", "entry", "large_city", "State category key.")]},
+    "state_population": {"label": "State Population", "cat": "State", "fields": [("amount", "entry", "> 1000000", "Population comparison.")]},
+    "free_building_slots": {"label": "Free Building Slots", "cat": "State", "fields": [("slots", "multiline", "building = industrial_complex\namount > 0", "Building type and free slot comparison.")], "_block": True},
+    "has_building_level": {"label": "Has Building Level", "cat": "State", "fields": [("building", "multiline", "type = industrial_complex\nlevel > 2", "Building type and level comparison.")], "_block": True},
+    "has_state_modifier": {"label": "Has State Modifier", "cat": "State", "fields": [("modifier", "entry", "my_state_modifier", "State modifier name.")]},
+    "is_demilitarized": {"label": "Is Demilitarized", "cat": "State", "fields": [("value", "dropdown:yes,no", "yes", "Whether the state is demilitarized.")]},
+    "is_border_state": {"label": "Is Border State", "cat": "State", "fields": [("value", "dropdown:yes,no", "yes", "Whether the state borders another country.")]},
+    "is_coastal": {"label": "Is Coastal", "cat": "State", "fields": [("value", "dropdown:yes,no", "yes", "Whether the state has a coastline.")]},
+    "has_port": {"label": "Has Port", "cat": "State", "fields": [("value", "dropdown:yes,no", "yes", "Whether the state has a port.")]},
+    "has_naval_base": {"label": "Has Naval Base", "cat": "State", "fields": [("value", "dropdown:yes,no", "yes", "Whether the state has a naval base.")]},
+    "terrain": {"label": "Has Terrain", "cat": "State", "fields": [("terrain", "entry", "plains", "Terrain key.")]},
+    "is_in_home_area": {"label": "Is In Home Area", "cat": "State", "fields": [("value", "dropdown:yes,no", "yes", "Whether the state is in the current country's home area.")]},
+    "is_on_continent": {"label": "Is On Continent", "cat": "State", "fields": [("continent", "entry", "europe", "Continent key.")]},
+    "has_continent": {"label": "Has Continent", "cat": "State", "fields": [("continent", "entry", "europe", "Continent key.")]},
+    "province_id": {"label": "Province ID", "cat": "Province", "fields": [("province", "entry", "1234", "Province ID.")]},
+    "has_province_modifier": {"label": "Has Province Modifier", "cat": "Province", "fields": [("modifier", "entry", "my_province_modifier", "Province modifier name.")]},
+    "is_in_state": {"label": "Is In State", "cat": "Province", "fields": [("state", "entry", "64", "State ID.")]},
+
+    # ── Date, AI and scope iteration ───────────────────────────────────────
+    "date": {"label": "Date", "cat": "Date", "fields": [("comparison", "entry", "> 1939.1.1", "Date comparison, for example < 1939.9.1.")]},
+    "has_start_date": {"label": "Has Start Date", "cat": "Date", "fields": [("comparison", "entry", ">= 1936.1.1", "Start date comparison.")]},
+    "days_since_last_war": {"label": "Days Since Last War", "cat": "Date", "fields": [("amount", "entry", "> 30", "Number of days comparison.")]},
+    "has_active_mission": {"label": "Has Active Mission", "cat": "Date", "fields": [("mission", "entry", "mission_id", "Mission ID.")]},
+    "ai_will_do": {"label": "AI Will Do", "cat": "AI", "fields": [("conditions", "multiline", "base = 1", "Modifier triggers used by an AI weight." )], "_block": True},
+    "ai_strategy_plan": {"label": "AI Strategy Plan", "cat": "AI", "fields": [("plan", "entry", "plan_id", "AI strategy plan ID.")]},
+    "is_in_home_area_of": {"label": "Is In Home Area Of", "cat": "AI", "fields": [("country", "entry", "GER", "Country tag or scope.")]},
+    "any_owned_state": {"label": "Any Owned State", "cat": "Scope", "fields": [("conditions", "multiline", "is_coastal = yes", "A state trigger checked for each owned state.")], "_block": True},
+    "all_owned_state": {"label": "All Owned States", "cat": "Scope", "fields": [("conditions", "multiline", "is_core_of = ROOT", "A state trigger checked for every owned state.")], "_block": True},
+    "any_controlled_state": {"label": "Any Controlled State", "cat": "Scope", "fields": [("conditions", "multiline", "has_building = { industrial_complex > 0 }", "A state trigger checked for each controlled state.")], "_block": True},
+    "all_controlled_state": {"label": "All Controlled States", "cat": "Scope", "fields": [("conditions", "multiline", "is_demilitarized = no", "A state trigger checked for every controlled state.")], "_block": True},
+    "any_neighbor_country": {"label": "Any Neighbor Country", "cat": "Scope", "fields": [("conditions", "multiline", "has_war = yes", "A country trigger checked for each neighbor.")], "_block": True},
+    "all_neighbor_country": {"label": "All Neighbor Countries", "cat": "Scope", "fields": [("conditions", "multiline", "has_war = no", "A country trigger checked for every neighbor.")], "_block": True},
+    "any_country": {"label": "Any Country", "cat": "Scope", "fields": [("conditions", "multiline", "is_major = yes", "A country trigger checked for each country.")], "_block": True},
+    "all_country": {"label": "All Countries", "cat": "Scope", "fields": [("conditions", "multiline", "is_ai = yes", "A country trigger checked for every country.")], "_block": True},
+    "any_state": {"label": "Any State", "cat": "Scope", "fields": [("conditions", "multiline", "is_coastal = yes", "A state trigger checked for each state.")], "_block": True},
+    "all_state": {"label": "All States", "cat": "Scope", "fields": [("conditions", "multiline", "has_state_category = rural", "A state trigger checked for every state.")], "_block": True},
+}
+
+TRIGGER_CATS = ["Logic", "Script", "Focus", "Diplomacy", "War", "Politics", "Military", "Research", "Economy", "State", "Province", "Date", "AI", "Scope"]
+# fmt: on
+
+_TRIGGERS_BY_CAT = None
+
+
+def triggers_in_cat(cat):
+    """Return ``[(key, label), ...]`` for every trigger in *cat*."""
+    global _TRIGGERS_BY_CAT
+    if _TRIGGERS_BY_CAT is None:
+        index = {}
+        for key, definition in TRIGGER_DEFS.items():
+            index.setdefault(definition.get("cat"), []).append(
+                (key, definition["label"])
+            )
+        _TRIGGERS_BY_CAT = index
+    return list(_TRIGGERS_BY_CAT.get(cat, []))
+
+
+__all__ = ["TRIGGER_DEFS", "TRIGGER_CATS", "triggers_in_cat"]

--- a/src/hoi4cm/wizards/_shared.py
+++ b/src/hoi4cm/wizards/_shared.py
@@ -8,7 +8,13 @@ coupling and gives the App a single place to clear caches on mod reload.
 import re
 import tkinter as tk
 
-from hoi4cm.core import EFFECT_CATS, EFFECT_DEFS, effects_in_cat, tr
+from hoi4cm.core import (
+    EFFECT_CATS,
+    EFFECT_DEFS,
+    TRIGGER_CATS,
+    TRIGGER_DEFS,
+    tr,
+)
 from hoi4cm.mod import notifying_workspace_files
 from hoi4cm.ui import (
     BG_CARD,
@@ -80,17 +86,55 @@ _app_img_caches.extend([_ev_gfx_cache, _ev_imgsize_cache])
 _LOC_KEY_RE = re.compile(r'\s+(\S+?)(?::\d+)?\s*"')
 
 
-# ── Effect picker popup (event + decision wizards) ─────────────────
-def open_effect_picker(parent, target_text, on_insert=None):
-    """Popup effect selector shared by the event and decision wizards.
+def render_script_snippet(key, definition, values, *, is_trigger=False):
+    """Render a catalogue entry from its field values without Tk widgets."""
+    if not definition:
+        return f"\t{key} = yes\n"
+    fields = definition.get("fields", [])
+    if is_trigger and not fields:
+        return f"\t{key} = yes\n"
 
-    Inserts rendered HOI4 code into ``target_text`` (a ``tk.Text`` widget).
-    ``on_insert``, if given, is called after a snippet is inserted (the
-    event wizard uses it to refresh its live preview). Returns the popup
-    ``Toplevel`` (tests drive it from there; wizard call sites ignore it).
+    if is_trigger and len(fields) == 1 and not definition.get("_block"):
+        value = values.get(fields[0][0], "").strip()
+        if value.startswith(("<", ">", "=")):
+            return f"\t{key} {value}\n"
+
+    if definition.get("_block") or len(fields) != 1:
+        lines = [f"\t{key} = {{"]
+        if definition.get("_block") and len(fields) == 1:
+            content = values.get(fields[0][0], "").strip()
+            lines.extend(f"\t\t{line}" for line in content.splitlines())
+        else:
+            for fname, _wtype, _default, _hint in fields:
+                value = values.get(fname, "").strip()
+                operator = (
+                    " " if is_trigger and value.startswith(("<", ">", "=")) else " = "
+                )
+                lines.append(f"\t\t{fname}{operator}{value}")
+        lines.append("\t}")
+        return "\n".join(lines) + "\n"
+    return f"\t{key} = {values.get(fields[0][0], '').strip()}\n"
+
+
+# ── Script picker popups (event, decision and condition wizards) ────────────
+def open_script_picker(
+    parent,
+    target_text,
+    definitions,
+    categories,
+    *,
+    picker_name="Effect",
+    on_insert=None,
+):
+    """Open a catalogue picker that inserts a script snippet into a Text.
+
+    The browser and field form are shared by effects and triggers. Keeping the
+    target widget as an explicit argument means each button inserts only into
+    the field that opened it, without replacing existing text.
     """
     pwin = tk.Toplevel(parent)
-    pwin.title(tr("effect_picker.title", "Effect Picker"))
+    picker_key = picker_name.lower()
+    pwin.title(tr(f"{picker_key}_picker.title", f"{picker_name} Picker"))
     pwin.configure(bg=BG_DARK)
     pwin.geometry("620x580")
     pwin.resizable(True, True)
@@ -102,7 +146,12 @@ def open_effect_picker(parent, target_text, on_insert=None):
     tk.Label(hdr, text="🔍", bg=BG_DARK, fg=TEXT_DIM, font=("Helvetica", 11)).pack(
         side="left", padx=(0, 4)
     )
-    _search_ph = tr("focus.effects.search_placeholder", "Search effects...")
+    search_key = (
+        "focus.effects.search_placeholder"
+        if picker_key == "effect"
+        else f"{picker_key}_picker.search_placeholder"
+    )
+    _search_ph = tr(search_key, f"Search {picker_name.lower()}s...")
     eff_search_var = tk.StringVar(value=_search_ph)
     eff_search_ent = tk.Entry(
         hdr,
@@ -140,9 +189,9 @@ def open_effect_picker(parent, target_text, on_insert=None):
         fg=TEXT_DIM,
         font=("Helvetica", 9),
     ).pack(side="left")
-    eff_cat = tk.StringVar(value=EFFECT_CATS[0])
+    eff_cat = tk.StringVar(value=categories[0])
     cat_menu = tk.OptionMenu(
-        cat_row, eff_cat, *EFFECT_CATS, command=lambda _: _rebuild_dd()
+        cat_row, eff_cat, *categories, command=lambda _: _rebuild_dd()
     )
     cat_menu.config(
         bg=BG_CARD,
@@ -168,7 +217,11 @@ def open_effect_picker(parent, target_text, on_insert=None):
         for w in dd_frame.winfo_children():
             w.destroy()
         if items is None:
-            items = effects_in_cat(eff_cat.get())
+            items = [
+                (key, definition["label"])
+                for key, definition in definitions.items()
+                if definition.get("cat") == eff_cat.get()
+            ]
         if not items:
             return
         eff_type.set(items[0][0])
@@ -205,7 +258,7 @@ def open_effect_picker(parent, target_text, on_insert=None):
         q = raw.strip().lower()
         matches = [
             (k, v["label"])
-            for k, v in EFFECT_DEFS.items()
+            for k, v in definitions.items()
             if q in k.lower()
             or q in v["label"].lower()
             or q in v.get("cat", "").lower()
@@ -213,9 +266,14 @@ def open_effect_picker(parent, target_text, on_insert=None):
         for w in dd_frame.winfo_children():
             w.destroy()
         if not matches:
+            none_key = (
+                "focus.effects.none_found"
+                if picker_key == "effect"
+                else f"{picker_key}_picker.none_found"
+            )
             tk.Label(
                 dd_frame,
-                text=tr("focus.effects.none_found", "No effects found"),
+                text=tr(none_key, f"No {picker_name.lower()}s found"),
                 bg=BG_DARK,
                 fg=TEXT_DIM,
                 font=("Helvetica", 9),
@@ -226,7 +284,7 @@ def open_effect_picker(parent, target_text, on_insert=None):
         menu = om["menu"]
         menu.delete(0, "end")
         for k, lbl in matches:
-            cat = EFFECT_DEFS[k].get("cat", "")
+            cat = definitions[k].get("cat", "")
             menu.add_command(
                 label=f"[{cat}]  {k}  —  {lbl}",
                 command=lambda v=k: [eff_type.set(v), _refresh_fields()],
@@ -288,15 +346,33 @@ def open_effect_picker(parent, target_text, on_insert=None):
             w.destroy()
         _fvars.clear()
         key = eff_type.get()
-        defn = EFFECT_DEFS.get(key, {})
+        defn = definitions.get(key, {})
         if not defn:
+            if picker_key == "effect":
+                unknown_text = tr(
+                    "effect_picker.unknown_effect",
+                    "\n".join(
+                        (
+                            "  Unknown effect: {effect}",
+                            "  Will be inserted as raw snippet.",
+                        )
+                    ),
+                    effect=repr(key),
+                )
+            else:
+                unknown_text = tr(
+                    "trigger_picker.unknown_trigger",
+                    "\n".join(
+                        (
+                            "  Unknown trigger: {trigger}",
+                            "  Will be inserted as raw snippet.",
+                        )
+                    ),
+                    trigger=repr(key),
+                )
             tk.Label(
                 fields_frm,
-                text=tr(
-                    "effect_picker.unknown_effect",
-                    "  Unknown effect: {effect}\n  Will be inserted as raw snippet.",
-                    effect=repr(key),
-                ),
+                text=unknown_text,
                 bg=BG_PANEL,
                 fg=ORANGE,
                 font=("Helvetica", 9, "italic"),
@@ -395,31 +471,18 @@ def open_effect_picker(parent, target_text, on_insert=None):
     # ── render HOI4 snippet ────────────────────────────────────────
     def _render_snippet():
         key = eff_type.get().strip()
-        defn = EFFECT_DEFS.get(key, {})
-        if not defn:
-            return f"\t{key} = yes\n"
-        fields = defn.get("fields", [])
-        if len(fields) == 1:
-            fname, wtype, _, _ = fields[0]
+        defn = definitions.get(key, {})
+        values = {}
+        for fname in (field[0] for field in defn.get("fields", [])):
             kind, ref = _fvars.get(fname, ("var", tk.StringVar()))
-            val = (
+            values[fname] = (
                 ref.get("1.0", "end-1c").strip()
                 if kind == "text"
                 else ref.get().strip()
             )
-            return f"\t{key} = {val}\n"
-        else:
-            lines = [f"\t{key} = {{"]
-            for fname, _wtype, _, _ in fields:
-                kind, ref = _fvars.get(fname, ("var", tk.StringVar()))
-                val = (
-                    ref.get("1.0", "end-1c").strip()
-                    if kind == "text"
-                    else ref.get().strip()
-                )
-                lines.append(f"\t\t{fname} = {val}")
-            lines.append("\t}")
-            return "\n".join(lines) + "\n"
+        return render_script_snippet(
+            key, defn, values, is_trigger=picker_key == "trigger"
+        )
 
     # ── live preview ───────────────────────────────────────────────
     tk.Frame(pwin, bg=BORDER_G, height=1).pack(fill="x", padx=8)
@@ -427,7 +490,7 @@ def open_effect_picker(parent, target_text, on_insert=None):
     prev_frame.pack(fill="x", padx=8, pady=(4, 0))
     tk.Label(
         prev_frame,
-        text=tr("effect_picker.preview", "  Preview:"),
+        text=tr(f"{picker_key}_picker.preview", "  Preview:"),
         bg=BG_DARK,
         fg=TEXT_DIM,
         font=("Helvetica", 8, "bold"),
@@ -489,7 +552,14 @@ def open_effect_picker(parent, target_text, on_insert=None):
 
     tk.Button(
         bot,
-        text=tr("effect_picker.insert_effect", "+ Insert Effect"),
+        text=tr(
+            (
+                "effect_picker.insert_effect"
+                if picker_key == "effect"
+                else f"{picker_key}_picker.insert_item"
+            ),
+            f"+ Insert {picker_name}",
+        ),
         command=_insert_effect,
         bg="#14532d",
         fg=GREEN,
@@ -502,7 +572,14 @@ def open_effect_picker(parent, target_text, on_insert=None):
 
     tk.Label(
         bot,
-        text=tr("effect_picker.insert_hint", "Inserts snippet at end of effects box"),
+        text=tr(
+            (
+                "effect_picker.insert_hint"
+                if picker_key == "effect"
+                else f"{picker_key}_picker.insert_hint"
+            ),
+            f"Inserts snippet at end of {picker_name.lower()}s box",
+        ),
         bg=BG_DARK,
         fg=TEXT_DIM,
         font=("Helvetica", 8, "italic"),
@@ -513,6 +590,30 @@ def open_effect_picker(parent, target_text, on_insert=None):
     return pwin
 
 
+def open_effect_picker(parent, target_text, on_insert=None):
+    """Open the shared effect picker."""
+    return open_script_picker(
+        parent,
+        target_text,
+        EFFECT_DEFS,
+        EFFECT_CATS,
+        picker_name="Effect",
+        on_insert=on_insert,
+    )
+
+
+def open_trigger_picker(parent, target_text, on_insert=None):
+    """Open the shared trigger picker for a condition Text widget."""
+    return open_script_picker(
+        parent,
+        target_text,
+        TRIGGER_DEFS,
+        TRIGGER_CATS,
+        picker_name="Trigger",
+        on_insert=on_insert,
+    )
+
+
 __all__ = [
     "_app_img_caches",
     "_ev_gfx_cache",
@@ -520,6 +621,9 @@ __all__ = [
     "_LOC_KEY_RE",
     "notifying_workspace_files",
     "open_effect_picker",
+    "open_script_picker",
+    "open_trigger_picker",
+    "render_script_snippet",
     "svar_get",
     "text_get",
 ]

--- a/src/hoi4cm/wizards/decision.py
+++ b/src/hoi4cm/wizards/decision.py
@@ -53,6 +53,7 @@ from hoi4cm.wizards._shared import (
     _app_img_caches,
     notifying_workspace_files,
     open_effect_picker,
+    open_trigger_picker,
 )
 
 
@@ -1022,6 +1023,22 @@ def open_decision_wizard(app):
             undo=True,
         )
         t.pack(fill="x", pady=(2, 0))
+        tk.Button(
+            hrow,
+            text=tr("trigger_picker.button", "+ Insert trigger"),
+            command=lambda tw=t: open_trigger_picker(
+                win, tw, on_insert=lambda: (_collect(), _rebuild_right())
+            ),
+            bg=C_CARD,
+            fg=C_BLUE,
+            relief="flat",
+            font=("Courier", 8),
+            cursor="hand2",
+            padx=6,
+            pady=1,
+            highlightthickness=1,
+            highlightbackground=TEAL_TAG_BD,
+        ).pack(side="right")
         return _reg_text(key, t, initial)
 
     def _effectblock(label, key, initial="", rows=4):

--- a/src/hoi4cm/wizards/dyn_mod.py
+++ b/src/hoi4cm/wizards/dyn_mod.py
@@ -43,6 +43,7 @@ from hoi4cm.wizards._graphics import browser_folders, collect_image_pairs
 from hoi4cm.wizards._image_loader import TkImageLoader
 from hoi4cm.wizards._shared import (
     notifying_workspace_files,
+    open_trigger_picker,
     svar_get,
     text_get,
 )
@@ -633,6 +634,20 @@ def open_dyn_mod_wizard(app):
         wrap="none",
     )
     v_enable.pack(fill="x", padx=12, pady=2)
+    tk.Button(
+        frm,
+        text=tr("trigger_picker.button", "+ Insert trigger"),
+        command=lambda: open_trigger_picker(win, v_enable, on_insert=_preview),
+        bg=BG_CARD,
+        fg=BLUE,
+        relief="flat",
+        font=("Helvetica", 8),
+        cursor="hand2",
+        padx=6,
+        pady=1,
+        highlightthickness=1,
+        highlightbackground=BORDER_G,
+    ).pack(anchor="e", padx=12, pady=(0, 2))
 
     sep()
     lbl(

--- a/src/hoi4cm/wizards/event.py
+++ b/src/hoi4cm/wizards/event.py
@@ -51,6 +51,7 @@ from hoi4cm.wizards._shared import (
     _ev_imgsize_cache,
     notifying_workspace_files,
     open_effect_picker,
+    open_trigger_picker,
 )
 
 
@@ -857,6 +858,10 @@ def open_event_wizard(app):
     def _open_effect_picker(target_text):
         """Open the shared effect picker, wired to this wizard's preview."""
         open_effect_picker(win, target_text, on_insert=_schedule_preview)
+
+    def _open_trigger_picker(target_text):
+        """Open the shared trigger picker, wired to this wizard's preview."""
+        open_trigger_picker(win, target_text, on_insert=_schedule_preview)
 
     # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
     # BUILD UI — all functions defined above, safe to reference them now
@@ -2805,6 +2810,20 @@ def open_event_wizard(app):
         )
     )
     t_trigger = _textbox("", height=3)
+    tk.Button(
+        F,
+        text=tr("trigger_picker.button", "+ Insert trigger"),
+        bg=BG_CARD,
+        fg=BLUE,
+        relief="flat",
+        font=("Helvetica", 8),
+        cursor="hand2",
+        padx=6,
+        pady=1,
+        highlightthickness=1,
+        highlightbackground=BORDER,
+        command=lambda: _open_trigger_picker(t_trigger),
+    ).pack(anchor="e", padx=8, pady=(0, 2))
     _hsep()
     imm_hdr = tk.Frame(F, bg=BG_PANEL)
     imm_hdr.pack(fill="x", padx=8, pady=(4, 0))

--- a/src/hoi4cm/wizards/national_spirit.py
+++ b/src/hoi4cm/wizards/national_spirit.py
@@ -50,6 +50,7 @@ from hoi4cm.wizards._graphics import browser_folders, collect_image_pairs
 from hoi4cm.wizards._image_loader import TkImageLoader
 from hoi4cm.wizards._shared import (
     notifying_workspace_files,
+    open_trigger_picker,
     svar_get,
     text_get,
 )
@@ -347,16 +348,17 @@ def open_national_spirit_wizard(app):
         om["menu"].config(bg=BG_CARD, fg=TEXT, activebackground=BORDER_G)
         om.pack(side="left", fill="x", expand=True)
 
-    def _trigger_field(label, height=2):
+    def _trigger_field(label, height=2, picker=False):
         row = tk.Frame(lfrm, bg=BG_PANEL)
         row.pack(fill="x", padx=10, pady=2)
+        label_row = tk.Frame(row, bg=BG_PANEL)
+        label_row.pack(fill="x")
         tk.Label(
-            row,
+            label_row,
             text=label,
             bg=BG_PANEL,
             fg=TEXT_DIM,
             font=("Helvetica", 9),
-            width=14,
             anchor="nw",
         ).pack(side="left")
         t = tk.Text(
@@ -371,7 +373,24 @@ def open_national_spirit_wizard(app):
             height=height,
             wrap="none",
         )
-        t.pack(side="left", fill="x", expand=True, ipady=2)
+        t.pack(fill="x", ipady=2)
+        if picker:
+            tk.Button(
+                label_row,
+                text=tr("trigger_picker.button", "+ Insert trigger"),
+                command=lambda tw=t: open_trigger_picker(
+                    win, tw, on_insert=_refresh_preview
+                ),
+                bg=BG_CARD,
+                fg=BLUE,
+                relief="flat",
+                font=("Helvetica", 8),
+                cursor="hand2",
+                padx=6,
+                pady=1,
+                highlightthickness=1,
+                highlightbackground=BORDER_G,
+            ).pack(side="right")
         t.bind("<KeyRelease>", lambda e: _refresh_preview())
         return t
 
@@ -838,10 +857,18 @@ def open_national_spirit_wizard(app):
     _sep()
     # ── TRIGGERS ──────────────────────────────────────────────────────
     _sec(tr("spirit.section.triggers", "TRIGGERS  (optional)"))
-    t_allowed = _trigger_field(tr("spirit.field.allowed", "allowed:"), height=2)
-    t_available = _trigger_field(tr("spirit.field.available", "available:"), height=2)
-    t_cancel = _trigger_field(tr("spirit.field.cancel", "cancel:"), height=2)
-    t_visible = _trigger_field(tr("spirit.field.visible", "visible:"), height=2)
+    t_allowed = _trigger_field(
+        tr("spirit.field.allowed", "allowed:"), height=2, picker=True
+    )
+    t_available = _trigger_field(
+        tr("spirit.field.available", "available:"), height=2, picker=True
+    )
+    t_cancel = _trigger_field(
+        tr("spirit.field.cancel", "cancel:"), height=2, picker=True
+    )
+    t_visible = _trigger_field(
+        tr("spirit.field.visible", "visible:"), height=2, picker=True
+    )
     t_allowed.insert("1.0", "original_tag = TAG")
 
     _sep()

--- a/tests/test_trigger_picker.py
+++ b/tests/test_trigger_picker.py
@@ -1,0 +1,140 @@
+"""Tk behavior tests for the shared trigger picker."""
+
+import tkinter as tk
+
+import hoi4cm.wizards.national_spirit as national_spirit
+from hoi4cm.wizards._shared import open_trigger_picker, render_script_snippet
+from hoi4cm.wizards.national_spirit import open_national_spirit_wizard
+
+
+def _widgets(widget, kind):
+    found = []
+    for child in widget.winfo_children():
+        if isinstance(child, kind):
+            found.append(child)
+        found.extend(_widgets(child, kind))
+    return found
+
+
+def test_render_trigger_snippets_without_tk():
+    from hoi4cm.data import TRIGGER_DEFS
+
+    assert render_script_snippet(
+        "always", TRIGGER_DEFS["always"], {}, is_trigger=True
+    ) == ("\talways = yes\n")
+    assert (
+        render_script_snippet(
+            "has_country_flag",
+            TRIGGER_DEFS["has_country_flag"],
+            {"flag": "my_flag"},
+            is_trigger=True,
+        )
+        == "\thas_country_flag = my_flag\n"
+    )
+    assert (
+        render_script_snippet(
+            "has_war_support",
+            TRIGGER_DEFS["has_war_support"],
+            {"amount": "> 0.5"},
+            is_trigger=True,
+        )
+        == "\thas_war_support > 0.5\n"
+    )
+    assert (
+        render_script_snippet(
+            "AND", TRIGGER_DEFS["AND"], {"conditions": "always = yes"}, is_trigger=True
+        )
+        == "\tAND = {\n\t\talways = yes\n\t}\n"
+    )
+
+
+def test_national_spirit_trigger_fields_use_picker(tk_root, monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        national_spirit,
+        "open_trigger_picker",
+        lambda parent, target, on_insert=None: calls.append((parent, target)),
+    )
+    open_national_spirit_wizard(tk_root)
+    picker_buttons = [
+        button
+        for button in _widgets(tk_root, tk.Button)
+        if button.cget("text") == "+ Insert trigger"
+    ]
+    assert len(picker_buttons) == 4
+    for button in picker_buttons:
+        button.invoke()
+    assert len(calls) == 4
+    assert all(isinstance(target, tk.Text) for _, target in calls)
+
+    for child in list(tk_root.winfo_children()):
+        if isinstance(child, tk.Toplevel):
+            child.destroy()
+
+
+def test_trigger_picker_renders_comparison_trigger(tk_root):
+    target = tk.Text(tk_root)
+    picker = open_trigger_picker(tk_root, target)
+    search = _widgets(picker, tk.Entry)[0]
+    search.delete(0, "end")
+    search.insert(0, "has_war_support")
+    picker.update_idletasks()
+    next(
+        button
+        for button in _widgets(picker, tk.Button)
+        if "Insert Trigger" in button.cget("text")
+    ).invoke()
+    assert target.get("1.0", "end-1c") == "\thas_war_support > 0.5\n"
+
+
+def test_trigger_picker_renders_nested_trigger_block(tk_root):
+    target = tk.Text(tk_root)
+    picker = open_trigger_picker(tk_root, target)
+    search = _widgets(picker, tk.Entry)[0]
+    search.delete(0, "end")
+    search.insert(0, "AND")
+    picker.update_idletasks()
+    option_menus = _widgets(picker, tk.OptionMenu)
+    option_menus[1]["menu"].invoke(0)
+    picker.update_idletasks()
+    insert_button = next(
+        button
+        for button in _widgets(picker, tk.Button)
+        if "Insert Trigger" in button.cget("text")
+    )
+    insert_button.invoke()
+    assert target.get("1.0", "end-1c") == "\tAND = {\n\t\talways = yes\n\t}\n"
+
+
+def test_trigger_picker_inserts_into_selected_text_and_preserves_text(tk_root):
+    target = tk.Text(tk_root)
+    target.insert("1.0", "already_here = yes\n")
+    picker = open_trigger_picker(tk_root, target)
+
+    search = _widgets(picker, tk.Entry)[0]
+    search.delete(0, "end")
+    search.insert(0, "has_country_flag")
+    picker.update_idletasks()
+    option_menus = _widgets(picker, tk.OptionMenu)
+    assert len(option_menus) >= 2
+    trigger_menu = option_menus[1]["menu"]
+    assert trigger_menu.entrycget(0, "label").startswith("[Script]")
+    trigger_menu.invoke(0)
+    picker.update_idletasks()
+
+    entries = _widgets(picker, tk.Entry)
+    assert entries
+    entries[-1].delete(0, "end")
+    entries[-1].insert(0, "my_flag")
+    insert_buttons = [
+        button
+        for button in _widgets(picker, tk.Button)
+        if "Insert Trigger" in button.cget("text")
+    ]
+    assert len(insert_buttons) == 1
+    insert_buttons[0].invoke()
+
+    assert target.get("1.0", "end-1c") == (
+        "already_here = yes\n\thas_country_flag = my_flag\n"
+    )
+    assert not picker.winfo_exists()

--- a/tests/test_triggers_data.py
+++ b/tests/test_triggers_data.py
@@ -1,0 +1,37 @@
+"""Regression tests for the vanilla trigger catalogue."""
+
+from hoi4cm.data import TRIGGER_CATS, TRIGGER_DEFS, triggers_in_cat
+
+
+def test_trigger_defs_cover_vanilla_catalogue_shape():
+    assert len(TRIGGER_DEFS) >= 100
+    assert {"always", "has_country_flag", "has_idea", "owns_state"} <= set(TRIGGER_DEFS)
+    for definition in TRIGGER_DEFS.values():
+        assert isinstance(definition["label"], str)
+        assert definition["cat"] in TRIGGER_CATS
+        assert isinstance(definition["fields"], list)
+        for field in definition["fields"]:
+            assert len(field) == 4
+            assert all(isinstance(value, str) for value in field)
+
+
+def test_triggers_in_cat_matches_catalogue_and_is_copy():
+    for category in TRIGGER_CATS:
+        expected = [
+            (key, definition["label"])
+            for key, definition in TRIGGER_DEFS.items()
+            if definition["cat"] == category
+        ]
+        assert triggers_in_cat(category) == expected
+
+    items = triggers_in_cat("Politics")
+    items.clear()
+    assert triggers_in_cat("Politics")
+    assert triggers_in_cat("missing") == []
+
+
+def test_trigger_fields_include_hints_for_common_conditions():
+    for key in ("has_country_flag", "has_idea", "has_completed_focus", "owns_state"):
+        fields = TRIGGER_DEFS[key]["fields"]
+        assert fields
+        assert all(field[3] for field in fields)


### PR DESCRIPTION
## Bottom line

Trigger-bearing fields now offer a searchable picker backed by a catalogue of common HOI4 triggers. Existing raw condition text remains editable and picker inserts append to the selected field.

## How

The shared effect picker now accepts either data source, and focus, decision, event, spirit, and dynamic-modifier condition fields wire into the trigger variant.

Closes #36

BLUF