### PR TITLE
Don't overwrite loc or gfx when dyn-mod save cannot read them

### DIFF
--- a/src/hoi4cm/wizards/dyn_mod.py
+++ b/src/hoi4cm/wizards/dyn_mod.py
@@ -1105,16 +1105,6 @@ def open_dyn_mod_wizard(app):
         def full(rel):
             return os.path.join(mod_root, rel)
 
-        def read_existing_text(rel, encoding="utf-8-sig"):
-            p = full(rel)
-            if not os.path.exists(p):
-                return None
-            try:
-                with open(p, encoding=encoding, errors="replace") as f:
-                    return f.read()
-            except OSError, UnicodeDecodeError, ValueError:
-                return None
-
         def record_read_error(rel):
             message = f"Could not read existing file: {rel}"
             add_error(message)
@@ -1231,7 +1221,7 @@ def open_dyn_mod_wizard(app):
                 loc_target.dirname(),
                 loc_target.filename(mid),
             )
-        loc_existing = read_existing_text(loc_rel, "utf-8-sig")
+        loc_state, loc_existing = _read_existing_file(full(loc_rel))
 
         new_loc_lines = []
 
@@ -1247,21 +1237,28 @@ def open_dyn_mod_wizard(app):
                 add_loc(tooltip, modifier.replace("_", " ").title())
 
         if new_loc_lines:
-            if loc_existing is None:
-                loc_final = loc_target.header() + "\n" + "\n".join(new_loc_lines) + "\n"
-                loc_action = "created"
+            if loc_state == _READ_FAILED:
+                record_read_error(loc_rel)
             else:
-                # Append after last non-empty line, preserving file
-                loc_final = (
-                    loc_existing.rstrip()
-                    + "\n\n"
-                    + f" # {mid} — added by Focus Maker\n"
-                    + "\n".join(new_loc_lines)
-                    + "\n"
-                )
-                loc_action = f"appended {len(new_loc_lines)} new keys"
-            if write(loc_rel, loc_final, "utf-8-sig"):
-                results.append((loc_rel, loc_action, f"{len(new_loc_lines)} loc keys"))
+                if loc_state == _READ_MISSING:
+                    loc_final = (
+                        loc_target.header() + "\n" + "\n".join(new_loc_lines) + "\n"
+                    )
+                    loc_action = "created"
+                else:
+                    loc_existing = loc_existing or ""
+                    loc_final = (
+                        loc_existing.rstrip()
+                        + "\n\n"
+                        + f" # {mid} — added by Focus Maker\n"
+                        + "\n".join(new_loc_lines)
+                        + "\n"
+                    )
+                    loc_action = f"appended {len(new_loc_lines)} new keys"
+                if write(loc_rel, loc_final, "utf-8-sig"):
+                    results.append(
+                        (loc_rel, loc_action, f"{len(new_loc_lines)} loc keys")
+                    )
         else:
             results.append((loc_rel, "skipped", "all keys already exist"))
 
@@ -1301,23 +1298,28 @@ def open_dyn_mod_wizard(app):
         if icon_gfx:
             icon_name = icon_gfx.replace("GFX_idea_", "").replace("GFX_", "")
             gfx_rel = os.path.join("interface", "ideas.gfx")
-            gfx_existing = read_existing_text(gfx_rel)
-            gfx_final, added_count = append_sprite_types(
-                gfx_existing,
-                [(icon_gfx, f"gfx/interface/ideas/{icon_name}.dds")],
-            )
-            if added_count:
-                gfx_action = "created" if gfx_existing is None else "appended sprite"
-                if write(gfx_rel, gfx_final):
-                    results.append(
-                        (
-                            gfx_rel,
-                            gfx_action,
-                            f"icon: {icon_gfx} → gfx/interface/ideas/{icon_name}.dds",
-                        )
-                    )
+            gfx_state, gfx_existing = _read_existing_file(full(gfx_rel))
+            if gfx_state == _READ_FAILED:
+                record_read_error(gfx_rel)
             else:
-                results.append((gfx_rel, "skipped (icon already defined)", ""))
+                gfx_final, added_count = append_sprite_types(
+                    gfx_existing,
+                    [(icon_gfx, f"gfx/interface/ideas/{icon_name}.dds")],
+                )
+                if added_count:
+                    gfx_action = (
+                        "created" if gfx_existing is None else "appended sprite"
+                    )
+                    if write(gfx_rel, gfx_final):
+                        results.append(
+                            (
+                                gfx_rel,
+                                gfx_action,
+                                f"icon: {icon_gfx} → gfx/interface/ideas/{icon_name}.dds",
+                            )
+                        )
+                else:
+                    results.append((gfx_rel, "skipped (icon already defined)", ""))
 
         # ── Summary ───────────────────────────────────────────
         if errors:

