### PR TITLE
Fix three test-suite hygiene defects

### DIFF
--- a/tests/test_sidebar_form.py
+++ b/tests/test_sidebar_form.py
@@ -4,7 +4,6 @@ A missed field in the match silently drops an edit when the user clicks
 another focus. The apply path must touch indexes only when name changes.
 """
 
-import time
 from unittest.mock import patch
 
 import pytest
@@ -303,36 +302,3 @@ def test_by_name_get_does_not_scan_all_focuses():
 
     assert got is selected
     assert visits["n"] == 0
-
-
-def test_select_away_hot_path_beats_full_rebuild_at_scale():
-    """1k matched checks and 10k by_name gets must beat full scans.
-
-    At Load All Trees scale the old path paid rebuild_indexes / name-map
-    rebuild per click. The dirty-check no-op and by_name view have to stay
-    cheaper than those full passes.
-    """
-    document, selected, values = _large_document(size=8_000)
-
-    t0 = time.perf_counter()
-    for _ in range(1_000):
-        assert sidebar_values_match_focus(selected, values)
-    match_s = time.perf_counter() - t0
-
-    t0 = time.perf_counter()
-    document.rebuild_indexes()
-    rebuild_s = time.perf_counter() - t0
-
-    t0 = time.perf_counter()
-    for _ in range(10_000):
-        assert document.by_name.get(selected.name) is selected
-    view_s = time.perf_counter() - t0
-
-    t0 = time.perf_counter()
-    for _ in range(10):
-        build_focus_name_lookup(document.values())
-    build_s = time.perf_counter() - t0
-
-    # Generous margins so CI load cannot flake this into a red build.
-    assert match_s < rebuild_s
-    assert view_s < build_s

--- a/tests/test_tk_finalizers.py
+++ b/tests/test_tk_finalizers.py
@@ -26,12 +26,16 @@ def _defer_cyclic_image(tk_root: tk.Misc, finalized_on: list[int]) -> None:
     del image, cycle
 
 
-def test_defer_tk_finalizer_until_fixture_teardown(tk_root):
+def test_deferred_tk_image_finalizes_on_main_collect(tk_root):
     finalized_on: list[int] = []
+    main_thread_id = threading.main_thread().ident
+    assert main_thread_id is not None
     gc.disable()
     try:
         _defer_cyclic_image(tk_root, finalized_on)
         assert finalized_on == []
+        gc.collect()
+        assert finalized_on == [main_thread_id]
     finally:
         gc.enable()
 
@@ -43,6 +47,7 @@ def test_worker_does_not_finalize_deferred_tk_image(tk_root):
     gc.disable()
     try:
         _defer_cyclic_image(tk_root, finalized_on)
+        assert finalized_on == []
         gc.collect()
         assert finalized_on == [main_thread_id]
 
@@ -53,7 +58,7 @@ def test_worker_does_not_finalize_deferred_tk_image(tk_root):
         finally:
             executor.shutdown()
 
-        assert worker_id != main_thread_id
         assert finalized_on == [main_thread_id]
+        assert worker_id != main_thread_id
     finally:
         gc.enable()

--- a/tests/test_tk_finalizers.py
+++ b/tests/test_tk_finalizers.py
@@ -8,28 +8,43 @@ import tkinter as tk
 
 from hoi4cm.core.concurrency import DaemonThreadPoolExecutor
 
-_FINALIZED_ON: list[int] = []
-
 
 class _TrackedPhotoImage(tk.PhotoImage):
+    _finalized_on: list[int] | None = None
+
     def __del__(self):
-        _FINALIZED_ON.append(threading.get_ident())
+        if self._finalized_on is not None:
+            self._finalized_on.append(threading.get_ident())
         super().__del__()
 
 
-def test_1_defer_tk_finalizer_until_fixture_teardown(tk_root):
-    gc.disable()
+def _defer_cyclic_image(tk_root: tk.Misc, finalized_on: list[int]) -> None:
     image = _TrackedPhotoImage(master=tk_root, width=1, height=1)
+    image._finalized_on = finalized_on
     cycle: list[object] = [image]
     cycle.append(cycle)
     del image, cycle
 
 
-def test_2_worker_does_not_finalize_deferred_tk_image(tk_root):
+def test_defer_tk_finalizer_until_fixture_teardown(tk_root):
+    finalized_on: list[int] = []
+    gc.disable()
     try:
-        main_thread_id = threading.main_thread().ident
-        assert main_thread_id is not None
-        assert _FINALIZED_ON == [main_thread_id]
+        _defer_cyclic_image(tk_root, finalized_on)
+        assert finalized_on == []
+    finally:
+        gc.enable()
+
+
+def test_worker_does_not_finalize_deferred_tk_image(tk_root):
+    finalized_on: list[int] = []
+    main_thread_id = threading.main_thread().ident
+    assert main_thread_id is not None
+    gc.disable()
+    try:
+        _defer_cyclic_image(tk_root, finalized_on)
+        gc.collect()
+        assert finalized_on == [main_thread_id]
 
         executor = DaemonThreadPoolExecutor(2, thread_name_prefix="tk-finalizer")
         try:
@@ -39,6 +54,6 @@ def test_2_worker_does_not_finalize_deferred_tk_image(tk_root):
             executor.shutdown()
 
         assert worker_id != main_thread_id
-        assert _FINALIZED_ON == [main_thread_id]
+        assert finalized_on == [main_thread_id]
     finally:
         gc.enable()

--- a/tests/test_workspace_cache.py
+++ b/tests/test_workspace_cache.py
@@ -121,16 +121,25 @@ def test_store_non_jsonable_degrades_without_raising(tmp_path, monkeypatch):
     )
 
 
-def test_store_load_does_not_leak_connection(cache):
-    import gc
-    import warnings
+def test_store_load_does_not_leak_connection(cache, monkeypatch):
+    import sqlite3
 
+    connections: list[sqlite3.Connection] = []
+    original_connect = cache._connect
+
+    def tracking_connect() -> sqlite3.Connection:
+        connection = original_connect()
+        connections.append(connection)
+        return connection
+
+    monkeypatch.setattr(cache, "_connect", tracking_connect)
     cache.store_graphics(
         {"a": 1}, schema_version=1, root_identity="root-1", config_fingerprint="fp"
     )
     cache.load_graphics(
         schema_version=1, root_identity="root-1", config_fingerprint="fp"
     )
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", ResourceWarning)
-        gc.collect()
+    assert connections
+    for connection in connections:
+        with pytest.raises(sqlite3.ProgrammingError):
+            connection.execute("SELECT 1")


### PR DESCRIPTION
## Bottom line

The workspace-cache leak test now asserts connections are closed, Tk finalizer tests no longer share GC state or declaration order, and the sidebar-form wall-clock comparison is gone.

Closes #218

## Why

The leak test had no assertion and would stay green if a connection leaked. One Tk test left `gc.disable()` on and the next depended on it. The sidebar timing test could flake under CI load.

BLUF