### PR TITLE
Make WorkspaceFiles.append_text atomic

### DIFF
--- a/src/hoi4cm/mod/workspace_files.py
+++ b/src/hoi4cm/mod/workspace_files.py
@@ -46,6 +46,15 @@ def _stage(target: Path, text: str, encoding: str) -> Path:
     directory, a bad encoding, a full disk — fails here, before the target
     itself is touched.
     """
+    return _stage_bytes(target, text.encode(encoding))
+
+
+def _stage_bytes(target: Path, content: bytes) -> Path:
+    """Write ``content`` to a sibling temp file, fully flushed to disk.
+
+    Everything that can reasonably fail — a missing parent, an unwritable
+    directory, a full disk — fails here, before the target itself is touched.
+    """
     target.parent.mkdir(parents=True, exist_ok=True)
     target_mode: int | None
     try:
@@ -56,9 +65,9 @@ def _stage(target: Path, text: str, encoding: str) -> Path:
     try:
         if target_mode is not None:
             os.chmod(temporary_path, target_mode)
-        with os.fdopen(descriptor, "w", encoding=encoding) as temporary:
+        with os.fdopen(descriptor, "wb") as temporary:
             descriptor = -1
-            temporary.write(text)
+            temporary.write(content)
             temporary.flush()
             os.fsync(temporary.fileno())
     except BaseException:
@@ -124,10 +133,14 @@ class WorkspaceFiles:
             self._notify(target)
 
     def append_text(self, path: str | Path, text: str, *, encoding: str) -> None:
+        """Append ``text`` to ``path`` atomically (temp file + ``os.replace``)."""
         target = Path(path)
-        target.parent.mkdir(parents=True, exist_ok=True)
-        with target.open("a", encoding=encoding) as stream:
-            stream.write(text)
+        original = _read_bytes(target) or b""
+        temporary = _stage_bytes(target, original + text.encode(encoding))
+        try:
+            os.replace(temporary, target)
+        finally:
+            _unlink(temporary)
         self._notify(target)
 
     def _notify(self, path: Path) -> None:

--- a/tests/test_workspace_files.py
+++ b/tests/test_workspace_files.py
@@ -3,6 +3,7 @@ import stat
 
 import pytest
 
+import hoi4cm.mod.workspace_files as workspace_files_module
 from hoi4cm.mod.workspace_files import WorkspaceFiles
 
 
@@ -195,6 +196,68 @@ def test_write_text_still_takes_the_single_entry_path(tmp_path, monkeypatch):
     WorkspaceFiles().write_text(target, "new", encoding="utf-8")
 
     assert target.read_text() == "new"
+
+
+def test_append_text_preserves_existing_bytes(tmp_path):
+    target = tmp_path / "data.txt"
+    original = bytes((0xFF, 0xFE)) + b"existing" + bytes((13, 10))
+    appended = "second" + chr(10)
+    target.write_bytes(original)
+
+    WorkspaceFiles().append_text(target, appended, encoding="utf-8")
+
+    assert target.read_bytes() == original + appended.encode("utf-8")
+
+
+def test_append_text_creates_missing_file(tmp_path):
+    target = tmp_path / "nested" / "data.txt"
+
+    WorkspaceFiles().append_text(target, "created", encoding="utf-8")
+
+    assert target.read_bytes() == b"created"
+
+
+def test_append_text_staging_failure_keeps_existing_file(tmp_path, monkeypatch):
+    target = tmp_path / "data.txt"
+    original = b"original" + bytes((0,)) + b"bytes"
+    target.write_bytes(original)
+    notifications = []
+    real_fdopen = workspace_files_module.os.fdopen
+
+    class FailingWriter:
+        def __init__(self, stream):
+            self._stream = stream
+
+        def __enter__(self):
+            self._stream.__enter__()
+            return self
+
+        def __exit__(self, *args):
+            return self._stream.__exit__(*args)
+
+        def write(self, content):
+            self._stream.write(content[:1])
+            raise OSError("write failed")
+
+        def flush(self):
+            return self._stream.flush()
+
+        def fileno(self):
+            return self._stream.fileno()
+
+    def failing_fdopen(*args, **kwargs):
+        return FailingWriter(real_fdopen(*args, **kwargs))
+
+    monkeypatch.setattr(workspace_files_module.os, "fdopen", failing_fdopen)
+
+    with pytest.raises(OSError, match="write failed"):
+        WorkspaceFiles(on_written=notifications.append).append_text(
+            target, " appended", encoding="utf-8"
+        )
+
+    assert target.read_bytes() == original
+    assert notifications == []
+    assert list(target.parent.glob("*.tmp")) == []
 
 
 def test_append_text_notifies_after_write(tmp_path):


### PR DESCRIPTION
## Bottom line

`append_text` now stages the original bytes plus the appended text into a fsynced sibling temp file and swaps via `os.replace`, matching the crash safety of `write_texts`.

Closes #216

## Why

A direct append could leave a truncated `defined_text` block or loc entry in a real mod file after a disk-full or interrupted write, which parse-errors the whole file in game.

## How

- `_stage` generalizes into `_stage_bytes`; append reads the target's bytes (empty if missing), stages `original + text.encode(encoding)`, replaces, and notifies once. Original bytes (BOM, encoding, line endings) are preserved exactly, with no decode/re-encode round trip.
- Tests: byte-exact append to an existing file, create-if-missing, mid-write failure leaves the original bytes untouched with no temp files left and no notification.

Validation: 1257 passed, ruff, black, mypy, pylint clean.

BLUF