### PR TITLE
Generate focus sprite declarations on export

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -32,9 +32,9 @@
   effects, scripted triggers, on-action hooks, dyn-mod IDs, country tags, and
   MD money-system paths. MD mode is detected from the mod identity or
   money-system file, unless `md_mode_override` is configured. `scan_cache.py`
-  is the SQLite per-file cache backing warm reloads. `workspace_files.py` is
-  the single writer every mod-file save goes through (see "Writing mod files"
-  below).
+  is the SQLite per-file cache backing warm reloads. `gfx_writer.py` preserves
+  and extends sprite declarations. `workspace_files.py` is the single writer
+  every mod-file save goes through (see "Writing mod files" below).
 - **`wizards/`**: the five `open_*_wizard(app)` entry points (decision,
   event, national spirit, dynamic modifier, additional income) plus
   `_shared.py` for cross-wizard state, including shared effect/trigger pickers.
@@ -108,6 +108,10 @@ truncate-in-place write destroys it if the process dies mid-write (issue #46).
 `hoi4cm.wizards._shared` for the wizards) builds a writer whose `on_written`
 hook pokes the graphics catalog — but only when the save target is the
 currently loaded mod, so writing elsewhere never touches live state.
+
+`mod.gfx_writer.append_sprite_types` renders declarations into new or existing
+`spriteTypes` wrappers without replacing user content. Callers still pass the
+result through `WorkspaceFiles`.
 
 The other half of the contract is that a failure is **reported**, not
 swallowed or raised as a traceback: `hoi4cm.ui.file_errors`'s

--- a/hoi4_content_maker.py
+++ b/hoi4_content_maker.py
@@ -70,6 +70,7 @@ from hoi4cm.core import (  # noqa: E402
     parse_focus_tree,
     read_file,
     render_focus_block,
+    safe_join,
     sanitize_component,
     set_error_callback,
     show_splash,
@@ -87,7 +88,13 @@ from hoi4cm.focus_tree.validate import (  # noqa: E402
     validate_document,
     worst_severity_per_focus,
 )
-from hoi4cm.mod import MOD, detect_loc_file  # noqa: E402
+from hoi4cm.mod import (  # noqa: E402
+    DEFAULT_FOCUS_ICON,
+    MOD,
+    build_focus_sprite_entries,
+    detect_loc_file,
+    resolve_focus_image_paths,
+)
 from hoi4cm.mod.workspace_files import WorkspaceFiles  # noqa: E402
 from hoi4cm.models import (  # noqa: E402
     EditorWorkspace,
@@ -5206,6 +5213,61 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
         else:
             on_done([])
 
+    def _focus_gfx_export(self, focuses, country_tag, *, show_dialog=True):
+        """Offer declarations for selected focus icons missing from the mod."""
+        if not show_dialog or not getattr(MOD, "loaded", False):
+            return None, ()
+        mod_root = getattr(MOD, "root", "") or ""
+        if not os.path.isdir(mod_root):
+            return None, ()
+        declared_names = getattr(MOD, "sprites", {}) or {}
+        icon_names = [getattr(focus, "gfx", "") for focus in focuses]
+        missing_names = sorted(
+            {
+                name
+                for name in icon_names
+                if name and name != DEFAULT_FOCUS_ICON and name not in declared_names
+            }
+        )
+        if not missing_names:
+            return None, ()
+        catalog = getattr(MOD, "graphics_catalog", None)
+        image_paths = {}
+        if catalog is not None:
+            image_paths = resolve_focus_image_paths(
+                missing_names,
+                catalog=catalog,
+                mod_root=mod_root,
+                goals_path=getattr(MOD, "path_goals", "")
+                or os.path.join("gfx", "interface", "goals"),
+            )
+        entries, unresolved = build_focus_sprite_entries(
+            missing_names,
+            declared_names=declared_names,
+            image_paths=image_paths,
+            mod_root=mod_root,
+        )
+        body = (
+            "The export uses focus icon keys that are not declared in the loaded mod:\n\n"
+            + "\n".join(f"  {name}" for name in missing_names)
+            + f"\n\nGenerate spriteType entries in interface/{country_tag}_focus.gfx?"
+        )
+        if unresolved:
+            body += (
+                "\n\nNo declaration will be generated for icons whose texture "
+                "cannot be resolved under the mod:\n"
+                + "\n".join(f"  {name}" for name in unresolved)
+            )
+        if not messagebox.askyesno("Generate focus icon declarations?", body):
+            return None, ()
+        if not entries:
+            return None, ()
+        try:
+            gfx_path = safe_join(mod_root, "interface", f"{country_tag}_focus.gfx")
+        except ValueError:
+            return None, ()
+        return gfx_path, entries
+
     def _make_main_export_plan(
         self, main_focuses, focus_lookup, focus_name_lookup, *, show_dialog
     ):
@@ -5292,6 +5354,9 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
                 )
                 if not loc_path:
                     loc_path = os.path.join(saved_dir, loc_filename)
+        gfx_path, gfx_entries = self._focus_gfx_export(
+            main_focuses, country_tag, show_dialog=show_dialog
+        )
         return make_main_export_plan(
             label=f"Main: {tree_id}",
             focus_path=path,
@@ -5310,6 +5375,8 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
             focus_lookup=focus_lookup,
             focus_name_lookup=focus_name_lookup,
             loc_language=MOD.loc_language,
+            gfx_path=gfx_path,
+            gfx_entries=gfx_entries,
         )
 
     def _make_extra_export_plan(
@@ -5341,6 +5408,13 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
             )
         if not path:
             return None
+        country_tag = sanitize_component(
+            str(info.get("country_tag", "TAG")).upper(), fallback="TAG"
+        )
+        if show_dialog:
+            gfx_path, gfx_entries = self._focus_gfx_export(focuses_in_tree, country_tag)
+        else:
+            gfx_path, gfx_entries = None, ()
         return make_extra_export_plan(
             label=f"{info['type'].capitalize()}: {info['tree_id']}",
             focus_path=path,
@@ -5349,6 +5423,8 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
             focus_lookup=focus_lookup,
             focus_name_lookup=focus_name_lookup,
             extra_tree_idx=tree_idx,
+            gfx_path=gfx_path,
+            gfx_entries=gfx_entries,
         )
 
     # ── SAVE / LOAD ─────────────────────────────────────────────

--- a/hoi4_content_maker.py
+++ b/hoi4_content_maker.py
@@ -5248,7 +5248,8 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
             mod_root=mod_root,
         )
         body = (
-            "The export uses focus icon keys that are not declared in the loaded mod:\n\n"
+            "The export uses focus icon keys that are not declared in the "
+            "loaded mod:\n\n"
             + "\n".join(f"  {name}" for name in missing_names)
             + f"\n\nGenerate spriteType entries in interface/{country_tag}_focus.gfx?"
         )

