### PR TITLE
Keep loc language headers when existing yml reads empty

### DIFF
--- a/src/hoi4cm/core/paths.py
+++ b/src/hoi4cm/core/paths.py
@@ -21,12 +21,11 @@ def default_hoi4_mod_dir():
     return os.path.join(os.path.expanduser("~"), "Documents", base)
 
 
-def read_file(path, max_bytes=MAX_READ_BYTES):
-    """Read *path* as text, trying several encodings. Returns "" if unreadable.
+def read_file(path: str, max_bytes: int | None = MAX_READ_BYTES) -> str | None:
+    """Read *path* as text, trying several encodings.
 
-    Files larger than *max_bytes* (or streaming pseudo-files like ``/dev/zero``)
-    are skipped and logged rather than read into memory. Pass ``max_bytes=None``
-    to disable the cap.
+    Missing files return ``""``. Files that cannot be read or exceed
+    *max_bytes* return ``None``. Pass ``max_bytes=None`` to disable the cap.
     """
     try:
         size = os.path.getsize(path)
@@ -34,7 +33,7 @@ def read_file(path, max_bytes=MAX_READ_BYTES):
         size = None
     if max_bytes is not None and size is not None and size > max_bytes:
         _log.warning("skipping oversize file (%d bytes): %s", size, path)
-        return ""
+        return None
     for enc in ("utf-8-sig", "utf-8", "latin-1"):
         try:
             with open(path, encoding=enc, errors="strict") as f:
@@ -43,11 +42,13 @@ def read_file(path, max_bytes=MAX_READ_BYTES):
                 data = f.read(max_bytes + 1)
                 if len(data) > max_bytes:
                     _log.warning("skipping oversize/streaming file: %s", path)
-                    return ""
+                    return None
                 return data
+        except FileNotFoundError:
+            return ""
         except OSError, ValueError, UnicodeDecodeError:
             pass
-    return ""
+    return None
 
 
 def autosave_path(name):

--- a/src/hoi4cm/focus_tree/export_plan.py
+++ b/src/hoi4cm/focus_tree/export_plan.py
@@ -101,7 +101,7 @@ def make_extra_export_plan(
 def render_export_plan(
     plan: ExportPlan,
     *,
-    read_text: Callable[[str], str] = read_file,
+    read_text: Callable[[str], str | None] = read_file,
     is_file: Callable[[str], bool] = os.path.isfile,
 ) -> tuple[tuple[WriteEntry, ...], int]:
     """Render a plan into the atomic write group it needs."""
@@ -112,17 +112,24 @@ def render_export_plan(
             focus_lookup=plan.focus_lookup,
             focus_name_lookup=plan.focus_name_lookup,
         )
-        existing_loc_text = (
-            read_text(plan.loc_path)
-            if plan.loc_path is not None and is_file(plan.loc_path)
-            else None
-        )
-        new_loc_text, added_count = build_loc_yml(
-            existing_loc_text,
-            plan.focuses,
-            str(plan.tree_info["country_tag"]),
-            language=plan.loc_language,
-        )
+        if plan.loc_path is not None and is_file(plan.loc_path):
+            existing_loc_text = read_text(plan.loc_path)
+            if existing_loc_text is None:
+                new_loc_text, added_count = None, 0
+            else:
+                new_loc_text, added_count = build_loc_yml(
+                    existing_loc_text,
+                    plan.focuses,
+                    str(plan.tree_info["country_tag"]),
+                    language=plan.loc_language,
+                )
+        else:
+            new_loc_text, added_count = build_loc_yml(
+                None,
+                plan.focuses,
+                str(plan.tree_info["country_tag"]),
+                language=plan.loc_language,
+            )
         writes = [(plan.focus_path, out_text, "utf-8")]
         if new_loc_text is not None and plan.loc_path is not None:
             writes.append((plan.loc_path, new_loc_text, "utf-8-sig"))
@@ -142,7 +149,7 @@ def execute_export_plans(
     write_texts: WriteTexts,
     *,
     progress: ProgressCallback | None = None,
-    read_text: Callable[[str], str] = read_file,
+    read_text: Callable[[str], str | None] = read_file,
     is_file: Callable[[str], bool] = os.path.isfile,
 ) -> list[ExportResult]:
     """Render and write each plan, continuing after individual failures."""

--- a/src/hoi4cm/focus_tree/loc.py
+++ b/src/hoi4cm/focus_tree/loc.py
@@ -95,11 +95,9 @@ def build_loc_yml(existing_text, focuses, country_tag, *, language="english"):
     """Return ``(new_text, changed_count)`` for the focus-tree loc .yml.
 
     ``existing_text`` is the current file contents, or ``None`` if the file
