### PR TITLE
Keep joint_trigger on main-tree exports

### DIFF
--- a/src/hoi4cm/focus_tree/export.py
+++ b/src/hoi4cm/focus_tree/export.py
@@ -225,6 +225,7 @@ def export_main_tree(
                 effect_renderer=effect_renderer,
                 coordinate_policy="canvas",
                 completion_reward_policy="main",
+                include_joint_extra=True,
             )
         )
 

--- a/tests/test_focus_tree_export_main.py
+++ b/tests/test_focus_tree_export_main.py
@@ -340,6 +340,44 @@ def test_fixture_country_raw_present_verbatim_on_first_export():
     assert "original_tag=TST" in text  # no space around '=', preserved verbatim
 
 
+def test_main_tree_joint_trigger_survives_round_trip():
+    src = "\n".join(
+        [
+            "focus_tree = {",
+            "\tid = TST_main_tree",
+            "\tcountry = { factor = 0 modifier = { original_tag = TST } }",
+            "\tcontinuous_focus_position = { x = 20 y = 300 }",
+            "\tfocus = {",
+            "\t\tid = TST_joint_trigger",
+            "\t\tx = 0",
+            "\t\ty = 0",
+            "\t\tcost = 10",
+            "\t\tjoint_trigger = {",
+            "\t\t\thas_government = democratic",
+            "\t\t\tOR = {",
+            "\t\t\t\thas_war = yes",
+            "\t\t\t\thas_stability = 50",
+            "\t\t\t}",
+            "\t\t}",
+            "\t\tcompletion_reward = {",
+            "\t\t\tadd_political_power = 5",
+            "\t\t}",
+            "\t}",
+            "}",
+        ]
+    )
+
+    f1, t1 = _load_and_export_main(src)
+    f2, t2 = _load_and_export_main(t1)
+
+    assert "joint_trigger = {" in t1
+    assert "has_government = democratic" in t1
+    assert "has_war = yes" in t1
+    assert "has_stability = 50" in t1
+    assert f1[0]._joint_extra == f2[0]._joint_extra
+    assert t1 == t2
+
+
 def test_main_tree_roundtrip_preserves_unknown_focus_keys_and_is_idempotent():
     src = "\n".join(
         [


### PR DESCRIPTION
## Bottom line

`export_main_tree` now passes `include_joint_extra=True`, so a main-tree focus carrying a `joint_trigger` block no longer loses it on export.

Closes #221

## Why

Parse captured `joint_trigger` off any focus and build attached it, but only the extra-tree exporter re-emitted it. Main-tree round-trips dropped the block silently, breaking the "parse -> export must not drop fields" rule.

## How

One parameter in the `render_focus_body` call, mirroring `export_focus_tree`. The only other caller (export plans) re-exports already-parsed trees and is unaffected. Test parses a main tree with a `joint_trigger` block, exports twice, and asserts the block and its contents survive idempotently.

Validation: 1255 passed, ruff, black, mypy, pylint clean.

BLUF