### PR TITLE
Close ScanCache even when the final commit fails

### DIFF
--- a/src/hoi4cm/mod/scan_cache.py
+++ b/src/hoi4cm/mod/scan_cache.py
@@ -181,10 +181,14 @@ class ScanCache:
         if not self._conn:
             return
         try:
-            self._conn.commit()
-            self._conn.close()
-        except sqlite3.Error, OSError:
-            pass
+            try:
+                self._conn.commit()
+            except (sqlite3.Error, OSError) as exc:
+                _log.warning("scan cache commit failed: %s", exc)
+            try:
+                self._conn.close()
+            except sqlite3.Error, OSError:
+                pass
         finally:
             self._conn = None
 

--- a/tests/test_scan_cache.py
+++ b/tests/test_scan_cache.py
@@ -5,6 +5,7 @@ Each test points ``STATE_DIR`` at a tmp dir so nothing touches the real
 """
 
 import os
+import sqlite3
 
 import pytest
 
@@ -168,3 +169,28 @@ def test_get_many_skips_none_contribution(cache):
     cache.commit()
     assert cache.get_many("focus", {"/x/a.txt": (1.0, 1)}) == {}
     assert cache.get("focus", "/x/a.txt", 1.0, 1) is None
+
+
+def test_close_still_closes_when_commit_fails(cache, monkeypatch):
+    inner = cache._conn
+    assert inner is not None
+    logged = []
+
+    class BoomConn:
+        def commit(self):
+            raise sqlite3.Error("disk I/O error")
+
+        def close(self):
+            inner.close()
+
+    def capture(msg, *args, **_kwargs):
+        logged.append(msg % args if args else msg)
+
+    cache._conn = BoomConn()
+    monkeypatch.setattr(sc._log, "warning", capture)
+    cache.close()
+    assert cache._conn is None
+    with pytest.raises(sqlite3.ProgrammingError):
+        inner.execute("SELECT 1")
+    assert logged
+    assert "commit failed" in logged[0]


### PR DESCRIPTION
## Bottom line

`ScanCache.close` now closes the SQLite connection even if the final `commit()` raises, and logs that failure instead of swallowing it.

Closes #195

## Why

Commit and close shared one `try`, so a `sqlite3.Error` from commit skipped close and dropped the only reference. Buffered `put_many`/`prune` work then vanished with no log.

BLUF