### PR TITLE
Cover AND prerequisite grouping and delete FocusDocument.link

### DIFF
--- a/src/hoi4cm/models/document.py
+++ b/src/hoi4cm/models/document.py
@@ -197,24 +197,6 @@ class FocusDocument(MutableMapping[int, Focus]):
         self._changed()
         self.rebuild_indexes()
 
-    def link(
-        self,
-        kind: str,
-        source_id: int,
-        target_ids: Iterable[int],
-        *,
-        mode: str = "or",
-    ) -> None:
-        targets = list(target_ids)
-        if kind == "prerequisite":
-            self.link_prerequisite(source_id, targets, mode=mode)
-            return
-        if kind == "mutex":
-            for target_id in targets:
-                self.link_mutex(source_id, target_id)
-            return
-        raise ValueError("kind must be 'prerequisite' or 'mutex'")
-
     def unlink_prerequisite_group(self, child_id: int, group_index: int) -> None:
         self._focuses[child_id].prereqs.pop(group_index)
         self._changed()

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -53,6 +53,19 @@ def _assert_indexes(document):
     assert document.validate_indexes()
 
 
+def test_link_prerequisite_and_mode_validation():
+    parent_a = _focus(1)
+    parent_b = _focus(2)
+    child = _focus(3)
+    document = FocusDocument((parent_a, parent_b, child))
+
+    document.link_prerequisite(child.id, (parent_a.id, parent_b.id), mode="and")
+
+    assert child.prereqs == [[parent_a.id], [parent_b.id]]
+    with pytest.raises(ValueError, match="mode must be 'or' or 'and'"):
+        document.link_prerequisite(child.id, (parent_a.id,), mode="invalid")
+
+
 def test_duplicate_name_lookup_has_explicit_first_and_last_policy():
     first = _focus(10, name="duplicate")
     last = _focus(20, name="duplicate")


### PR DESCRIPTION
## Bottom line

AND-mode prerequisites now have a regression test for `[[a],[b]]` grouping, and the unused `FocusDocument.link()` dispatcher is gone.

Closes #187

BLUF