### PR TITLE
Preserve unmodelled decision keys on wizard import and save

### DIFF
--- a/src/hoi4cm/wizards/_generators.py
+++ b/src/hoi4cm/wizards/_generators.py
@@ -12,6 +12,8 @@ headless callers agree byte-for-byte.
 """
 
 import json
+import re
+import textwrap
 
 from hoi4cm.focus_tree.loc import LocTarget
 
@@ -20,6 +22,172 @@ def _indent_lines(text, n=1):
     """Indent every non-blank line by n tabs."""
     tab = "\t" * n
     return "\n".join(tab + line if line.strip() else line for line in text.splitlines())
+
+
+_DECISION_MODELED_KEYS = frozenset(
+    {
+        "allowed",
+        "icon",
+        "target_root_trigger",
+        "target_trigger",
+        "state_target",
+        "on_map_mode",
+        "targets",
+        "targets_dynamic",
+        "target_non_existing",
+        "target_array",
+        "visible",
+        "available",
+        "highlight_states",
+        "days_mission_timeout",
+        "selectable_mission",
+        "is_good",
+        "is_mission",
+        "activation",
+        "cost",
+        "ai_hint_pp_cost",
+        "custom_cost_trigger",
+        "custom_cost_text",
+        "days_remove",
+        "days_re_enable",
+        "fire_only_once",
+        "fixed_random_seed",
+        "war_with_target_on_complete",
+        "war_with_target_on_remove",
+        "war_with_on_complete",
+        "war_with_on_remove",
+        "war_with_on_timeout",
+        "modifier",
+        "complete_effect",
+        "timeout_effect",
+        "remove_effect",
+        "cancel_trigger",
+        "cancel_effect",
+        "cancel_if_not_visible",
+        "remove_trigger",
+        "ai_will_do",
+        "priority",
+    }
+)
+
+
+def _skip_script_string(source, position):
+    end = source.find('"', position + 1)
+    return len(source) if end == -1 else end + 1
+
+
+def _skip_script_comment(source, position):
+    end = source.find("\n", position)
+    return len(source) if end == -1 else end
+
+
+def _skip_space_and_comments(source, position):
+    while position < len(source):
+        if source[position].isspace():
+            position += 1
+        elif source[position] == "#":
+            position = _skip_script_comment(source, position)
+        else:
+            break
+    return position
+
+
+def _block_value_end(source, position):
+    depth = 0
+    while position < len(source):
+        char = source[position]
+        if char == '"':
+            position = _skip_script_string(source, position)
+        elif char == "#":
+            position = _skip_script_comment(source, position)
+        elif char == "{":
+            depth += 1
+            position += 1
+        elif char == "}":
+            depth -= 1
+            position += 1
+            if depth == 0:
+                return position
+        else:
+            position += 1
+    return len(source)
+
+
+def _assignment_end(source, position):
+    position = _skip_space_and_comments(source, position)
+    if position < len(source) and source[position] == "{":
+        return _block_value_end(source, position)
+    while position < len(source) and source[position] != "\n":
+        if source[position] == '"':
+            position = _skip_script_string(source, position)
+        else:
+            position += 1
+    return position
+
+
+def _top_level_assignments(source):
+    assignments = []
+    position = 0
+    depth = 0
+    identifier = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+    while position < len(source):
+        char = source[position]
+        if char == '"':
+            position = _skip_script_string(source, position)
+            continue
+        if char == "#":
+            position = _skip_script_comment(source, position)
+            continue
+        if char == "{":
+            depth += 1
+            position += 1
+            continue
+        if char == "}":
+            depth = max(depth - 1, 0)
+            position += 1
+            continue
+        if depth == 0 and (char.isalpha() or char == "_"):
+            match = identifier.match(source, position)
+            if match:
+                equals = _skip_space_and_comments(source, match.end())
+                if equals < len(source) and source[equals] == "=":
+                    raw_start = match.start()
+                    while raw_start > 0 and source[raw_start - 1] in " \t":
+                        raw_start -= 1
+                    raw_end = _assignment_end(source, equals + 1)
+                    assignments.append((match.group(), raw_start, raw_end))
+                    position = raw_end
+                    continue
+                position = match.end()
+                continue
+        position += 1
+    return assignments
+
+
+def capture_decision_extras(source, modeled_keys=None):
+    """Capture unmodelled top-level decision assignments as raw text."""
+    modeled = (
+        _DECISION_MODELED_KEYS if modeled_keys is None else frozenset(modeled_keys)
+    )
+    extras = []
+    for name, start, end in _top_level_assignments(source):
+        if name not in modeled:
+            raw = textwrap.dedent(source[start:end]).strip()
+            if raw:
+                extras.append(raw)
+    return extras
+
+
+def render_decision_extras(extras, indent=2):
+    """Indent captured decision assignments for re-emission."""
+    if isinstance(extras, str):
+        extras = [extras]
+    lines = []
+    for extra in extras or []:
+        if not isinstance(extra, str) or not extra.strip():
+            continue
+        lines.extend(_indent_lines(textwrap.dedent(extra).strip(), indent).splitlines())
+    return lines
 
 
 def render_event_txt(ev):
@@ -341,6 +509,7 @@ def generate_decision_block(dec, *, targeted=None, cost_type=None):
     if s(dec.get("priority", "")) not in ("", "1"):
         lines.append(f"{T2}priority = {s(dec['priority'])}")
 
+    lines.extend(render_decision_extras(dec.get("_extras", []), indent=2))
     lines.append(f"{T1}}}")
     return "\n".join(lines)
 

--- a/src/hoi4cm/wizards/decision.py
+++ b/src/hoi4cm/wizards/decision.py
@@ -97,6 +97,15 @@ def collect_decision_state(evars, dec=None):
     }
 
 
+def decision_save_needs_confirmation(target_path, import_source, target_exists):
+    """Return whether saving would overwrite a file not imported by the wizard."""
+    if not target_exists:
+        return False
+    target = os.path.normcase(os.path.abspath(target_path))
+    source = os.path.normcase(os.path.abspath(import_source)) if import_source else None
+    return target != source
+
+
 def open_decision_wizard(app):
     """HOI4 Decision / Decision Category maker — matches mockup layout."""
     win = tk.Toplevel(app)
@@ -223,6 +232,7 @@ def open_decision_wizard(app):
     dm_decs = []
     sel: dict[str, object] = {"uid": None, "type": None}
     _uid_n = [0]
+    _decision_import_source = None
 
     def _uid():
         _uid_n[0] += 1
@@ -304,6 +314,7 @@ def open_decision_wizard(app):
             priority="1",
             chain="",
             highlight_states="",
+            _extras=[],
         )
 
     # ── helpers ──────────────────────────────────────────────────────────────
@@ -4491,6 +4502,7 @@ def open_decision_wizard(app):
         ).pack(side="right", padx=10)
 
     def _import_txt(_paths=None):
+        nonlocal _decision_import_source
         import os as _os
         import re as _re
 
@@ -4510,6 +4522,7 @@ def open_decision_wizard(app):
         # Auto-set edit target to the first imported .txt so Save overwrites in place
         _first_txt = next((p for p in paths if p.lower().endswith(".txt")), None)
         if _first_txt:
+            _decision_import_source = _first_txt
             MOD.edit_decisions_file = _first_txt
             # Try to auto-detect matching categories file in common/decisions/categories/
             _base = _os.path.basename(_first_txt)
@@ -4573,11 +4586,10 @@ def open_decision_wizard(app):
 
         imported = 0
         for path in txt_paths:
-            try:
-                with open(path, encoding="utf-8", errors="replace") as f:
-                    raw = f.read()
-            except OSError as e:
-                report_error(str(e), e, parent=win, title="Import Error")
+            raw = read_file(path)
+            if raw is None:
+                error = OSError(f"Unable to read decision file: {path}")
+                report_error(str(error), error, parent=win, title="Import Error")
                 continue
 
             for cat_name, cat_inner, _ in find_blocks(raw):
@@ -4639,6 +4651,8 @@ def open_decision_wizard(app):
                         "icon": "icon",
                         "mission_timeout": "days_mission_timeout",
                         "target_array": "target_array",
+                        "war_complete_tag": "war_with_on_complete",
+                        "war_remove_tag": "war_with_on_remove",
                     }
                     for dkey, hkey in sv_map.items():
                         v = _get_value(dec_inner, hkey or dkey)
@@ -4668,6 +4682,10 @@ def open_decision_wizard(app):
                         d["targets_dynamic"] = True
                     if _get_yes_no(dec_inner, "target_non_existing"):
                         d["target_non_existing"] = True
+                    if _get_yes_no(dec_inner, "war_with_target_on_complete"):
+                        d["war_target_complete"] = True
+                    if _get_yes_no(dec_inner, "war_with_target_on_remove"):
+                        d["war_target_remove"] = True
 
                     # ── cost type detection ──
                     if _re.search(r"\bcustom_cost_trigger\b", dec_inner):
@@ -4719,6 +4737,8 @@ def open_decision_wizard(app):
                             d["targets"] = tv
                     if _re.search(r"\bstate_target\b", dec_inner):
                         d["targeted"] = "state"
+                    d["_extras"] = _generators.capture_decision_extras(dec_inner)
+
                     if d["targeted"] != "none":
                         on_mm = _get_value(dec_inner, "on_map_mode")
                         if on_mm:
@@ -4894,6 +4914,15 @@ def open_decision_wizard(app):
             dec_path = os.path.join(
                 mod_root, "common", "decisions", f"{ns}_decisions.txt"
             )
+        if decision_save_needs_confirmation(
+            dec_path, _decision_import_source, os.path.isfile(dec_path)
+        ) and not messagebox.askyesno(
+            "Overwrite Existing Decisions",
+            "This decisions file was not imported by the wizard.\n"
+            "Overwrite its existing contents?",
+            parent=win,
+        ):
+            return
         try:
             wf.write_text(dec_path, _gen_decisions_file(), encoding="utf-8")
             try:

--- a/tests/test_wizard_generators_decision.py
+++ b/tests/test_wizard_generators_decision.py
@@ -2,13 +2,17 @@
 
 import pytest
 
+from hoi4cm.core import read_file
+from hoi4cm.script.syntax import find_blocks
 from hoi4cm.wizards._generators import (
     _strip_val,
+    capture_decision_extras,
     generate_decision_block,
     generate_decision_categories_file,
     generate_decision_loc_yml,
     generate_decision_scripted_loc,
     generate_decisions_file,
+    render_decision_extras,
 )
 
 
@@ -92,6 +96,46 @@ def _dec(**overrides):
     )
     base.update(overrides)
     return base
+
+
+def test_decision_unmodelled_assignments_survive_import_and_save(tmp_path):
+    source_path = tmp_path / "decisions.txt"
+    source_path.write_text(
+        """
+TAG_cat = {
+\tTAG_decision = {
+\t\tallowed = { always = yes }
+\t\twar_with_on_complete = TAG_enemy
+\t\tcustom_engine_key = {
+\t\t\tcheck_variable = { var = example value = 1 }
+\t\t\t# Keep this comment too.
+\t\t}
+\t\tcustom_engine_scalar = "value # not a comment"
+\t}
+}
+""",
+        encoding="utf-8",
+    )
+    raw = read_file(str(source_path))
+    assert raw is not None
+    cat_inner = find_blocks(raw)[0][1]
+    inner = find_blocks(cat_inner)[0][1]
+    extras = capture_decision_extras(inner)
+
+    assert len(extras) == 2
+    assert "custom_engine_key = {" in extras[0]
+    assert 'custom_engine_scalar = "value # not a comment"' in extras[1]
+    assert render_decision_extras(extras)[0].startswith("\t\tcustom_engine_key")
+
+    out = generate_decisions_file(
+        [_cat()], [_dec(_extras=extras, war_complete_tag="TAG_enemy")]
+    )
+
+    assert "custom_engine_key = {" in out
+    assert "check_variable = { var = example value = 1 }" in out
+    assert "# Keep this comment too." in out
+    assert 'custom_engine_scalar = "value # not a comment"' in out
+    assert "war_with_on_complete = TAG_enemy" in out
 
 
 def test_decision_block_minimum_open_and_close():

--- a/tests/test_wizard_save.py
+++ b/tests/test_wizard_save.py
@@ -253,3 +253,16 @@ def test_malformed_decision_apply_restores_model_and_reports_failure(
     assert "TAG_my_decision" in refreshed_text
     assert "TAG_broken" not in refreshed_text
     _cleanup(tk_root)
+
+
+def test_decision_save_confirmation_detects_other_existing_target(tmp_path):
+    source = tmp_path / "imported.txt"
+    target = tmp_path / "other.txt"
+
+    assert not decision_mod.decision_save_needs_confirmation(
+        str(source), str(source), True
+    )
+    assert decision_mod.decision_save_needs_confirmation(str(target), str(source), True)
+    assert not decision_mod.decision_save_needs_confirmation(
+        str(target), str(source), False
+    )


### PR DESCRIPTION
## Bottom line

Decision import now captures every top-level assignment it does not model as raw text and re-emits it verbatim on save, so importing a real decisions file and saving no longer deletes keys the wizard does not understand.

Closes #209

## Why

The import loop only filled fields from a fixed whitelist, and Save to Mod rewrote the whole target file from that lossy model. A decision carrying `war_with_on_complete` (emitted by the wizard's own generator but missing from the import maps) silently stopped declaring war after an unrelated edit.

## How

- `capture_decision_extras` in `wizards/_generators.py` scans each imported decision body for top-level assignments outside the modeled key set, string- and comment-aware, and stores them raw on the decision; `generate_decision_block` re-emits them before the closing brace.
- The four `war_with_*` keys are now modeled properly on import (scalar tags and boolean variants), matching `_generators.py` emission, so they survive without relying on the raw-extras path.
- Import reads files through `read_file` instead of a lossy bare `open`.
- Saving to an existing decisions file the wizard did not import from now prompts first (`decision_save_needs_confirmation` plus an `askyesno` in the save path); saving over the imported file stays silent.
- Tests: unmodelled-key round-trip (nested block, comment, quoted scalar with `#`) and confirmation-helper cases.

Validation: 1256 passed, ruff, black, mypy, pylint clean.

BLUF