### PR TITLE
Treat unreadable dyn-mod files as errors, not missing

### DIFF
--- a/src/hoi4cm/wizards/dyn_mod.py
+++ b/src/hoi4cm/wizards/dyn_mod.py
@@ -51,6 +51,22 @@ from hoi4cm.wizards._shared import (
     text_get,
 )
 
+_READ_MISSING = "missing"
+_READ_FAILED = "read-failed"
+_READ_CONTENT = "content"
+
+
+def _read_existing_file(path):
+    if not os.path.exists(path):
+        return _READ_MISSING, None
+    try:
+        content = read_file(path)
+    except OSError, UnicodeDecodeError, ValueError:
+        return _READ_FAILED, None
+    if content is None:
+        return _READ_FAILED, None
+    return _READ_CONTENT, content
+
 
 def collect_dyn_mod_state(svars, text_widgets):
     """Collect dynamic-modifier form state into kwargs for ``build_dyn_mod_output``."""
@@ -1089,7 +1105,7 @@ def open_dyn_mod_wizard(app):
         def full(rel):
             return os.path.join(mod_root, rel)
 
-        def read_existing(rel, encoding="utf-8-sig"):
+        def read_existing_text(rel, encoding="utf-8-sig"):
             p = full(rel)
             if not os.path.exists(p):
                 return None
@@ -1098,6 +1114,11 @@ def open_dyn_mod_wizard(app):
                     return f.read()
             except OSError, UnicodeDecodeError, ValueError:
                 return None
+
+        def record_read_error(rel):
+            message = f"Could not read existing file: {rel}"
+            add_error(message)
+            errors.append(message)
 
         def write(rel, content, encoding="utf-8"):
             p = full(rel)
@@ -1114,7 +1135,7 @@ def open_dyn_mod_wizard(app):
         #           if not, create it fresh.
         # ════════════════════════════════════════════════════════
         dm_rel = os.path.join("common", "dynamic_modifiers", f"{mid}.txt")
-        dm_existing = read_existing(dm_rel)
+        dm_state, dm_existing = _read_existing_file(full(dm_rel))
 
         # Build the new block
         icon_gfx = (
@@ -1141,32 +1162,38 @@ def open_dyn_mod_wizard(app):
         dm_block_lines.append("}")
         dm_new_block = "\n".join(dm_block_lines)
 
-        if dm_existing is None:
-            # Fresh file
-            dm_final = dm_new_block + "\n"
-            action = "created"
+        if dm_state == _READ_FAILED:
+            record_read_error(dm_rel)
         else:
-            # Replace existing block for `mid` if present, else append
-            # Match: mid = { ... } at top level (handles nested braces)
-            def replace_or_append(src, block_id, new_block):
-                # Find "block_id = {" and extract to matching "}"
-                pattern = re.compile(
-                    r"^\s*" + re.escape(block_id) + r"\s*=\s*\{", re.MULTILINE
-                )
-                m = pattern.search(src)
-                if not m:
-                    # Not found — append
+            if dm_state == _READ_MISSING:
+                # Fresh file
+                dm_final = dm_new_block + "\n"
+                action = "created"
+            else:
+                # Replace existing block for `mid` if present, else append
+                # Match: mid = { ... } at top level (handles nested braces)
+                def replace_or_append(src, block_id, new_block):
+                    # Find "block_id = {" and extract to matching "}"
+                    pattern = re.compile(
+                        r"^\s*" + re.escape(block_id) + r"\s*=\s*\{", re.MULTILINE
+                    )
+                    m = pattern.search(src)
+                    if not m:
+                        # Not found — append
+                        return src.rstrip() + "\n\n" + new_block + "\n", "appended"
+                    i = match_brace(src, m.end() - 1)
+                    if i < len(src):
+                        replaced = src[: m.start()] + new_block + src[i + 1 :]
+                        return replaced, "updated"
                     return src.rstrip() + "\n\n" + new_block + "\n", "appended"
-                i = match_brace(src, m.end() - 1)
-                if i < len(src):
-                    replaced = src[: m.start()] + new_block + src[i + 1 :]
-                    return replaced, "updated"
-                return src.rstrip() + "\n\n" + new_block + "\n", "appended"
 
-            dm_final, action = replace_or_append(dm_existing, mid, dm_new_block)
+                dm_existing = dm_existing or ""
+                dm_final, action = replace_or_append(dm_existing, mid, dm_new_block)
 
-        if write(dm_rel, dm_final):
-            results.append((dm_rel, action, f"{len(mod_entries)} variable modifiers"))
+            if write(dm_rel, dm_final):
+                results.append(
+                    (dm_rel, action, f"{len(mod_entries)} variable modifiers")
+                )
 
         # ════════════════════════════════════════════════════════
         # FILE 2 — configured localisation language
@@ -1204,7 +1231,7 @@ def open_dyn_mod_wizard(app):
                 loc_target.dirname(),
                 loc_target.filename(mid),
             )
-        loc_existing = read_existing(loc_rel, "utf-8-sig")
+        loc_existing = read_existing_text(loc_rel, "utf-8-sig")
 
         new_loc_lines = []
 
@@ -1274,7 +1301,7 @@ def open_dyn_mod_wizard(app):
         if icon_gfx:
             icon_name = icon_gfx.replace("GFX_idea_", "").replace("GFX_", "")
             gfx_rel = os.path.join("interface", "ideas.gfx")
