### PR TITLE
Treat fingerprint failure as dirty so the save prompt still fires

### DIFF
--- a/hoi4_content_maker.py
+++ b/hoi4_content_maker.py
@@ -350,13 +350,14 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
                 self, "_saved_fingerprint", None
             )
         except Exception:
-            return False
+            return True
 
     def _mark_clean(self) -> None:
         self._saved_revision = self.focuses.revision
         try:
             self._saved_fingerprint = self._workspace_fingerprint()
-        except Exception:
+        except Exception as e:
+            add_error(f"Failed to update workspace fingerprint: {e}")
             self._saved_fingerprint = None
         self._update_title()
 
@@ -5413,14 +5414,11 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
             log.error("project save failed: %s", e, exc_info=True)
             report_write_failure(self, path, e)
             return False
-        try:
-            self._last_project_path = path
-        except Exception:
-            pass
+        self._last_project_path = path
         try:
             self._mark_clean()
-        except Exception:
-            pass
+        except Exception as e:
+            add_error(f"Failed to mark workspace clean: {e}")
         try:
             clear_workspace_autosave()
         except Exception:
@@ -5496,14 +5494,11 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
         self._grid_key = None
         self._grid_img = None
         self._install_workspace(workspace)
-        try:
-            self._last_project_path = path
-        except Exception:
-            pass
+        self._last_project_path = path
         try:
             self._mark_clean()
-        except Exception:
-            pass
+        except Exception as e:
+            add_error(f"Failed to mark workspace clean: {e}")
         try:
             clear_workspace_autosave()
         except Exception:

--- a/tests/test_workspace_dirty.py
+++ b/tests/test_workspace_dirty.py
@@ -177,6 +177,33 @@ def test_confirm_discard_no_dirty_returns_true_without_prompt(monkeypatch):
     assert called == []
 
 
+def test_confirm_discard_fingerprint_error_prompts(monkeypatch):
+    app = _fake_app()
+    app._workspace_fingerprint = lambda: (_ for _ in ()).throw(
+        RuntimeError("fingerprint failed")
+    )
+    called = []
+    monkeypatch.setattr(
+        m.messagebox, "askyesnocancel", lambda *a, **kw: called.append(1) or False
+    )
+    assert app._is_dirty() is True
+    assert app._confirm_discard("loading") is True
+    assert called == [1]
+
+
+def test_mark_clean_fingerprint_error_reports(monkeypatch):
+    app = _fake_app()
+    app._workspace_fingerprint = lambda: (_ for _ in ()).throw(
+        RuntimeError("fingerprint failed")
+    )
+    errors = []
+    monkeypatch.setattr(m, "add_error", errors.append)
+
+    app._mark_clean()
+
+    assert errors == ["Failed to update workspace fingerprint: fingerprint failed"]
+
+
 def test_confirm_discard_dirty_cancel_returns_false(monkeypatch):
     app = _fake_app()
     app.focuses.add(Focus(0, 0))


### PR DESCRIPTION
## Bottom line

A workspace fingerprint error now counts as dirty, so New/Open/Close still ask to save instead of discarding work.

## How

`_is_dirty` fails open. `_mark_clean` reports through `add_error`. Save and load no longer swallow assignment of the last project path.

Closes #156

BLUF