--- a/src/hoi4cm/wizards/dyn_mod.py
+++ b/src/hoi4cm/wizards/dyn_mod.py
@@ -1236,29 +1236,24 @@ def open_dyn_mod_wizard(app):
             if tooltip:
                 add_loc(tooltip, modifier.replace("_", " ").title())
 
-        if new_loc_lines:
-            if loc_state == _READ_FAILED:
-                record_read_error(loc_rel)
+        if loc_state == _READ_FAILED:
+            record_read_error(loc_rel)
+        elif new_loc_lines:
+            if loc_state == _READ_MISSING:
+                loc_final = loc_target.header() + "\n" + "\n".join(new_loc_lines) + "\n"
+                loc_action = "created"
             else:
-                if loc_state == _READ_MISSING:
-                    loc_final = (
-                        loc_target.header() + "\n" + "\n".join(new_loc_lines) + "\n"
-                    )
-                    loc_action = "created"
-                else:
-                    loc_existing = loc_existing or ""
-                    loc_final = (
-                        loc_existing.rstrip()
-                        + "\n\n"
-                        + f" # {mid} — added by Focus Maker\n"
-                        + "\n".join(new_loc_lines)
-                        + "\n"
-                    )
-                    loc_action = f"appended {len(new_loc_lines)} new keys"
-                if write(loc_rel, loc_final, "utf-8-sig"):
-                    results.append(
-                        (loc_rel, loc_action, f"{len(new_loc_lines)} loc keys")
-                    )
+                loc_existing = loc_existing or ""
+                loc_final = (
+                    loc_existing.rstrip()
+                    + "\n\n"
+                    + f" # {mid} — added by Focus Maker\n"
+                    + "\n".join(new_loc_lines)
+                    + "\n"
+                )
+                loc_action = f"appended {len(new_loc_lines)} new keys"
+            if write(loc_rel, loc_final, "utf-8-sig"):
+                results.append((loc_rel, loc_action, f"{len(new_loc_lines)} loc keys"))
         else:
             results.append((loc_rel, "skipped", "all keys already exist"))
 