--- a/src/hoi4cm/focus_tree/export_plan.py
+++ b/src/hoi4cm/focus_tree/export_plan.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 
 from hoi4cm.core.logger import get_logger
 from hoi4cm.core.paths import read_file
+from hoi4cm.mod import append_sprite_types
 from hoi4cm.mod.workspace_files import WriteEntry
 from hoi4cm.models import Focus
 
@@ -34,6 +35,8 @@ class ExportPlan:
     loc_path: str | None = None
     loc_language: str = "english"
     extra_tree_idx: int | None = None
+    gfx_path: str | None = None
+    gfx_entries: tuple[tuple[str, str], ...] = ()
 
 
 @dataclass(frozen=True)
@@ -60,6 +63,8 @@ def make_main_export_plan(
     focus_lookup: Mapping[int, Focus],
     focus_name_lookup: Mapping[str, Focus],
     loc_language: str = "english",
+    gfx_path: str | None = None,
+    gfx_entries: Iterable[tuple[str, str]] = (),
 ) -> ExportPlan:
     """Create a main-tree plan after the UI has resolved its destinations."""
     return ExportPlan(
@@ -72,6 +77,8 @@ def make_main_export_plan(
         focus_lookup=focus_lookup,
         focus_name_lookup=focus_name_lookup,
         loc_language=loc_language,
+        gfx_path=gfx_path,
+        gfx_entries=tuple(gfx_entries),
     )
 
 
@@ -84,6 +91,8 @@ def make_extra_export_plan(
     focus_lookup: Mapping[int, Focus],
     focus_name_lookup: Mapping[str, Focus],
     extra_tree_idx: int,
+    gfx_path: str | None = None,
+    gfx_entries: Iterable[tuple[str, str]] = (),
 ) -> ExportPlan:
     """Create a shared/joint-tree plan after the UI has resolved its destination."""
     return ExportPlan(
@@ -95,6 +104,8 @@ def make_extra_export_plan(
         focus_lookup=focus_lookup,
         focus_name_lookup=focus_name_lookup,
         extra_tree_idx=extra_tree_idx,
+        gfx_path=gfx_path,
+        gfx_entries=tuple(gfx_entries),
     )
 
 
@@ -126,15 +137,22 @@ def render_export_plan(
         writes = [(plan.focus_path, out_text, "utf-8")]
         if new_loc_text is not None and plan.loc_path is not None:
             writes.append((plan.loc_path, new_loc_text, "utf-8-sig"))
-        return tuple(writes), added_count
+    else:
+        out_text = export_focus_tree(
+            plan.focuses,
+            plan.tree_info,
+            focus_lookup=plan.focus_lookup,
+            focus_name_lookup=plan.focus_name_lookup,
+        )
+        writes = [(plan.focus_path, out_text, "utf-8")]
+        added_count = 0
 
-    out_text = export_focus_tree(
-        plan.focuses,
-        plan.tree_info,
-        focus_lookup=plan.focus_lookup,
-        focus_name_lookup=plan.focus_name_lookup,
-    )
-    return ((plan.focus_path, out_text, "utf-8"),), 0
+    if plan.gfx_path is not None and plan.gfx_entries:
+        existing_gfx = read_text(plan.gfx_path) if is_file(plan.gfx_path) else None
+        new_gfx, gfx_added = append_sprite_types(existing_gfx, plan.gfx_entries)
+        if gfx_added:
+            writes.append((plan.gfx_path, new_gfx, "utf-8"))
+    return tuple(writes), added_count
 
 
 def execute_export_plans(

--- a/src/hoi4cm/mod/__init__.py
+++ b/src/hoi4cm/mod/__init__.py
@@ -6,6 +6,15 @@ The :class:`~hoi4cm.mod.context.ModContext` instance lives at module level as
 """
 
 from hoi4cm.mod.context import ModContext, detect_loc_file, find_loc_files
+from hoi4cm.mod.gfx_writer import (
+    DEFAULT_FOCUS_ICON,
+    SpriteTypeEntry,
+    append_sprite_types,
+    build_focus_sprite_entries,
+    build_sprite_type,
+    resolve_focus_image_paths,
+    resolve_mod_texture_path,
+)
 from hoi4cm.mod.graphics_catalog import (
     AssetRef,
     GraphicsCatalog,
@@ -24,13 +33,20 @@ MOD = ModContext()
 
 __all__ = [
     "AssetRef",
+    "DEFAULT_FOCUS_ICON",
     "GraphicsCatalog",
     "GraphicsScanConfig",
     "ModContext",
     "MOD",
+    "SpriteTypeEntry",
     "WorkspaceFiles",
     "WriteEntry",
+    "append_sprite_types",
+    "build_focus_sprite_entries",
+    "build_sprite_type",
     "detect_loc_file",
     "find_loc_files",
     "notifying_workspace_files",
+    "resolve_focus_image_paths",
+    "resolve_mod_texture_path",
 ]

--- a/src/hoi4cm/mod/gfx_writer.py
+++ b/src/hoi4cm/mod/gfx_writer.py
@@ -1,0 +1,228 @@
+"""Helpers for preserving and extending Clausewitz ``spriteTypes`` files."""
+
+from __future__ import annotations
+
+import os
+import re
+from collections.abc import Collection, Iterable, Mapping
+from pathlib import Path
+from typing import cast
+
+from hoi4cm.script.syntax import match_brace
+
+DEFAULT_FOCUS_ICON = "GFX_goal_generic_political_pressure"
+
+_SPRITE_BLOCK_RE = re.compile(r'"[^"]*"|#[^\n]*|(?<!\w)spriteType\s*=\s*\{')
+_SPRITE_NAME_RE = re.compile(r'"[^"]*"|#[^\n]*|\bname\s*=\s*"([^"]+)"')
+_WRAPPER_RE = re.compile(r'"[^"]*"|#[^\n]*|(?<!\w)spriteTypes\s*=\s*\{')
+
+SpriteTypeEntry = tuple[str, str]
+
+
+def build_sprite_type(name: str, texture_path: str) -> str:
+    """Return one indented ``spriteType`` declaration."""
+    return (
+        "\tspriteType = {\n"
+        f'\t\tname = "{name}"\n'
+        f'\t\ttexturefile = "{texture_path}"\n'
+        "\t}"
+    )
+
+
+def append_sprite_types(
+    existing: str | None,
+    entries: Mapping[str, str] | Iterable[SpriteTypeEntry],
+) -> tuple[str, int]:
+    """Append missing declarations while leaving existing text untouched.
+
+    A missing file is wrapped in ``spriteTypes``. Existing wrappers receive the
+    declarations before their matching close brace; unwrapped files are kept
+    as-is and receive declarations at the end.
+    """
+    requested: Iterable[SpriteTypeEntry]
+    if isinstance(entries, Mapping):
+        requested = cast(Iterable[SpriteTypeEntry], entries.items())
+    else:
+        requested = entries
+    pending: list[SpriteTypeEntry] = []
+    seen: set[str] = set()
+    for name, texture_path in requested:
+        if name in seen:
+            continue
+        seen.add(name)
+        pending.append((name, texture_path))
+
+    if not pending:
+        return existing or "", 0
+
+    source = existing
+    existing_names = _declared_sprite_names(source or "")
+    new_entries = [
+        (name, texture_path)
+        for name, texture_path in pending
+        if name not in existing_names
+    ]
+    if not new_entries:
+        return source or "", 0
+
+    blocks = "\n".join(
+        build_sprite_type(name, texture_path) for name, texture_path in new_entries
+    )
+    if source is None:
+        return f"spriteTypes = {{\n\n{blocks}\n\n}}\n", len(new_entries)
+
+    wrapper = _next_code_match(_WRAPPER_RE, source)
+    if wrapper is not None:
+        close = match_brace(source, wrapper.end() - 1)
+        if close < len(source):
+            prefix = source[:close]
+            separator = "\n" if not prefix.endswith("\n\n") else ""
+            return (
+                f"{prefix}{separator}{blocks}\n{source[close:]}",
+                len(new_entries),
+            )
+
+    separator = "" if source.endswith(("\n", "\r")) else "\n"
+    return f"{source}{separator}{blocks}\n", len(new_entries)
+
+
+def resolve_mod_texture_path(
+    mod_root: str, image_path: str | os.PathLike[str] | None
+) -> str | None:
+    """Return a slash-separated mod-relative image path when it is safe."""
+    if not mod_root or not image_path:
+        return None
+    from hoi4cm.core.safe_path import safe_join
+
+    root = os.path.realpath(mod_root)
+    candidate = os.fspath(image_path)
+    if not os.path.isabs(candidate):
+        candidate = os.path.join(root, candidate)
+    try:
+        relative = os.path.relpath(candidate, root)
+        resolved = safe_join(root, relative)
+    except OSError, ValueError:
+        return None
+    if not os.path.isfile(resolved):
+        return None
+    return os.path.relpath(resolved, root).replace(os.sep, "/")
+
+
+def build_focus_sprite_entries(
+    icon_names: Iterable[str],
+    *,
+    declared_names: Collection[str],
+    image_paths: Mapping[str, str | os.PathLike[str]],
+    mod_root: str,
+) -> tuple[tuple[SpriteTypeEntry, ...], tuple[str, ...]]:
+    """Build safe declarations and report icon keys with unresolved images."""
+    candidates = sorted(
+        {
+            name
+            for name in icon_names
+            if name and name != DEFAULT_FOCUS_ICON and name not in declared_names
+        }
+    )
+    entries: list[SpriteTypeEntry] = []
+    unresolved: list[str] = []
+    for name in candidates:
+        texture_path = resolve_mod_texture_path(mod_root, image_paths.get(name))
+        if texture_path is None:
+            unresolved.append(name)
+        else:
+            entries.append((name, texture_path))
+    return tuple(entries), tuple(unresolved)
+
+
+def resolve_focus_image_paths(
+    icon_names: Iterable[str],
+    *,
+    catalog,
+    mod_root: str,
+    goals_path: str,
+) -> dict[str, str]:
+    """Resolve selected focus icons through the graphics catalog."""
+    paths: dict[str, str] = {}
+    names = tuple(dict.fromkeys(icon_names))
+    for name in names:
+        try:
+            asset = catalog.resolve(name)
+        except KeyError, OSError, ValueError, TypeError, RuntimeError:
+            asset = None
+        if asset is not None:
+            try:
+                paths[name] = catalog.path_for(asset)
+            except KeyError, OSError, ValueError, TypeError, RuntimeError:
+                pass
+
+    unresolved = [name for name in names if name not in paths]
+    if not unresolved:
+        return paths
+
+    roots = []
+    configured = goals_path
+    if not os.path.isabs(configured):
+        configured = os.path.join(mod_root, configured)
+    roots.append(os.path.realpath(configured))
+    roots.append(os.path.realpath(os.path.join(mod_root, "gfx", "interface")))
+    for root in dict.fromkeys(roots):
+        try:
+            assets = catalog.query(under=root)
+        except KeyError, OSError, ValueError, TypeError, RuntimeError:
+            continue
+        by_stem: dict[str, str] = {}
+        for asset in assets:
+            try:
+                path = catalog.path_for(asset)
+            except KeyError, OSError, ValueError, TypeError, RuntimeError:
+                continue
+            by_stem.setdefault(Path(path).stem, path)
+        for name in unresolved:
+            stem = _focus_icon_stem(name)
+            path = by_stem.get(stem)
+            if path is not None:
+                paths[name] = path
+        unresolved = [name for name in unresolved if name not in paths]
+        if not unresolved:
+            break
+    return paths
+
+
+def _focus_icon_stem(name: str) -> str:
+    for prefix in ("GFX_focus_", "GFX_goal_"):
+        if name.startswith(prefix):
+            return name[len(prefix) :]
+    return name
+
+
+def _declared_sprite_names(source: str) -> set[str]:
+    names: set[str] = set()
+    for match in _SPRITE_BLOCK_RE.finditer(source):
+        if match.group().startswith(('"', "#")):
+            continue
+        close = match_brace(source, match.end() - 1)
+        if close >= len(source):
+            continue
+        for name in _SPRITE_NAME_RE.finditer(source, match.end(), close):
+            if name.group(1) is not None:
+                names.add(name.group(1))
+                break
+    return names
+
+
+def _next_code_match(pattern: re.Pattern[str], source: str) -> re.Match[str] | None:
+    for match in pattern.finditer(source):
+        if not match.group().startswith(('"', "#")):
+            return match
+    return None
+
+
+__all__ = [
+    "DEFAULT_FOCUS_ICON",
+    "SpriteTypeEntry",
+    "append_sprite_types",
+    "build_focus_sprite_entries",
+    "build_sprite_type",
+    "resolve_focus_image_paths",
+    "resolve_mod_texture_path",
+]

--- a/src/hoi4cm/mod/gfx_writer.py
+++ b/src/hoi4cm/mod/gfx_writer.py
@@ -21,6 +21,8 @@ SpriteTypeEntry = tuple[str, str]
 
 def build_sprite_type(name: str, texture_path: str) -> str:
     """Return one indented ``spriteType`` declaration."""
+    _validate_quoted_scalar(name, label="sprite name")
+    _validate_quoted_scalar(texture_path, label="texture path")
     return (
         "\tspriteType = {\n"
         f'\t\tname = "{name}"\n'
@@ -130,7 +132,12 @@ def build_focus_sprite_entries(
         if texture_path is None:
             unresolved.append(name)
         else:
-            entries.append((name, texture_path))
+            try:
+                build_sprite_type(name, texture_path)
+            except ValueError:
+                unresolved.append(name)
+            else:
+                entries.append((name, texture_path))
     return tuple(entries), tuple(unresolved)
 
 
@@ -193,6 +200,12 @@ def _focus_icon_stem(name: str) -> str:
         if name.startswith(prefix):
             return name[len(prefix) :]
     return name
+
+
+def _validate_quoted_scalar(value: str, *, label: str) -> None:
+    """Reject values Clausewitz cannot safely represent inside quotes."""
+    if not value or any(character in value for character in '"\r\n'):
+        raise ValueError(f"{label} cannot be empty or contain quotes/newlines")
 
 
 def _declared_sprite_names(source: str) -> set[str]:

--- a/src/hoi4cm/wizards/dyn_mod.py
+++ b/src/hoi4cm/wizards/dyn_mod.py
@@ -22,7 +22,7 @@ from hoi4cm.core import (
 )
 from hoi4cm.core.image import PIL_OK, PILImage, PILImageTk
 from hoi4cm.core.paths import read_file
-from hoi4cm.mod import MOD, find_loc_files
+from hoi4cm.mod import MOD, append_sprite_types, find_loc_files
 from hoi4cm.script.syntax import match_brace, parse_script, serialize_block
 from hoi4cm.ui import (
     BG_CARD,
@@ -38,7 +38,10 @@ from hoi4cm.ui import (
     _safe_after_idle,
     report_error,
 )
-from hoi4cm.wizards._generators import build_dyn_mod_output
+from hoi4cm.wizards._generators import (
+    _parse_dyn_mod_line,
+    build_dyn_mod_output,
+)
 from hoi4cm.wizards._graphics import browser_folders, collect_image_pairs
 from hoi4cm.wizards._image_loader import TkImageLoader
 from hoi4cm.wizards._shared import (
@@ -215,7 +218,9 @@ def open_dyn_mod_wizard(app):
     ).pack(side="left", fill="x", expand=True, ipady=4)
 
     def _open_dynmod_gfx_browser():
-        ideas_root = os.path.join(MOD.root, MOD.path_ideas_gfx) if MOD.loaded else None
+        mod_root = getattr(MOD, "root", "") or ""
+        ideas_path = getattr(MOD, "path_ideas_gfx", "") or ""
+        ideas_root = os.path.join(mod_root, ideas_path) if MOD.loaded else None
         catalog = (
             MOD.graphics_catalog if ideas_root and os.path.isdir(ideas_root) else None
         )
@@ -483,7 +488,7 @@ def open_dyn_mod_wizard(app):
 
         def _decode_image2(item):
             i, path = item
-            if not PIL_OK:
+            if not PIL_OK or PILImage is None:
                 return None
             paths_try = [path] + [
                 os.path.splitext(path)[0] + ext
@@ -505,6 +510,11 @@ def open_dyn_mod_wizard(app):
                 except OSError, ValueError, RuntimeError, AttributeError:
                     pass
             return None
+
+        def _realize_image2(pil):
+            if PILImageTk is None:
+                raise RuntimeError("Pillow Tk support is unavailable")
+            return PILImageTk.PhotoImage(pil)
 
         def _apply_image2(item, img):
             i, path = item
@@ -531,12 +541,12 @@ def open_dyn_mod_wizard(app):
                 for i in (visible + ahead)
                 if _st2["pairs"][i][1] not in _st2["img_cache"]
             ]
-            if to_load:
+            if to_load and PILImageTk is not None:
                 snap = list(_st2["pairs"])
                 image_loader.submit_many(
                     ((i, snap[i][1]) for i in to_load if i < len(snap)),
                     _decode_image2,
-                    realizer=lambda pil: PILImageTk.PhotoImage(pil),
+                    realizer=_realize_image2,
                     apply=_apply_image2,
                 )
 
@@ -744,7 +754,7 @@ def open_dyn_mod_wizard(app):
         anchor="w",
     ).pack(side="left")
     _dm_edit_mode = [False]
-    _dm_raw_override = [None]
+    _dm_raw_override: list[str | None] = [None]
 
     _dm_edit_btn = tk.Button(
         dm_prev_hdr,
@@ -995,7 +1005,7 @@ def open_dyn_mod_wizard(app):
 
     # Real builder + line parser live in _generators.py (headless-testable).
     def _parse_mod_line(ln):
-        return _parse_mod_line_pure(ln)
+        return _parse_dyn_mod_line(ln)
 
     def _build_output():
         state = collect_dyn_mod_state(
@@ -1258,34 +1268,17 @@ def open_dyn_mod_wizard(app):
 
         # ════════════════════════════════════════════════════════
         # FILE 4 — interface/ideas.gfx (if icon set)
-        # Strategy: if file exists, check if spriteType already there;
-        #           if not, append it before the last closing }.
         # ════════════════════════════════════════════════════════
         if icon_gfx:
             icon_name = icon_gfx.replace("GFX_idea_", "").replace("GFX_", "")
-            sprite_block = (
-                f"\tspriteType = {{\n"
-                f'\t\tname = "{icon_gfx}"\n'
-                f'\t\ttexturefile = "gfx/interface/ideas/{icon_name}.dds"\n'
-                f"\t}}"
-            )
             gfx_rel = os.path.join("interface", "ideas.gfx")
             gfx_existing = read_existing(gfx_rel)
-            if gfx_existing is None:
-                gfx_final = f"spriteTypes = {{\n\n{sprite_block}\n\n}}\n"
-                gfx_action = "created"
-            elif icon_gfx in gfx_existing:
-                gfx_final = gfx_existing
-                gfx_action = "skipped (icon already defined)"
-            else:
-                # Insert before last closing }
-                last = gfx_existing.rfind("}")
-                if last >= 0:
-                    gfx_final = gfx_existing[:last] + f"\n{sprite_block}\n\n}}\n"
-                else:
-                    gfx_final = gfx_existing.rstrip() + f"\n{sprite_block}\n"
-                gfx_action = "appended sprite"
-            if gfx_action != "skipped (icon already defined)":
+            gfx_final, added_count = append_sprite_types(
+                gfx_existing,
+                [(icon_gfx, f"gfx/interface/ideas/{icon_name}.dds")],
+            )
+            if added_count:
+                gfx_action = "created" if gfx_existing is None else "appended sprite"
                 if write(gfx_rel, gfx_final):
                     results.append(
                         (
@@ -1295,7 +1288,7 @@ def open_dyn_mod_wizard(app):
                         )
                     )
             else:
-                results.append((gfx_rel, gfx_action, ""))
+                results.append((gfx_rel, "skipped (icon already defined)", ""))
 
         # ── Summary ───────────────────────────────────────────
         if errors:

--- a/tests/test_export_plan.py
+++ b/tests/test_export_plan.py
@@ -7,6 +7,7 @@ from hoi4cm.focus_tree.export_plan import (
     make_extra_export_plan,
     make_main_export_plan,
 )
+from hoi4cm.mod.workspace_files import WorkspaceFiles
 from hoi4cm.models import Focus
 
 
@@ -25,7 +26,7 @@ def _focus(name, tree_idx=0):
     return focus
 
 
-def _main_plan(tmp_path, *, loc_language="english"):
+def _main_plan(tmp_path, *, loc_language="english", gfx_path=None, gfx_entries=()):
     focus = _focus("TST_root")
     return make_main_export_plan(
         label="Main: TST_focus_tree",
@@ -45,6 +46,8 @@ def _main_plan(tmp_path, *, loc_language="english"):
         focus_lookup={focus.id: focus},
         focus_name_lookup={focus.name: focus},
         loc_language=loc_language,
+        gfx_path=gfx_path,
+        gfx_entries=gfx_entries,
     )
 
 
@@ -86,6 +89,58 @@ def test_main_plan_writes_tree_and_localisation_as_one_group(tmp_path):
     ]
     assert "TST_root" in calls[0][0][1]
     assert "TST_root" in calls[0][1][1]
+
+
+def test_main_plan_writes_focus_gfx_declarations(tmp_path):
+    gfx_path = tmp_path / "interface" / "TST_focus.gfx"
+    plan = _main_plan(
+        tmp_path,
+        gfx_path=str(gfx_path),
+        gfx_entries=(("GFX_focus_custom", "gfx/interface/goals/custom.dds"),),
+    )
+
+    results = execute_export_plans([plan], WorkspaceFiles().write_texts)
+
+    assert results[0].ok
+    assert results[0].written_paths[-1] == str(gfx_path)
+    assert 'name = "GFX_focus_custom"' in gfx_path.read_text()
+
+
+def test_main_plan_does_not_duplicate_existing_focus_gfx_declarations(tmp_path):
+    gfx_path = tmp_path / "interface" / "TST_focus.gfx"
+    gfx_path.parent.mkdir()
+    existing = (
+        "spriteTypes = {\n"
+        '\tspriteType = { name = "GFX_focus_custom" '
+        'texturefile = "gfx/interface/goals/custom.dds" }\n'
+        "}\n"
+    )
+    gfx_path.write_text(existing)
+    plan = _main_plan(
+        tmp_path,
+        gfx_path=str(gfx_path),
+        gfx_entries=(("GFX_focus_custom", "gfx/interface/goals/custom.dds"),),
+    )
+
+    results = execute_export_plans([plan], WorkspaceFiles().write_texts)
+
+    assert results[0].ok
+    assert str(gfx_path) not in results[0].written_paths
+    assert gfx_path.read_text() == existing
+
+
+def test_main_plan_with_unresolved_focus_icon_has_no_gfx_write(tmp_path):
+    gfx_path = tmp_path / "interface" / "TST_focus.gfx"
+    plan = _main_plan(
+        tmp_path,
+        gfx_path=str(gfx_path),
+        gfx_entries=(),
+    )
+
+    results = execute_export_plans([plan], WorkspaceFiles().write_texts)
+
+    assert results[0].ok
+    assert not gfx_path.exists()
 
 
 def test_main_plan_snapshots_non_english_localisation_header(tmp_path):

--- a/tests/test_gfx_writer.py
+++ b/tests/test_gfx_writer.py
@@ -1,9 +1,12 @@
 from importlib import import_module
 
+import pytest
+
 _gfx_writer = import_module("hoi4cm.mod.gfx_writer")
 DEFAULT_FOCUS_ICON = _gfx_writer.DEFAULT_FOCUS_ICON
 append_sprite_types = _gfx_writer.append_sprite_types
 build_focus_sprite_entries = _gfx_writer.build_focus_sprite_entries
+build_sprite_type = _gfx_writer.build_sprite_type
 resolve_focus_image_paths = _gfx_writer.resolve_focus_image_paths
 resolve_mod_texture_path = _gfx_writer.resolve_mod_texture_path
 
@@ -94,6 +97,20 @@ def test_append_sprite_types_skips_existing_names_without_rewriting():
     assert added == 0
 
 
+@pytest.mark.parametrize(
+    ("name", "texture_path"),
+    [
+        ('GFX_focus_bad"name', "gfx/interface/goals/custom.dds"),
+        ("GFX_focus_bad\nname", "gfx/interface/goals/custom.dds"),
+        ("GFX_focus_custom", 'gfx/interface/goals/bad"path.dds'),
+        ("GFX_focus_custom", "gfx/interface/goals/bad\npath.dds"),
+    ],
+)
+def test_build_sprite_type_rejects_unsafe_quoted_values(name, texture_path):
+    with pytest.raises(ValueError):
+        build_sprite_type(name, texture_path)
+
+
 def test_build_focus_sprite_entries_filters_default_declared_and_unresolved(tmp_path):
     image = tmp_path / "gfx" / "interface" / "goals" / "custom.dds"
     image.parent.mkdir(parents=True)
@@ -113,6 +130,22 @@ def test_build_focus_sprite_entries_filters_default_declared_and_unresolved(tmp_
 
     assert entries == (("GFX_focus_custom", "gfx/interface/goals/custom.dds"),)
     assert unresolved == ("GFX_focus_missing",)
+
+
+def test_build_focus_sprite_entries_reports_unsafe_name_as_unresolved(tmp_path):
+    image = tmp_path / "gfx" / "interface" / "goals" / "custom.dds"
+    image.parent.mkdir(parents=True)
+    image.write_bytes(b"image")
+
+    entries, unresolved = build_focus_sprite_entries(
+        ['GFX_focus_bad"name'],
+        declared_names=set(),
+        image_paths={'GFX_focus_bad"name': str(image)},
+        mod_root=str(tmp_path),
+    )
+
+    assert entries == ()
+    assert unresolved == ('GFX_focus_bad"name',)
 
 
 def test_resolve_focus_image_paths_uses_catalog_stem_fallback(tmp_path):

--- a/tests/test_gfx_writer.py
+++ b/tests/test_gfx_writer.py
@@ -1,0 +1,141 @@
+from importlib import import_module
+
+_gfx_writer = import_module("hoi4cm.mod.gfx_writer")
+DEFAULT_FOCUS_ICON = _gfx_writer.DEFAULT_FOCUS_ICON
+append_sprite_types = _gfx_writer.append_sprite_types
+build_focus_sprite_entries = _gfx_writer.build_focus_sprite_entries
+resolve_focus_image_paths = _gfx_writer.resolve_focus_image_paths
+resolve_mod_texture_path = _gfx_writer.resolve_mod_texture_path
+
+
+class _Catalog:
+    def __init__(self, paths):
+        self.paths = paths
+
+    def resolve(self, _name):
+        return None
+
+    def query(self, *, under):
+        return [path for path in self.paths if str(path).startswith(under)]
+
+    def path_for(self, path):
+        return str(path)
+
+
+def test_append_sprite_types_creates_wrapper_and_deduplicates_requests():
+    text, added = append_sprite_types(
+        None,
+        [
+            ("GFX_focus_custom", "gfx/interface/goals/custom.dds"),
+            ("GFX_focus_custom", "gfx/interface/goals/other.dds"),
+        ],
+    )
+
+    assert added == 1
+    assert text == (
+        "spriteTypes = {\n\n"
+        "\tspriteType = {\n"
+        '\t\tname = "GFX_focus_custom"\n'
+        '\t\ttexturefile = "gfx/interface/goals/custom.dds"\n'
+        "\t}\n\n}\n"
+    )
+
+
+def test_append_sprite_types_preserves_existing_wrapper_and_declarations():
+    existing = (
+        '# spriteTypes = { name = "GFX_focus_new" }\n'
+        "spriteTypes = {\n"
+        "\t# Keep this note.\n"
+        '\tspriteType = { name = "GFX_focus_existing" '
+        'texturefile = "gfx/interface/goals/existing.dds" }\n'
+        "}\n"
+        "# Keep this suffix.\n"
+    )
+
+    text, added = append_sprite_types(
+        existing,
+        [
+            ("GFX_focus_existing", "gfx/interface/goals/replacement.dds"),
+            ("GFX_focus_new", "gfx/interface/goals/new.dds"),
+        ],
+    )
+
+    assert added == 1
+    assert text.startswith(existing[: existing.index("}\n")])
+    assert "# Keep this note." in text
+    assert text.count('name = "GFX_focus_new"') == 2
+    assert "# Keep this suffix." in text
+    assert text.count('name = "GFX_focus_existing"') == 1
+
+
+def test_append_sprite_types_preserves_unwrapped_content():
+    existing = "# User content\n"
+
+    text, added = append_sprite_types(
+        existing, [("GFX_focus_new", "gfx/interface/goals/new.dds")]
+    )
+
+    assert added == 1
+    assert text.startswith(existing)
+    assert 'name = "GFX_focus_new"' in text
+
+
+def test_append_sprite_types_skips_existing_names_without_rewriting():
+    existing = (
+        'spriteType = { name = "GFX_focus_existing" '
+        'texturefile = "gfx/interface/goals/existing.dds" }\n'
+    )
+
+    text, added = append_sprite_types(
+        existing, [("GFX_focus_existing", "gfx/interface/goals/new.dds")]
+    )
+
+    assert text == existing
+    assert added == 0
+
+
+def test_build_focus_sprite_entries_filters_default_declared_and_unresolved(tmp_path):
+    image = tmp_path / "gfx" / "interface" / "goals" / "custom.dds"
+    image.parent.mkdir(parents=True)
+    image.write_bytes(b"image")
+
+    entries, unresolved = build_focus_sprite_entries(
+        [
+            DEFAULT_FOCUS_ICON,
+            "GFX_focus_custom",
+            "GFX_focus_custom",
+            "GFX_focus_missing",
+        ],
+        declared_names={"GFX_focus_declared"},
+        image_paths={"GFX_focus_custom": str(image)},
+        mod_root=str(tmp_path),
+    )
+
+    assert entries == (("GFX_focus_custom", "gfx/interface/goals/custom.dds"),)
+    assert unresolved == ("GFX_focus_missing",)
+
+
+def test_resolve_focus_image_paths_uses_catalog_stem_fallback(tmp_path):
+    image = tmp_path / "gfx" / "interface" / "goals" / "custom.dds"
+    image.parent.mkdir(parents=True)
+    image.write_bytes(b"image")
+
+    paths = resolve_focus_image_paths(
+        ["GFX_focus_custom"],
+        catalog=_Catalog([image]),
+        mod_root=str(tmp_path),
+        goals_path="gfx/interface/goals",
+    )
+
+    assert paths == {"GFX_focus_custom": str(image)}
+
+
+def test_resolve_mod_texture_path_rejects_outside_and_missing_paths(tmp_path):
+    image = tmp_path / "inside.dds"
+    image.write_bytes(b"image")
+    outside = tmp_path.parent / "outside.dds"
+    outside.write_bytes(b"image")
+
+    assert resolve_mod_texture_path(str(tmp_path), image) == "inside.dds"
+    assert resolve_mod_texture_path(str(tmp_path), outside) is None
+    assert resolve_mod_texture_path(str(tmp_path), "missing.dds") is None

--- a/tests/test_monolith_export.py
+++ b/tests/test_monolith_export.py
@@ -72,6 +72,24 @@ class _App:
         self._extra_trees = []
 
 
+class _Catalog:
+    def __init__(self, paths):
+        self.paths = paths
+        self.written = []
+
+    def resolve(self, _name):
+        return None
+
+    def query(self, *, under):
+        return [path for path in self.paths if str(path).startswith(under)]
+
+    def path_for(self, path):
+        return str(path)
+
+    def note_written(self, path, *, read_text):
+        self.written.append(path)
+
+
 def _focus(name, x=0, y=0):
     focus = Focus(x, y)
     focus.name = name
@@ -79,7 +97,16 @@ def _focus(name, x=0, y=0):
     return focus
 
 
+def _configure_custom_focus_gfx(monkeypatch, mod_files, image=None):
+    monkeypatch.setattr(m.MOD, "loaded", True)
+    monkeypatch.setattr(m.MOD, "sprites", {})
+    catalog = _Catalog([image] if image is not None else [])
+    monkeypatch.setattr(m.MOD, "graphics_catalog", catalog)
+    return catalog
+
+
 def _bind_export_shells(app):
+    app._focus_gfx_export = m.App._focus_gfx_export.__get__(app, _App)
     app._make_main_export_plan = m.App._make_main_export_plan.__get__(app, _App)
     app._make_extra_export_plan = m.App._make_extra_export_plan.__get__(app, _App)
     app._apply_export_results = m.App._apply_export_results.__get__(app, _App)
@@ -131,14 +158,104 @@ def test_default_localisation_filename_is_generic(mod_files, monkeypatch):
     )
 
     app = _App([_focus("TST_root")])
+    _bind_export_shells(app)
     focuses = list(app.focuses.values())
     names = {focus.name: focus for focus in focuses}
-    plan = m.App._make_main_export_plan.__get__(app, _App)(
-        focuses, app.focuses, names, show_dialog=False
-    )
+    plan = app._make_main_export_plan(focuses, app.focuses, names, show_dialog=False)
 
     assert plan is not None
     assert plan.loc_path.endswith("TST_focus_l_english.yml")
+
+
+def test_export_accepts_custom_focus_icon_declaration(dialogs, mod_files, monkeypatch):
+    image = mod_files.root / "gfx" / "interface" / "goals" / "custom.dds"
+    image.parent.mkdir(parents=True)
+    image.write_bytes(b"image")
+    catalog = _configure_custom_focus_gfx(monkeypatch, mod_files, image)
+    monkeypatch.setattr(m.messagebox, "askyesno", lambda *_args, **_kwargs: True)
+
+    focus = _focus("TST_root")
+    focus.gfx = "GFX_focus_custom"
+    _export(_App([focus]))
+
+    gfx = mod_files.root / "interface" / "TST_focus.gfx"
+    assert gfx.exists()
+    assert 'name = "GFX_focus_custom"' in gfx.read_text()
+    assert 'texturefile = "gfx/interface/goals/custom.dds"' in gfx.read_text()
+    assert str(gfx) in catalog.written
+
+
+def test_noninteractive_export_does_not_prompt_for_custom_focus_icon(
+    dialogs, mod_files, monkeypatch
+):
+    image = mod_files.root / "gfx" / "interface" / "goals" / "custom.dds"
+    image.parent.mkdir(parents=True)
+    image.write_bytes(b"image")
+    _configure_custom_focus_gfx(monkeypatch, mod_files, image)
+    monkeypatch.setattr(
+        m.messagebox,
+        "askyesno",
+        lambda *_args, **_kwargs: pytest.fail("noninteractive export prompted"),
+    )
+
+    focus = _focus("TST_root")
+    focus.gfx = "GFX_focus_custom"
+    _export(_App([focus]), show_dialog=False)
+
+    assert not (mod_files.root / "interface" / "TST_focus.gfx").exists()
+
+
+def test_export_declining_custom_focus_icon_declaration_leaves_no_gfx_file(
+    dialogs, mod_files, monkeypatch
+):
+    image = mod_files.root / "gfx" / "interface" / "goals" / "custom.dds"
+    image.parent.mkdir(parents=True)
+    image.write_bytes(b"image")
+    _configure_custom_focus_gfx(monkeypatch, mod_files, image)
+    monkeypatch.setattr(m.messagebox, "askyesno", lambda *_args, **_kwargs: False)
+
+    focus = _focus("TST_root")
+    focus.gfx = "GFX_focus_custom"
+    _export(_App([focus]))
+
+    assert not (mod_files.root / "interface" / "TST_focus.gfx").exists()
+
+
+def test_export_deduplicates_existing_custom_focus_icon(
+    dialogs, mod_files, monkeypatch
+):
+    image = mod_files.root / "gfx" / "interface" / "goals" / "custom.dds"
+    image.parent.mkdir(parents=True)
+    image.write_bytes(b"image")
+    gfx = mod_files.root / "interface" / "TST_focus.gfx"
+    gfx.parent.mkdir(parents=True)
+    gfx.write_text(
+        "spriteTypes = {\n"
+        '\tspriteType = { name = "GFX_focus_custom" '
+        'texturefile = "gfx/interface/goals/custom.dds" }\n'
+        "}\n"
+    )
+    _configure_custom_focus_gfx(monkeypatch, mod_files, image)
+    monkeypatch.setattr(m.messagebox, "askyesno", lambda *_args, **_kwargs: True)
+
+    focus = _focus("TST_root")
+    focus.gfx = "GFX_focus_custom"
+    _export(_App([focus]))
+
+    assert gfx.read_text().count('name = "GFX_focus_custom"') == 1
+
+
+def test_export_does_not_generate_unresolved_custom_focus_icon(
+    dialogs, mod_files, monkeypatch
+):
+    _configure_custom_focus_gfx(monkeypatch, mod_files)
+    monkeypatch.setattr(m.messagebox, "askyesno", lambda *_args, **_kwargs: True)
+
+    focus = _focus("TST_root")
+    focus.gfx = "GFX_focus_missing"
+    _export(_App([focus]))
+
+    assert not (mod_files.root / "interface" / "TST_focus.gfx").exists()
 
 
 def test_failed_export_leaves_the_tracked_files_untouched(
@@ -220,6 +337,7 @@ def test_failed_extra_tree_export_keeps_the_source_file(dialogs, tmp_path, monke
 
 def test_run_export_plans_uses_document_scope_and_closes_modal(monkeypatch, mod_files):
     app = _App([_focus("TST_root")])
+    _bind_export_shells(app)
     plan = m.App._make_main_export_plan.__get__(app, _App)(
         list(app.focuses.values()),
         dict(app.focuses),


### PR DESCRIPTION
## Bottom line

Focus-tree export now offers to generate missing `spriteType` declarations for custom icons whose textures resolve inside the loaded mod.

## How

A shared GFX writer preserves existing files and deduplicates declarations. Focus and dynamic-modifier exports use the same writer through the atomic workspace pipeline.

Closes #40

BLUF