-    doesn't exist yet (distinct from an existing-but-empty file, which still
-    gets appended to rather than re-headered). ``focuses`` contributes a
-    localized or title-cased name key and a ``_desc`` key per focus (falling
-    back to a generated sentence when the focus has no ``desc``). ``country_tag``
-    names the section header.
+    doesn't exist yet. ``focuses`` contributes a localized or title-cased name
+    key and a ``_desc`` key per focus (falling back to a generated sentence
+    when the focus has no ``desc``). ``country_tag`` names the section header.
 
     A missing key is appended. Existing title and ``_desc`` keys are rewritten
     in place when their non-empty focus values differ from the value already
@@ -136,7 +134,9 @@ def build_loc_yml(existing_text, focuses, country_tag, *, language="english"):
         return None, 0
 
     target = LocTarget(language)
-    base = existing_text if existing_text is not None else target.header() + "\n"
+    base = existing_text if existing_text is not None else ""
+    if target.header() not in base:
+        base = target.header() + "\n" + base
     if base and not base.endswith("\n"):
         base += "\n"
 

--- a/src/hoi4cm/wizards/decision.py
+++ b/src/hoi4cm/wizards/decision.py
@@ -4520,7 +4520,10 @@ def open_decision_wizard(app):
         for path in paths:
             if path.lower().endswith(".yml"):
                 try:
-                    for line in read_file(path).splitlines():
+                    content = read_file(path)
+                    if not content:
+                        continue
+                    for line in content.splitlines():
                         lm = _re.match(r'\s+([\w]+):(?:\d+)?\s+"(.*?)"', line)
                         if lm:
                             loc[lm.group(1)] = lm.group(2)
@@ -4537,7 +4540,10 @@ def open_decision_wizard(app):
                 if os.path.isdir(loc_dir):
                     for loc_path in find_loc_files(folder, language=MOD.loc_language):
                         try:
-                            for line in read_file(loc_path).splitlines():
+                            content = read_file(loc_path)
+                            if not content:
+                                continue
+                            for line in content.splitlines():
                                 lm = _re.match(r'\s+([\w]+):(?:\d+)?\s+"(.*?)"', line)
                                 if lm:
                                     loc[lm.group(1)] = lm.group(2)

--- a/src/hoi4cm/wizards/dyn_mod.py
+++ b/src/hoi4cm/wizards/dyn_mod.py
@@ -1159,6 +1159,8 @@ def open_dyn_mod_wizard(app):
                 content = read_file(loc_path)
             except OSError, ValueError, UnicodeDecodeError:
                 continue
+            if not content:
+                continue
             for m in re.finditer(
                 r'^\s+(\S+?)(?::\d+)?\s*[=:]?\s*"', content, re.MULTILINE
             ):

