### PR TITLE
Reject absolute export paths in loaded projects

### DIFF
--- a/hoi4_content_maker.py
+++ b/hoi4_content_maker.py
@@ -80,6 +80,7 @@ from hoi4cm.editor import (  # noqa: E402
     clear_workspace_autosave,
     read_project,
     sibling_autosave_path,
+    validate_project_file_path,
     workspace_autosave_path,
     write_project,
 )
@@ -5305,8 +5306,14 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
         except Exception:
             pass
         default_filename = f"05_{country_tag}.txt"
-        if MOD.edit_focus_file and os.path.isfile(MOD.edit_focus_file):
-            path = MOD.edit_focus_file
+        mod_root = MOD.root if MOD.root and os.path.isdir(MOD.root) else None
+        focus_path = (
+            validate_project_file_path(MOD.edit_focus_file, mod_root)
+            if mod_root
+            else ""
+        )
+        if focus_path and os.path.isfile(focus_path):
+            path = focus_path
         else:
             path = filedialog.asksaveasfilename(
                 defaultextension=".txt",
@@ -5319,13 +5326,15 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
             )
         if not path:
             return None
-        if MOD.edit_loc_file and os.path.isfile(MOD.edit_loc_file):
-            loc_path = MOD.edit_loc_file
+        loc_path_from_project = (
+            validate_project_file_path(MOD.edit_loc_file, mod_root) if mod_root else ""
+        )
+        if loc_path_from_project and os.path.isfile(loc_path_from_project):
+            loc_path = loc_path_from_project
         else:
             loc_target = MOD.loc_target
             loc_filename = loc_target.filename(f"{country_tag}_focus")
             saved_dir = os.path.dirname(os.path.abspath(path))
-            mod_root = MOD.root if MOD.root and os.path.isdir(MOD.root) else None
             if mod_root is None:
                 candidate = saved_dir
                 for _ in range(5):
@@ -5395,8 +5404,12 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
                     tr("dialog.no_focuses_in_tree", "No focuses in this tree."),
                 )
             return None
