### PR TITLE
Keep the graphics cache dirty until store succeeds

### DIFF
--- a/src/hoi4cm/mod/graphics_catalog.py
+++ b/src/hoi4cm/mod/graphics_catalog.py
@@ -425,20 +425,19 @@ class GraphicsCatalog:
         self._flush_cache()
 
     def _flush_cache(self) -> None:
-        if not self._cache_dirty:
-            return
-        self._cache_dirty = False
-        if not self._root:
+        if not self._cache_dirty or not self._root:
             return
         snapshot = self._snapshot_for_store()
         if not snapshot.cacheable:
             return
-        WorkspaceCache(scan_cache.database_path(self._root)).store_graphics(
+        stored = WorkspaceCache(scan_cache.database_path(self._root)).store_graphics(
             snapshot.to_data(),
             schema_version=_CACHE_VERSION,
             root_identity=self._root_identity,
             config_fingerprint=self._config_fingerprint,
         )
+        if stored:
+            self._cache_dirty = False
 
     def _snapshot_for_store(self) -> GraphicsSnapshot:
         goals_root = self._goals_root

--- a/src/hoi4cm/mod/workspace_cache.py
+++ b/src/hoi4cm/mod/workspace_cache.py
@@ -57,7 +57,7 @@ class WorkspaceCache:
         schema_version: int,
         root_identity: str,
         config_fingerprint: str,
-    ) -> None:
+    ) -> bool:
         try:
             encoded = json.dumps(data, ensure_ascii=False, separators=(",", ":"))
             with self._connection() as connection:
@@ -74,6 +74,8 @@ class WorkspaceCache:
                 )
         except (OSError, TypeError, ValueError, sqlite3.Error) as error:
             _log.debug("graphics cache write failed: %s", error)
+            return False
+        return True
 
     @contextlib.contextmanager
     def _connection(self) -> Iterator[sqlite3.Connection]:

--- a/tests/test_graphics_catalog.py
+++ b/tests/test_graphics_catalog.py
@@ -7,6 +7,7 @@ import pytest
 from hoi4cm.core.paths import read_file
 from hoi4cm.mod import scan_cache
 from hoi4cm.mod.graphics_catalog import FileStamp, GraphicsCatalog, GraphicsScanConfig
+from hoi4cm.mod.workspace_cache import WorkspaceCache
 
 
 @pytest.fixture(autouse=True)
@@ -560,6 +561,39 @@ def test_snapshot_store_is_deferred_until_flush(graphics_tree):
     fresh.refresh(str(graphics_tree), _config(), read_text=read_file)
     assert fresh.last_metrics.cache_status == "hit"
     assert fresh.resolve("GFX_focus_deferred") is not None
+
+
+def test_failed_snapshot_store_keeps_catalog_dirty_until_retry(
+    graphics_tree, monkeypatch
+):
+    catalog = GraphicsCatalog()
+    catalog.refresh(str(graphics_tree), _config(), read_text=read_file)
+    added = graphics_tree / "gfx" / "interface" / "goals" / "retry.dds"
+    added.write_bytes(b"retry")
+    catalog.note_written(str(added), read_text=read_file)
+
+    original_store = WorkspaceCache.store_graphics
+    attempts = 0
+
+    def store_once_then_succeed(cache, data, **kwargs):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return False
+        return original_store(cache, data, **kwargs)
+
+    monkeypatch.setattr(WorkspaceCache, "store_graphics", store_once_then_succeed)
+
+    catalog.flush_cache()
+    assert catalog._cache_dirty
+    catalog.flush_cache()
+    assert not catalog._cache_dirty
+
+    fresh = GraphicsCatalog()
+    fresh.refresh(str(graphics_tree), _config(), read_text=read_file)
+    assert attempts == 2
+    assert fresh.last_metrics.cache_status == "hit"
+    assert fresh.resolve("GFX_focus_retry") is not None
 
 
 def test_refresh_flushes_pending_writes(graphics_tree):

--- a/tests/test_workspace_cache.py
+++ b/tests/test_workspace_cache.py
@@ -15,7 +15,7 @@ def cache(tmp_path):
 
 
 def test_store_load_roundtrip(cache):
-    cache.store_graphics(
+    assert cache.store_graphics(
         {"a": 1, "b": ["x", "y"]},
         schema_version=1,
         root_identity="root-1",
@@ -106,7 +106,7 @@ def test_unreadable_database_degrades_to_none(tmp_path, monkeypatch):
 
 def test_store_non_jsonable_degrades_without_raising(tmp_path, monkeypatch):
     cache = WorkspaceCache(tmp_path / "state" / "cache.db")
-    cache.store_graphics(
+    assert not cache.store_graphics(
         {"bad": object()},
         schema_version=1,
         root_identity="root-1",


### PR DESCRIPTION
## Bottom line

`GraphicsCatalog` now leaves the snapshot dirty when `store_graphics` fails, so the next flush retries instead of permanently skipping the write.

Closes #194

## Why

The dirty flag was cleared before the store. A read-only cache dir, full disk, or locked DB then made every later `flush_cache()` no-op, and every mod load rescanned.

## How

`store_graphics` returns `True` only on success. `_flush_cache` clears `_cache_dirty` only then.

BLUF