--- a/tests/test_core_image_paths.py
+++ b/tests/test_core_image_paths.py
@@ -165,7 +165,7 @@ def test_image_no_auto_install_without_env_does_not_call_install(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_paths_read_file_mixed_encoding_returns_empty(monkeypatch, tmp_path):
+def test_paths_read_file_mixed_encoding_returns_none(monkeypatch, tmp_path):
     p = tmp_path / "mixed.txt"
     p.write_bytes(b"\xff\xfe\xfd")
 
@@ -176,10 +176,10 @@ def test_paths_read_file_mixed_encoding_returns_empty(monkeypatch, tmp_path):
     # getsize should not short-circuit; return small size
     monkeypatch.setattr(os.path, "getsize", lambda _: 3)
 
-    assert paths.read_file(str(p)) == ""
+    assert paths.read_file(str(p)) is None
 
 
-def test_paths_read_file_value_error_returns_empty(monkeypatch, tmp_path):
+def test_paths_read_file_value_error_returns_none(monkeypatch, tmp_path):
     p = tmp_path / "bad.txt"
     p.write_text("hello", encoding="utf-8")
 
@@ -189,10 +189,10 @@ def test_paths_read_file_value_error_returns_empty(monkeypatch, tmp_path):
     monkeypatch.setattr(builtins, "open", fake_open)
     monkeypatch.setattr(os.path, "getsize", lambda _: 5)
 
-    assert paths.read_file(str(p)) == ""
+    assert paths.read_file(str(p)) is None
 
 
-def test_paths_read_file_unicode_decode_error_returns_empty(monkeypatch, tmp_path):
+def test_paths_read_file_unicode_decode_error_returns_none(monkeypatch, tmp_path):
     p = tmp_path / "ud.txt"
     p.write_text("hello", encoding="utf-8")
 
@@ -202,14 +202,14 @@ def test_paths_read_file_unicode_decode_error_returns_empty(monkeypatch, tmp_pat
     monkeypatch.setattr(builtins, "open", fake_open)
     monkeypatch.setattr(os.path, "getsize", lambda _: 5)
 
-    assert paths.read_file(str(p)) == ""
+    assert paths.read_file(str(p)) is None
 
 
-def test_paths_read_file_streaming_oversize_returns_empty(tmp_path):
+def test_paths_read_file_streaming_oversize_returns_none(tmp_path):
     p = tmp_path / "stream.txt"
     p.write_text("x" * 20, encoding="utf-8")
     # max_bytes=10 but file is 20 bytes; read(max_bytes+1) will be 11 -> oversize
-    assert paths.read_file(str(p), max_bytes=10) == ""
+    assert paths.read_file(str(p), max_bytes=10) is None
 
 
 def test_paths_read_file_getsize_oserror_still_reads(tmp_path, monkeypatch):
@@ -224,10 +224,10 @@ def test_paths_read_file_getsize_oserror_still_reads(tmp_path, monkeypatch):
     assert paths.read_file(str(p)) == "hello"
 
 
-def test_paths_read_file_oversize_via_getsize_returns_empty(tmp_path):
+def test_paths_read_file_oversize_via_getsize_returns_none(tmp_path):
     p = tmp_path / "big.txt"
     p.write_text("x" * 100, encoding="utf-8")
-    assert paths.read_file(str(p), max_bytes=10) == ""
+    assert paths.read_file(str(p), max_bytes=10) is None
 
 
 def test_paths_read_file_latin1_fallback(tmp_path, monkeypatch):
@@ -251,7 +251,7 @@ def test_paths_read_file_latin1_fallback(tmp_path, monkeypatch):
 def test_paths_read_file_max_bytes_none_reads_large(tmp_path):
     p = tmp_path / "large.txt"
     p.write_text("y" * 5000, encoding="utf-8")
-    assert paths.read_file(str(p), max_bytes=None) == "y" * 5000  # type: ignore[arg-type]
+    assert paths.read_file(str(p), max_bytes=None) == "y" * 5000
 
 
 def test_paths_read_file_missing_returns_empty(tmp_path):

--- a/tests/test_export_plan.py
+++ b/tests/test_export_plan.py
@@ -6,6 +6,7 @@ from hoi4cm.focus_tree.export_plan import (
     execute_export_plans,
     make_extra_export_plan,
     make_main_export_plan,
+    render_export_plan,
 )
 from hoi4cm.models import Focus
 
@@ -104,6 +105,19 @@ def test_main_plan_exports_german_localisation_header(tmp_path):
     execute_export_plans([plan], lambda entries: calls.append(tuple(entries)))
 
     assert calls[0][1][1].startswith("l_german:\n")
+
+
+def test_unreadable_existing_localisation_is_not_replaced(tmp_path):
+    plan = _main_plan(tmp_path)
+
+    writes, added_count = render_export_plan(
+        plan,
+        read_text=lambda _path: None,
+        is_file=lambda _path: True,
+    )
+
+    assert added_count == 0
+    assert [path for path, _text, _encoding in writes] == [plan.focus_path]
 
 
 def test_batch_continues_after_one_plan_fails(tmp_path):

--- a/tests/test_loc.py
+++ b/tests/test_loc.py
@@ -18,6 +18,7 @@ def test_missing_file_gets_header_and_all_keys():
     focuses = [_focus("TST_alpha")]
     text, count = build_loc_yml(None, focuses, "TST")
     assert count == 2
+    assert text is not None
     assert text.startswith("l_english:\n")
     assert "##########Focuses - TST##########" in text
     assert ' TST_alpha: "Tst Alpha"\n' in text
@@ -27,6 +28,7 @@ def test_missing_file_gets_header_and_all_keys():
 def test_desc_falls_back_to_generated_sentence_when_blank():
     focuses = [_focus("TST_alpha", desc="")]
     text, _count = build_loc_yml(None, focuses, "TST")
+    assert text is not None
     assert ' TST_alpha_desc: "Complete the Tst Alpha national focus."\n' in text
 
 
@@ -51,6 +53,7 @@ def test_blank_localized_name_uses_title_case_fallback():
 def test_desc_uses_focus_desc_when_present():
     focuses = [_focus("TST_alpha", desc="Do the thing.")]
     text, _count = build_loc_yml(None, focuses, "TST")
+    assert text is not None
     assert ' TST_alpha_desc: "Do the thing."\n' in text
 
 
@@ -59,6 +62,7 @@ def test_existing_file_without_header_appends_and_adds_header():
     focuses = [_focus("TST_alpha")]
     text, count = build_loc_yml(existing, focuses, "TST")
     assert count == 2
+    assert text is not None
     assert text.startswith(existing)
     assert "##########Focuses - TST##########" in text
     assert ' TST_alpha: "Tst Alpha"\n' in text
@@ -73,6 +77,7 @@ def test_existing_header_is_not_duplicated():
     # TST_alpha (title) and TST_alpha_desc are still missing? No: TST_alpha
     # key is present, so only the _desc key plus all of TST_beta's keys are new.
     assert count == 3
+    assert text is not None
     assert text.count("##########Focuses - TST##########") == 1
 
 
@@ -95,6 +100,7 @@ def test_existing_desc_is_rewritten_when_focus_desc_changes():
     focuses = [_focus("TST_alpha", desc="New description.")]
     text, count = build_loc_yml(existing, focuses, "TST")
     assert count == 1
+    assert text is not None
     assert ' TST_alpha_desc: "New description."\n' in text
     assert "Old description." not in text
     assert ' TST_alpha: "Tst Alpha"\n' in text
@@ -155,6 +161,7 @@ def test_rewritten_desc_value_with_quote_is_escaped():
     focuses = [_focus("TST_alpha", desc='Say "hello".')]
     text, count = build_loc_yml(existing, focuses, "TST")
     assert count == 1
+    assert text is not None
     assert ' TST_alpha_desc: "Say \\"hello\\"."\n' in text
 
 
@@ -165,6 +172,7 @@ def test_rewritten_desc_preserves_pluralization_suffix():
     focuses = [_focus("TST_alpha", desc="New description.")]
     text, count = build_loc_yml(existing, focuses, "TST")
     assert count == 1
+    assert text is not None
     assert ' TST_alpha_desc:0 "New description."\n' in text
 
 
@@ -178,6 +186,7 @@ def test_rewrite_and_add_combine_in_one_pass():
     ]
     text, count = build_loc_yml(existing, focuses, "TST")
     assert count == 3
+    assert text is not None
     assert ' TST_alpha_desc: "New description."\n' in text
     assert ' TST_beta: "Tst Beta"\n' in text
     assert ' TST_beta_desc: "Complete the Tst Beta national focus."\n' in text
@@ -190,20 +199,31 @@ def test_existing_key_detection_handles_pluralization_suffix():
     text, count = build_loc_yml(existing, focuses, "TST")
     # The name key is detected as already present; only _desc is new.
     assert count == 1
+    assert text is not None
     assert "TST_alpha_desc" in text
 
 
-def test_empty_but_existing_file_does_not_get_header_line():
-    """A present-but-empty file is appended to, not re-created with a header."""
+def test_empty_but_existing_file_gets_header_line():
+    """A present-but-empty file gets the language header before new entries."""
     focuses = [_focus("TST_alpha")]
     text, _count = build_loc_yml("", focuses, "TST")
-    assert not text.startswith("l_english:")
+    assert text is not None
+    assert text.startswith("l_english:\n")
     assert "##########Focuses - TST##########" in text
+
+
+def test_existing_content_without_language_header_gets_one():
+    existing = ' TST_other: "Something Else"\n'
+    text, _count = build_loc_yml(existing, [_focus("TST_alpha")], "TST")
+    assert text is not None
+    assert text.startswith("l_english:\n")
+    assert ' TST_other: "Something Else"\n' in text
 
 
 def test_custom_language_header_for_fresh_file():
     focuses = [_focus("TST_alpha")]
     text, _count = build_loc_yml(None, focuses, "TST", language="french")
+    assert text is not None
     assert text.startswith("l_french:\n")
 
 
@@ -247,11 +267,13 @@ def test_loc_target_invalid_language_falls_back_to_english():
 def test_name_title_cased_with_underscores_replaced():
     focuses = [_focus("TST_some_focus_name")]
     text, _count = build_loc_yml(None, focuses, "TST")
+    assert text is not None
     assert ' TST_some_focus_name: "Tst Some Focus Name"\n' in text
 
 
 def test_values_are_escaped():
     text, _count = build_loc_yml(None, [_focus("TST_alpha", 'Say "hello"\\now')], "TST")
+    assert text is not None
     assert ' TST_alpha_desc: "Say \\"hello\\"\\\\now"\n' in text
 
 
@@ -280,4 +302,5 @@ def test_hydrate_focus_localization_leaves_missing_values_untouched():
 
 def test_existing_content_without_newline_gets_separator():
     text, _count = build_loc_yml("l_english:", [_focus("TST_alpha")], "TST")
+    assert text is not None
     assert text.startswith("l_english:\n")

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -25,8 +25,10 @@ def test_read_file_missing_returns_empty(tmp_path):
 def test_read_file_falls_back_to_latin1(tmp_path):
     p = tmp_path / "c.txt"
     p.write_bytes("café".encode("latin-1"))  # 0xe9 is not valid UTF-8
-    assert paths.read_file(str(p)) == "café"
-    assert "�" not in paths.read_file(str(p))
+    content = paths.read_file(str(p))
+    assert content == "café"
+    assert content is not None
+    assert "�" not in content
 
 
 def test_default_mod_dir_linux(monkeypatch):
@@ -55,7 +57,13 @@ def test_default_mod_dir_windows(monkeypatch):
 def test_read_file_respects_size_cap(tmp_path):
     p = tmp_path / "big.txt"
     p.write_text("x" * 5000, encoding="utf-8")
-    assert paths.read_file(str(p), max_bytes=1000) == ""
+    assert paths.read_file(str(p), max_bytes=1000) is None
+
+
+def test_read_file_keeps_successful_empty_read_distinct(tmp_path):
+    p = tmp_path / "empty.txt"
+    p.write_text("", encoding="utf-8")
+    assert paths.read_file(str(p)) == ""
 
 
 def test_read_file_reads_within_cap(tmp_path):


### PR DESCRIPTION
## Bottom line

Empty localisation files get an `l_<lang>:` header on export, and unreadable or oversize loc files are left alone instead of being replaced.

## How

`read_file` returns `None` for oversize and read failures, distinct from a successful empty read. `build_loc_yml` prepends the language header whenever it is missing. Export skips the loc write when the existing file cannot be read.

Closes #168

BLUF