--- a/tests/test_dyn_mod_save.py
+++ b/tests/test_dyn_mod_save.py
@@ -157,6 +157,41 @@ def test_save_skips_unreadable_loc(
     assert dm_target.exists()
 
 
+def test_save_reports_unreadable_loc_when_keys_already_exist(
+    tmp_path, monkeypatch, tk_root, isolated_error_buffer
+):
+    loc_rel = _loc_rel()
+    target = tmp_path / loc_rel
+    target.parent.mkdir(parents=True)
+    original = b"l_english:\n existing loc bytes\n"
+    target.write_bytes(original)
+    _unread_paths(monkeypatch, target)
+
+    other = (
+        tmp_path
+        / "localisation"
+        / dm_mod.MOD.loc_target.dirname()
+        / "existing_keys_l_english.yml"
+    )
+    other.write_text(
+        "l_english:\n"
+        ' TAG_my_dynamic_modifier: "Name"\n'
+        ' TAG_my_dynamic_modifier_desc: "Desc"\n'
+        ' modifies_dynamic_modifier_tt: "Modifies $MODIFIER$"\n'
+        ' stability_factor_tt: "Stability Factor"\n'
+        ' industrial_capacity_factory_tt: "Industrial Capacity Factory"\n'
+        ' political_power_gain_tt: "Political Power Gain"\n',
+        encoding="utf-8-sig",
+    )
+
+    _, info_messages = _open_and_save(tk_root, tmp_path, monkeypatch)
+
+    assert target.read_bytes() == original
+    _assert_read_error(loc_rel)
+    summary = "\n".join(str(arg) for call in info_messages for arg in call)
+    assert loc_rel not in summary
+
+
 def test_save_skips_unreadable_ideas_gfx(
     tmp_path, monkeypatch, tk_root, isolated_error_buffer
 ):

--- a/tests/test_dyn_mod_save.py
+++ b/tests/test_dyn_mod_save.py
@@ -1,5 +1,6 @@
 """Dynamic-modifier save-path regression tests."""
 
+import os
 import tkinter as tk
 
 import pytest
@@ -7,6 +8,43 @@ import pytest
 import hoi4cm.core.logger as logmod
 import hoi4cm.wizards.dyn_mod as dm_mod
 from hoi4cm.wizards.dyn_mod import open_dyn_mod_wizard
+
+_DEFAULT_MID = "TAG_my_dynamic_modifier"
+_GFX_REL = os.path.join("interface", "ideas.gfx")
+
+
+def _loc_rel(mid=_DEFAULT_MID):
+    loc_target = dm_mod.MOD.loc_target
+    return os.path.join("localisation", loc_target.dirname(), loc_target.filename(mid))
+
+
+def _unread_paths(monkeypatch, *paths):
+    unread = {os.path.abspath(str(path)) for path in paths}
+    original = dm_mod.read_file
+
+    def stub(path, *args, **kwargs):
+        if os.path.abspath(path) in unread:
+            return None
+        return original(path, *args, **kwargs)
+
+    monkeypatch.setattr(dm_mod, "read_file", stub)
+
+
+def _set_icon(window, value):
+    pending = [window]
+    while pending:
+        current = pending.pop()
+        if isinstance(current, tk.Entry) and current.get() == "":
+            current.insert(0, value)
+            return
+        pending.extend(current.winfo_children())
+    raise AssertionError("dynamic-modifier icon entry not found")
+
+
+def _assert_read_error(rel):
+    entries = logmod.get_error_entries()
+    assert any("Could not read existing file" in message for _, message in entries)
+    assert any(rel in message for _, message in entries)
 
 
 @pytest.fixture
@@ -35,7 +73,7 @@ def _save_button(window):
     raise AssertionError("dynamic-modifier save button not found")
 
 
-def _open_and_save(tk_root, tmp_path, monkeypatch):
+def _open_and_save(tk_root, tmp_path, monkeypatch, icon=None):
     info_messages = []
     monkeypatch.setattr(dm_mod.filedialog, "askdirectory", lambda **_: str(tmp_path))
     monkeypatch.setattr(
@@ -49,6 +87,8 @@ def _open_and_save(tk_root, tmp_path, monkeypatch):
     window = next(
         child for child in tk_root.winfo_children() if isinstance(child, tk.Toplevel)
     )
+    if icon is not None:
+        _set_icon(window, icon)
     _save_button(window).invoke()
     return window, info_messages
 
@@ -95,3 +135,57 @@ def test_save_creates_missing_dynamic_modifier(tmp_path, monkeypatch, tk_root):
     target = tmp_path / "common" / "dynamic_modifiers" / "TAG_my_dynamic_modifier.txt"
     assert target.exists()
     assert b"TAG_my_dynamic_modifier = {" in target.read_bytes()
+
+
+def test_save_skips_unreadable_loc(
+    tmp_path, monkeypatch, tk_root, isolated_error_buffer
+):
+    loc_rel = _loc_rel()
+    target = tmp_path / loc_rel
+    target.parent.mkdir(parents=True)
+    original = b"l_english:\n existing loc bytes\n"
+    target.write_bytes(original)
+    _unread_paths(monkeypatch, target)
+
+    _, info_messages = _open_and_save(tk_root, tmp_path, monkeypatch)
+
+    assert target.read_bytes() == original
+    _assert_read_error(loc_rel)
+    summary = "\n".join(str(arg) for call in info_messages for arg in call)
+    assert loc_rel not in summary
+    dm_target = tmp_path / "common" / "dynamic_modifiers" / f"{_DEFAULT_MID}.txt"
+    assert dm_target.exists()
+
+
+def test_save_skips_unreadable_ideas_gfx(
+    tmp_path, monkeypatch, tk_root, isolated_error_buffer
+):
+    target = tmp_path / _GFX_REL
+    target.parent.mkdir(parents=True)
+    original = b"spriteTypes = {\n existing gfx bytes\n}\n"
+    target.write_bytes(original)
+    _unread_paths(monkeypatch, target)
+
+    _, info_messages = _open_and_save(tk_root, tmp_path, monkeypatch, icon="my_icon")
+
+    assert target.read_bytes() == original
+    _assert_read_error(_GFX_REL)
+    summary = "\n".join(str(arg) for call in info_messages for arg in call)
+    assert _GFX_REL not in summary
+    loc_target = tmp_path / _loc_rel()
+    assert loc_target.exists()
+
+
+def test_save_creates_missing_loc_and_gfx(tmp_path, monkeypatch, tk_root):
+    _open_and_save(tk_root, tmp_path, monkeypatch, icon="my_icon")
+
+    loc_target = tmp_path / _loc_rel()
+    assert loc_target.exists()
+    loc_text = loc_target.read_text(encoding="utf-8-sig")
+    assert f" {_DEFAULT_MID}:" in loc_text
+
+    gfx_target = tmp_path / _GFX_REL
+    assert gfx_target.exists()
+    gfx_text = gfx_target.read_text(encoding="utf-8")
+    assert "GFX_idea_my_icon" in gfx_text
+    assert "spriteTypes" in gfx_text


### PR DESCRIPTION
## Bottom line

Dynamic-modifier save now treats an unreadable loc file or `ideas.gfx` as a read failure, reports it, and leaves the existing bytes alone. Missing files still create.

Closes #233

## Why

#210 already did this for the definition file. Loc and gfx still treated a failed read as missing and wrote a fresh copy.

BLUF