-        if os.path.isfile(info["file_path"]):
-            path = info["file_path"]
+        mod_root = MOD.root if MOD.root and os.path.isdir(MOD.root) else None
+        focus_path = (
+            validate_project_file_path(info["file_path"], mod_root) if mod_root else ""
+        )
+        if focus_path and os.path.isfile(focus_path):
+            path = focus_path
         else:
             path = filedialog.asksaveasfilename(
                 defaultextension=".txt",
@@ -5516,8 +5529,15 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
         self._tree_had_wrapper = workspace.main_tree.had_wrapper
         # Legacy projects decode with an empty file_path; keep the user's
         # existing export target rather than wiping it.
-        if workspace.main_tree.file_path:
-            MOD.edit_focus_file = workspace.main_tree.file_path
+        mod_root = getattr(MOD, "root", "") or ""
+        mod_root = mod_root if os.path.isdir(mod_root) else None
+        focus_path = (
+            validate_project_file_path(workspace.main_tree.file_path, mod_root)
+            if mod_root
+            else ""
+        )
+        if focus_path:
+            MOD.edit_focus_file = focus_path
         self._cfp_x = meta.cfp_x
         self._cfp_y = meta.cfp_y
         self._cfp_x_var.set("" if meta.cfp_x is None else str(meta.cfp_x))
@@ -5659,6 +5679,18 @@ class App(CanvasMixin, ModLoadingMixin, EffectsMixin, tk.Tk):  # type: ignore[mi
         self._hide_form()
         self._redraw()
         self._invalidate_focus_list_structure()
+        rejected_paths = getattr(workspace, "_rejected_file_paths", ())
+        if rejected_paths:
+            messagebox.showwarning(
+                tr("dialog.load_project_paths_ignored.title", "Project Load"),
+                tr(
+                    "dialog.load_project_paths_ignored.body",
+                    "Stored export paths were ignored because they are unsafe:\n\n"
+                    "{paths}",
+                    paths="\n".join(f"  {path}" for path in rejected_paths),
+                ),
+                parent=self,
+            )
 
     # ── EXPORT ──────────────────────────────────────────────────
 

--- a/src/hoi4cm/editor/__init__.py
+++ b/src/hoi4cm/editor/__init__.py
@@ -1,4 +1,10 @@
-from .project_codec import decode_project, encode_project, read_project, write_project
+from .project_codec import (
+    decode_project,
+    encode_project,
+    read_project,
+    validate_project_file_path,
+    write_project,
+)
 from .workspace_autosave import (
     AUTOSAVE_NAME,
     clear_workspace_autosave,
@@ -13,6 +19,7 @@ __all__ = [
     "encode_project",
     "read_project",
     "sibling_autosave_path",
+    "validate_project_file_path",
     "workspace_autosave_path",
     "write_project",
 ]

--- a/src/hoi4cm/editor/project_codec.py
+++ b/src/hoi4cm/editor/project_codec.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import json
+import ntpath
+import os
 from collections.abc import Mapping
 from dataclasses import asdict
 from pathlib import Path
 from typing import Any
 
+from hoi4cm.core.safe_path import safe_join
 from hoi4cm.mod.workspace_files import WorkspaceFiles
 from hoi4cm.models import (
     EditorWorkspace,
@@ -54,6 +57,7 @@ def encode_project(workspace: EditorWorkspace) -> dict[str, Any]:
 
 
 def decode_project(data: Mapping[str, Any]) -> EditorWorkspace:
+    rejected_paths: list[str] = []
     format_name = data.get("format")
     if format_name is not None:
         if format_name != PROJECT_FORMAT:
@@ -62,12 +66,15 @@ def decode_project(data: Mapping[str, Any]) -> EditorWorkspace:
             raise ValueError(f"unsupported project version: {data.get('version')!r}")
         if not isinstance(data.get("workspace"), Mapping):
             raise ValueError("project workspace must be an object")
-        return _decode_v2(data)
-    if data.get("version") == PROJECT_VERSION and isinstance(
+        workspace = _decode_v2(data, rejected_paths)
+    elif data.get("version") == PROJECT_VERSION and isinstance(
         data.get("workspace"), Mapping
     ):
-        return _decode_v2(data)
-    return _decode_legacy(data)
+        workspace = _decode_v2(data, rejected_paths)
+    else:
+        workspace = _decode_legacy(data)
+    workspace.__dict__["_rejected_file_paths"] = tuple(rejected_paths)
+    return workspace
 
 
 def write_project(path: str | Path, workspace: EditorWorkspace) -> None:
@@ -103,7 +110,7 @@ def _encode_tree(tree: TreeDocument) -> dict[str, Any]:
     return data
 
 
-def _decode_v2(data: Mapping[str, Any]) -> EditorWorkspace:
+def _decode_v2(data: Mapping[str, Any], rejected_paths: list[str]) -> EditorWorkspace:
     raw_workspace = data["workspace"]
     raw_canvas = raw_workspace.get("canvas", {})
     if not isinstance(raw_canvas, Mapping):
@@ -114,9 +121,11 @@ def _decode_v2(data: Mapping[str, Any]) -> EditorWorkspace:
         focuses=FocusDocument(
             Focus.from_dict(focus) for focus in raw_workspace.get("focuses", [])
         ),
-        main_tree=_decode_tree(raw_workspace.get("main_tree", {}), "main"),
+        main_tree=_decode_tree(
+            raw_workspace.get("main_tree", {}), "main", rejected_paths
+        ),
         extra_trees=[
-            _decode_tree(tree, tree.get("tree_type", "shared"))
+            _decode_tree(tree, tree.get("tree_type", "shared"), rejected_paths)
             for tree in raw_workspace.get("extra_trees", [])
         ],
         canvas_min=canvas_min,
@@ -158,7 +167,9 @@ def _decode_legacy(data: Mapping[str, Any]) -> EditorWorkspace:
     )
 
 
-def _decode_tree(data: Mapping[str, Any], default_type: str) -> TreeDocument:
+def _decode_tree(
+    data: Mapping[str, Any], default_type: str, rejected_paths: list[str]
+) -> TreeDocument:
     metadata_data = data.get("metadata", {})
     if not isinstance(metadata_data, Mapping):
         metadata_data = {}
@@ -167,10 +178,16 @@ def _decode_tree(data: Mapping[str, Any], default_type: str) -> TreeDocument:
         **{key: value for key, value in metadata_data.items() if key in metadata_fields}
     )
     known = {"metadata", "tree_type", "file_path", "had_wrapper", "focus_ids"}
+    raw_file_path = data.get("file_path", "")
+    file_path = validate_project_file_path(raw_file_path)
+    if raw_file_path and not file_path:
+        path_text = str(raw_file_path)
+        if path_text not in rejected_paths:
+            rejected_paths.append(path_text)
     return TreeDocument(
         metadata=metadata,
         tree_type=data.get("tree_type", default_type),
-        file_path=data.get("file_path", ""),
+        file_path=file_path,
         had_wrapper=bool(data.get("had_wrapper", True)),
         focus_ids=set(data.get("focus_ids", [])),
         metadata_extras={
@@ -180,6 +197,29 @@ def _decode_tree(data: Mapping[str, Any], default_type: str) -> TreeDocument:
         },
         extras={key: value for key, value in data.items() if key not in known},
     )
+
+
+def validate_project_file_path(
+    path: object, base: str | os.PathLike[str] | None = None
+) -> str:
+    if isinstance(path, os.PathLike):
+        path = os.fspath(path)
+    if not isinstance(path, str) or not path:
+        return ""
+    normalized = path.replace("\\", "/")
+    if ".." in normalized.split("/"):
+        return ""
+    if ntpath.splitdrive(path)[0] and not os.path.isabs(path):
+        return ""
+    if os.path.isabs(path) or ntpath.isabs(path) or normalized.startswith("/"):
+        if base is None or not os.path.isabs(path):
+            return ""
+    if base is None:
+        return path
+    try:
+        return safe_join(base, normalized)
+    except OSError, TypeError, ValueError:
+        return ""
 
 
 def _pair(value: object, default: tuple[int, int]) -> tuple[int, int]:
@@ -192,6 +232,7 @@ __all__ = [
     "PROJECT_FORMAT",
     "PROJECT_VERSION",
     "decode_project",
+    "validate_project_file_path",
     "encode_project",
     "read_project",
     "write_project",

--- a/tests/test_monolith_error_reporting.py
+++ b/tests/test_monolith_error_reporting.py
@@ -7,12 +7,14 @@ touching any widget state, so a bare shell stands in for the App.
 """
 
 from types import SimpleNamespace
+from typing import cast
 
 import pytest
 
 import hoi4_content_maker as m
 import hoi4cm.core.logger as logmod
 import hoi4cm.ui.error_report as error_report
+from hoi4cm.editor import decode_project
 from hoi4cm.models import Focus, FocusDocument
 
 
@@ -51,6 +53,54 @@ def test_load_reports_a_corrupt_project(shown, monkeypatch):
     assert len(entries) == 1
     assert "invalid JSON" in entries[0][1]
     assert "Traceback" in entries[0][1]
+
+
+def test_load_warns_when_stored_export_paths_are_dropped(shown, monkeypatch):
+    monkeypatch.setattr(m.filedialog, "askopenfilename", lambda **_kw: "project.json")
+    workspace = decode_project(
+        {
+            "format": "hoi4cm-project",
+            "version": 2,
+            "workspace": {
+                "main_tree": {"file_path": "/outside/main.txt"},
+                "extra_trees": [{"file_path": "../outside/shared.txt"}],
+            },
+        }
+    )
+    monkeypatch.setattr(m, "read_project", lambda _path: workspace)
+    monkeypatch.setattr(m, "clear_workspace_autosave", lambda: None)
+    warnings = []
+    monkeypatch.setattr(
+        m.messagebox,
+        "showwarning",
+        lambda *args, **kwargs: warnings.append((args, kwargs)),
+    )
+    shell = type(
+        "Shell",
+        (),
+        {
+            "cv": type("Canvas", (), {"delete": lambda self, *_args: None})(),
+            "selected": None,
+            "_lines": set(),
+            "_grid_item": None,
+            "_grid_key": None,
+            "_grid_img": None,
+            "_install_workspace": lambda self, _workspace: None,
+            "_mark_clean": lambda self: None,
+            "_detect_and_apply_tag": lambda self: None,
+            "_refresh_tree_meta_panel": lambda self: None,
+            "_refresh_loaded_trees_panel": lambda self: None,
+            "_hide_form": lambda self: None,
+            "_redraw": lambda self: None,
+            "_invalidate_focus_list_structure": lambda self: None,
+        },
+    )()
+
+    m.App._load(cast(m.App, shell))
+
+    assert len(warnings) == 1
+    assert "Stored export paths were ignored" in warnings[0][0][1]
+    assert "/outside/main.txt" in warnings[0][0][1]
 
 
 def test_load_cancel_shows_nothing(shown, monkeypatch):

--- a/tests/test_monolith_export.py
+++ b/tests/test_monolith_export.py
@@ -1,5 +1,6 @@
 """Tests for the monolith's Tk shells around the export-plan pipeline."""
 
+from collections.abc import Callable
 from types import SimpleNamespace
 from typing import Any
 
@@ -60,6 +61,8 @@ def mod_files(tmp_path, monkeypatch):
 
 
 class _App:
+    _make_extra_export_plan: Callable[..., Any]
+    _make_main_export_plan: Callable[..., Any]
     _run_export_plans: Any = None
 
     def _begin_document_generation(self):
@@ -144,6 +147,79 @@ def test_export_writes_both_tracked_files(dialogs, mod_files):
     assert "TST_root" in mod_files.loc.read_text(encoding="utf-8-sig")
     assert len(dialogs.info) == 1
     assert dialogs.error == []
+
+
+def test_export_reprompts_for_targets_outside_loaded_mod(
+    dialogs, mod_files, monkeypatch
+):
+    outside_focus = mod_files.root.parent / "outside.txt"
+    outside_loc = mod_files.root.parent / "outside.yml"
+    outside_focus.write_text("user file\n", encoding="utf-8")
+    outside_loc.write_text("user file\n", encoding="utf-8")
+    chosen_focus = mod_files.root / "common" / "national_focus" / "new.txt"
+    prompts = []
+    monkeypatch.setattr(m.MOD, "edit_focus_file", str(outside_focus))
+    monkeypatch.setattr(m.MOD, "edit_loc_file", str(outside_loc))
+    monkeypatch.setattr(
+        m.filedialog,
+        "asksaveasfilename",
+        lambda **kwargs: prompts.append(kwargs) or str(chosen_focus),
+    )
+
+    app = _App([_focus("TST_root")])
+    _bind_export_shells(app)
+    plan = app._make_main_export_plan(
+        list(app.focuses.values()),
+        dict(app.focuses),
+        {"TST_root": next(iter(app.focuses.values()))},
+        show_dialog=False,
+    )
+
+    assert plan is not None
+    assert plan.focus_path == str(chosen_focus)
+    assert plan.loc_path == str(
+        mod_files.root / "localisation" / "english" / "TST_focus_l_english.yml"
+    )
+    assert len(prompts) == 1
+
+
+def test_extra_export_reprompts_without_a_mod_root(dialogs, mod_files, monkeypatch):
+    focus = _focus("TST_shared")
+    focus.tree_idx = 1
+    app = _App([focus])
+    app._extra_trees = [
+        {
+            "type": "shared",
+            "file_path": str(mod_files.focus),
+            "tree_id": "TST_shared_focuses",
+            "country_tag": "TST",
+            "country_raw": "",
+            "cfp_x": None,
+            "cfp_y": None,
+            "had_wrapper": False,
+        }
+    ]
+    chosen = mod_files.root / "new_shared.txt"
+    prompts = []
+    monkeypatch.setattr(m.MOD, "root", None)
+    monkeypatch.setattr(
+        m.filedialog,
+        "asksaveasfilename",
+        lambda **kwargs: prompts.append(kwargs) or str(chosen),
+    )
+
+    _bind_export_shells(app)
+    plan = app._make_extra_export_plan(
+        1,
+        [focus],
+        dict(app.focuses),
+        {focus.name: focus},
+        show_dialog=False,
+    )
+
+    assert plan is not None
+    assert plan.focus_path == str(chosen)
+    assert len(prompts) == 1
 
 
 def test_default_localisation_filename_is_generic(mod_files, monkeypatch):
@@ -326,6 +402,7 @@ def test_failed_extra_tree_export_keeps_the_source_file(dialogs, tmp_path, monke
         }
     ]
     monkeypatch.setattr(m.MOD, "loaded", False)
+    monkeypatch.setattr(m.MOD, "root", str(tmp_path))
     _fail_replace(monkeypatch)
 
     _export_extra_tree(app, 1)

--- a/tests/test_project_codec.py
+++ b/tests/test_project_codec.py
@@ -4,6 +4,7 @@ from hoi4cm.editor.project_codec import (
     decode_project,
     encode_project,
     read_project,
+    validate_project_file_path,
     write_project,
 )
 from hoi4cm.models import (
@@ -77,6 +78,49 @@ def test_legacy_decode_yields_empty_file_path():
     workspace = decode_project({"tree_name": "legacy_tree", "focuses": []})
 
     assert workspace.main_tree.file_path == ""
+
+
+def test_v2_decode_drops_absolute_file_paths(tmp_path):
+    project = {
+        "format": "hoi4cm-project",
+        "version": 2,
+        "workspace": {
+            "main_tree": {"file_path": str(tmp_path / "main.txt")},
+            "extra_trees": [{"file_path": str(tmp_path / "shared.txt")}],
+        },
+    }
+
+    workspace = decode_project(project)
+
+    assert workspace.main_tree.file_path == ""
+    assert workspace.extra_trees[0].file_path == ""
+
+
+def test_v2_decode_drops_parent_file_paths():
+    project = {
+        "format": "hoi4cm-project",
+        "version": 2,
+        "workspace": {
+            "main_tree": {"file_path": "C:\\outside.txt"},
+            "extra_trees": [{"file_path": "..\\outside.txt"}],
+        },
+    }
+
+    workspace = decode_project(project)
+
+    assert workspace.main_tree.file_path == ""
+    assert workspace.extra_trees[0].file_path == ""
+
+
+def test_validate_project_file_path_requires_containment(tmp_path):
+    base = tmp_path / "mod"
+    base.mkdir()
+
+    assert validate_project_file_path(str(tmp_path / "outside.txt"), base) == ""
+    relative = "common/national_focus/shared.txt"
+    expected = base / relative
+    assert validate_project_file_path(relative, base) == str(expected)
+    assert validate_project_file_path(str(expected), base) == str(expected)
 
 
 def test_v2_roundtrip_preserves_workspace_and_tree_metadata():


### PR DESCRIPTION
## Bottom line

Loaded project JSON can no longer aim Save All Trees at an arbitrary absolute path. Untrusted `file_path` values are dropped on decode, export re-prompts, and load warns.

Closes #155

## Why

A shared project could set `main_tree.file_path` to something like `/home/victim/.bashrc` and put a payload in `country_raw`. One Save All Trees click then overwrote that file.

## How

- `validate_project_file_path` rejects absolute paths, `..` segments, and anything that escapes the loaded mod root via `safe_join`.
- Decode stores `""` for those paths so `_install_workspace` does not clobber the current export target.
- Main, extra, and loc export reuse a stored path only when it stays inside `MOD.root`.

BLUF