-            gfx_existing = read_existing(gfx_rel)
+            gfx_existing = read_existing_text(gfx_rel)
             gfx_final, added_count = append_sprite_types(
                 gfx_existing,
                 [(icon_gfx, f"gfx/interface/ideas/{icon_name}.dds")],
@@ -1410,6 +1437,13 @@ def open_dyn_mod_wizard(app):
             modifier_id, fp = mods[sel[0]]
             try:
                 src = read_file(fp)
+                if src is None:
+                    report_error(
+                        f"Could not read modifier '{modifier_id}'",
+                        parent=dlg,
+                        title="Read Error",
+                    )
+                    return
                 parsed = parse_script(src)
                 blk = parsed.get(modifier_id, {})
                 if not isinstance(blk, dict):
@@ -1462,6 +1496,8 @@ def open_dyn_mod_wizard(app):
             for loc_path in find_loc_files(MOD.root, language=MOD.loc_language):
                 try:
                     loc_src = read_file(loc_path)
+                    if loc_src is None:
+                        continue
                     for m in re.finditer(
                         r'^\s+(\S+?)(?::\d+)?\s+"(.*)"', loc_src, re.MULTILINE
                     ):

--- a/tests/test_dyn_mod_save.py
+++ b/tests/test_dyn_mod_save.py
@@ -1,0 +1,97 @@
+"""Dynamic-modifier save-path regression tests."""
+
+import tkinter as tk
+
+import pytest
+
+import hoi4cm.core.logger as logmod
+import hoi4cm.wizards.dyn_mod as dm_mod
+from hoi4cm.wizards.dyn_mod import open_dyn_mod_wizard
+
+
+@pytest.fixture
+def isolated_error_buffer():
+    original_entries = list(logmod.get_error_entries())
+    original_callback = logmod._error_callback
+    logmod.clear_errors()
+    logmod.set_error_callback(None)
+    try:
+        yield
+    finally:
+        logmod.clear_errors()
+        logmod.get_error_entries().extend(original_entries)
+        logmod.set_error_callback(original_callback)
+
+
+def _save_button(window):
+    pending = [window]
+    while pending:
+        current = pending.pop()
+        if isinstance(current, tk.Button) and current.cget("text") == dm_mod.tr(
+            "common.generate_all_files", "Generate All Files ->"
+        ):
+            return current
+        pending.extend(current.winfo_children())
+    raise AssertionError("dynamic-modifier save button not found")
+
+
+def _open_and_save(tk_root, tmp_path, monkeypatch):
+    info_messages = []
+    monkeypatch.setattr(dm_mod.filedialog, "askdirectory", lambda **_: str(tmp_path))
+    monkeypatch.setattr(
+        dm_mod.messagebox,
+        "showinfo",
+        lambda *args, **kwargs: info_messages.append(args),
+    )
+    monkeypatch.setattr(dm_mod.messagebox, "showerror", lambda *args, **kwargs: None)
+    open_dyn_mod_wizard(tk_root)
+    tk_root.update_idletasks()
+    window = next(
+        child for child in tk_root.winfo_children() if isinstance(child, tk.Toplevel)
+    )
+    _save_button(window).invoke()
+    return window, info_messages
+
+
+def test_read_existing_file_distinguishes_missing_content_and_failure(
+    tmp_path, monkeypatch
+):
+    missing = tmp_path / "missing.txt"
+    existing = tmp_path / "existing.txt"
+    existing.write_text("existing = {}\n", encoding="utf-8")
+
+    assert dm_mod._read_existing_file(missing) == (dm_mod._READ_MISSING, None)
+    assert dm_mod._read_existing_file(existing) == (
+        dm_mod._READ_CONTENT,
+        "existing = {}\n",
+    )
+
+    monkeypatch.setattr(dm_mod, "read_file", lambda _path: None)
+    assert dm_mod._read_existing_file(existing) == (dm_mod._READ_FAILED, None)
+
+
+def test_save_skips_unreadable_dynamic_modifier(
+    tmp_path, monkeypatch, tk_root, isolated_error_buffer
+):
+    target = tmp_path / "common" / "dynamic_modifiers" / "TAG_my_dynamic_modifier.txt"
+    target.parent.mkdir(parents=True)
+    original = b"\xff\xfeexisting modifier bytes\n"
+    target.write_bytes(original)
+    monkeypatch.setattr(dm_mod, "read_file", lambda _path: None)
+
+    _, info_messages = _open_and_save(tk_root, tmp_path, monkeypatch)
+
+    assert target.read_bytes() == original
+    entries = logmod.get_error_entries()
+    assert any("Could not read existing file" in message for _, message in entries)
+    assert any(str(target.relative_to(tmp_path)) in message for _, message in entries)
+    summary = "\n".join(str(arg) for call in info_messages for arg in call)
+    assert str(target.relative_to(tmp_path)) not in summary
+
+
+def test_save_creates_missing_dynamic_modifier(tmp_path, monkeypatch, tk_root):
+    _open_and_save(tk_root, tmp_path, monkeypatch)
+
+    target = tmp_path / "common" / "dynamic_modifiers" / "TAG_my_dynamic_modifier.txt"
+    assert target.exists()
+    assert b"TAG_my_dynamic_modifier = {" in target.read_bytes()


### PR DESCRIPTION
## Bottom line

If an existing dynamic-modifier file cannot be read, the wizard now records an error and leaves the file alone instead of treating it as missing and overwriting it.

Closes #210

## Why

`read_existing` returned `None` for both a missing file and a failed read. The save path treated `None` as a fresh file, wrote only the new block, and reported `[created]`.

## How

A module-level helper distinguishes missing, content, and read failure via `read_file`. Failure goes through `add_error` and skips the write. Missing files still create.

BLUF