### PR TITLE
Reject emit_scalar values containing double quotes

### DIFF
--- a/src/hoi4cm/script/syntax.py
+++ b/src/hoi4cm/script/syntax.py
@@ -202,11 +202,15 @@ def extract_named_block(source: str, name: str) -> str | None:
 def emit_scalar(value: str) -> str:
     """Wrap a string in double quotes if it contains bare-token-breaking chars.
 
-    Paradox script bare tokens cannot contain whitespace, ``{``, ``}``, ``=``,
-    ``"``, or ``#``. Values containing any of these characters are quoted so
-    that they survive a parse -> export -> parse round-trip intact.
+    Paradox script bare tokens cannot contain whitespace, ``{``, ``}``, ``=`` or
+    ``#``. Values containing any of these characters are quoted so that they
+    survive a parse -> export -> parse round-trip intact. Values containing a
+    double quote raise ``ValueError`` because Clausewitz has no string escape
+    mechanism, so emitting one would corrupt the script.
     """
-    if any(c in value for c in ' \t\n\r{}="#') or '"' in value:
+    if '"' in value:
+        raise ValueError(f"Cannot emit scalar containing a double quote: {value!r}")
+    if any(c in value for c in " \t\n\r{}=#"):
         return f'"{value}"'
     return value
 

--- a/tests/test_emit_scalar.py
+++ b/tests/test_emit_scalar.py
@@ -1,3 +1,5 @@
+import pytest
+
 from hoi4cm.script.syntax import emit_scalar
 
 
@@ -31,8 +33,9 @@ def test_emit_scalar_quotes_on_braces_equals_hash():
     assert emit_scalar("hello#world") == '"hello#world"'
 
 
-def test_emit_scalar_quotes_on_embedded_quote():
-    assert emit_scalar('hello"world') == '"hello"world"'
+def test_emit_scalar_rejects_embedded_quote():
+    with pytest.raises(ValueError, match=r'hello"world'):
+        emit_scalar('hello"world')
 
 
 def test_emit_scalar_icon_path_with_space():

--- a/tests/test_export_plan.py
+++ b/tests/test_export_plan.py
@@ -92,6 +92,19 @@ def test_main_plan_writes_tree_and_localisation_as_one_group(tmp_path):
     assert "TST_root" in calls[0][1][1]
 
 
+def test_main_plan_rejects_focus_text_with_double_quote(tmp_path):
+    plan = _main_plan(tmp_path)
+    plan.focuses[0].text = 'a"b'
+    calls = []
+
+    results = execute_export_plans([plan], lambda entries: calls.append(tuple(entries)))
+
+    assert len(results) == 1
+    assert isinstance(results[0].error, ValueError)
+    assert 'a"b' in str(results[0].error)
+    assert calls == []
+
+
 def test_main_plan_writes_focus_gfx_declarations(tmp_path):
     gfx_path = tmp_path / "interface" / "TST_focus.gfx"
     plan = _main_plan(


### PR DESCRIPTION
## Bottom line

`emit_scalar` now raises `ValueError` for values containing a double quote instead of emitting unparseable script like `"hello"world"`.

Closes #211

## Why

Clausewitz has no string escape mechanism, so a string closes at the very next quote. Wrapping a quote-containing value in more quotes corrupted everything after it in the exported file, and a test locked that broken output in as correct. Since the value cannot be represented re-parseably either, rejection is the only safe behavior.

## How

- `emit_scalar` raises `ValueError` naming the offending value; docstring updated.
- Export-plan execution catches the error per file and reports it without writing anything (`calls == []` asserted in the new plan test).
- The locked broken-behavior test now asserts rejection; normal quoting (whitespace, braces, `=`, `#`) unchanged.

Validation: 1255 passed, ruff, black, mypy, pylint clean.

BLUF