### PR TITLE
Automate pre-release and release publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Mypy
         run: mypy
       - name: Pylint
-        run: pylint src/hoi4cm tests
+        run: pylint src/hoi4cm tests scripts
 
   test:
     runs-on: ubuntu-latest
@@ -125,11 +125,32 @@ jobs:
 
   release:
     needs: build
-    if: startsWith(github.ref, 'refs/tags/v')
+    # `-pre.` tags belong to pre-release.yml, which publishes them itself. They
+    # are skipped here so a pre-release can never go out as a full release.
+    if: >
+      startsWith(github.ref, 'refs/tags/v')
+      && !contains(github.ref_name, '-pre.')
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        # v5.6.0
+        with:
+          python-version: "3.14"
+
+      # Releases live on the even minors; the odd minor above each one is the
+      # pre-release line. Fail rather than publish a hand-pushed tag that lands
+      # on it.
+      - name: Check the release tag
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: python scripts/versioning.py check-release-tag "$RELEASE_TAG"
+
       - name: Download all artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         # v4.3.0

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,139 @@
+name: Pre-release
+
+# Every push to main becomes a GitHub prerelease carrying the three binaries.
+# The version is the odd minor above the current stable one, with the Actions
+# run number as the patch; see prerelease_identity in scripts/versioning.py.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Least privilege: read by default. Only `publish` gets write, and it uses the
+# automatic GITHUB_TOKEN — a tag created with it starts no workflow, which is
+# what keeps a pre-release out of ci.yml's v* release path.
+permissions:
+  contents: read
+
+# Unlike a release, a superseded pre-release build is worth cancelling: only
+# the newest commit on main needs publishing.
+concurrency:
+  group: pre-release
+  cancel-in-progress: true
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.identity.outputs.version }}
+      tag: ${{ steps.identity.outputs.tag }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        # v5.6.0
+        with:
+          python-version: "3.14"
+      # Fails the run when the project sits on an odd minor, rather than
+      # publishing a pre-release into the stable line.
+      - name: Resolve the pre-release identity
+        id: identity
+        run: python scripts/versioning.py prerelease-identity >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: version
+    strategy:
+      # One platform breaking shouldn't hide whether the other two are fine.
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            artifact_name: HOI4ContentMaker.exe
+          - os: macos-latest
+            artifact_name: HOI4ContentMaker-mac
+          - os: ubuntu-latest
+            artifact_name: HOI4ContentMaker-linux
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        # v5.6.0
+        with:
+          python-version: "3.14"
+
+      - name: Install tkinter (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y python3-tk
+
+      - name: Install build dependencies
+        run: pip install --require-hashes -r build/requirements.txt
+
+      - name: Build executable
+        run: python build/build.py
+
+      - name: Make executable (Linux/macOS)
+        if: runner.os != 'Windows'
+        run: chmod +x "${{ matrix.artifact_name }}"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        # v4.6.2
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: ${{ matrix.artifact_name }}
+
+  publish:
+    needs: [version, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        # v4.3.0
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Checksum the binaries
+        working-directory: artifacts
+        run: >
+          sha256sum HOI4ContentMaker.exe HOI4ContentMaker-mac
+          HOI4ContentMaker-linux > SHA256SUMS.txt
+
+      - name: Publish the GitHub prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.version.outputs.tag }}
+          VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          gh release create "$TAG" \
+            artifacts/HOI4ContentMaker.exe \
+            artifacts/HOI4ContentMaker-mac \
+            artifacts/HOI4ContentMaker-linux \
+            artifacts/SHA256SUMS.txt \
+            --target "$GITHUB_SHA" \
+            --title "Pre-release $VERSION" \
+            --prerelease \
+            --notes-file - <<EOF
+          Automated pre-release build from commit \`$GITHUB_SHA\`.
+
+          ### Downloads
+          | Platform | File |
+          |----------|------|
+          | Windows | \`HOI4ContentMaker.exe\` |
+          | macOS | \`HOI4ContentMaker-mac\` |
+          | Linux | \`HOI4ContentMaker-linux\` |
+
+          Pre-releases take the odd minor above the current stable version, so
+          \`$VERSION\` is a build of what will become the next stable release.
+          They are test builds and may break — use a tagged release if you want
+          something stable.
+
+          \`SHA256SUMS.txt\` has the SHA-256 of each binary; verify the same way
+          as a full release.
+          EOF

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,0 +1,124 @@
+name: Release PR
+
+# Keeps a release pull request open against main. Every push to main
+# regenerates release/version-bump from origin/main: the changelog's
+# `## Unreleased` section becomes a dated version heading and every version
+# source in the repo moves to match. Merging that pull request is what cuts a
+# release — tag-release.yml takes it from there.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: "Which part of the version to bump"
+        type: choice
+        options: [patch, minor, major]
+        default: patch
+
+permissions:
+  contents: read
+
+# Never cancel: two runs racing would fight over the same branch.
+concurrency:
+  group: release-pull-request
+  cancel-in-progress: false
+
+jobs:
+  release-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      BRANCH: release/version-bump
+      BUMP: ${{ inputs.release_type || 'patch' }}
+      # `secrets` is not usable in a job-level `if`, so the guard rides on an
+      # env value the steps below can read.
+      HAS_APP: ${{ secrets.RELEASE_PR_APP_ID != '' }}
+    steps:
+      # A pull request opened with GITHUB_TOKEN triggers no workflow, so CI
+      # would never run against it. An App installation token does trigger
+      # workflows, and unlike a PAT it leaves no person as the author of the
+      # release pull request. continue-on-error keeps a missing or misconfigured
+      # App from breaking main: every consumer below falls back to
+      # github.token, which still opens the pull request.
+      - name: Mint a GitHub App token
+        id: app-token
+        if: ${{ env.HAS_APP == 'true' }}
+        continue-on-error: true
+        # v3.2.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        with:
+          app-id: ${{ secrets.RELEASE_PR_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PR_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+          # Credentials are kept on purpose: this job pushes the release branch.
+          token: ${{ steps.app-token.outputs.token || github.token }}
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        # v5.6.0
+        with:
+          python-version: "3.14"
+
+      # The branch is regenerated from origin/main on every push rather than
+      # merged forward, so the edit is always the same mechanical rewrite and
+      # nothing can conflict. Hand edits pushed to it are discarded; fixes
+      # belong in main's `## Unreleased`.
+      - name: Prepare the release commit
+        id: prepare
+        run: |
+          git checkout -B "$BRANCH" origin/main
+          python scripts/release_pr.py --bump "$BUMP" >> "$GITHUB_OUTPUT"
+
+      - name: Push the release branch
+        if: ${{ steps.prepare.outputs.release == 'true' }}
+        env:
+          VERSION: ${{ steps.prepare.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email \
+            "41898282+github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md pyproject.toml src/hoi4cm/__init__.py \
+            build/version_info.txt README.md
+          git commit -m "Release $VERSION"
+          git push --force origin "$BRANCH"
+
+      - name: Open or update the release pull request
+        if: ${{ steps.prepare.outputs.release == 'true' }}
+        env:
+          VERSION: ${{ steps.prepare.outputs.version }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+        run: |
+          title="Release $VERSION"
+          body_file="$RUNNER_TEMP/release-pr-body.md"
+          {
+            echo "Promotes the changelog's \`## Unreleased\` section to"
+            echo "\`## [$VERSION]\` and moves every version source in the repo"
+            echo "to the same version."
+            echo
+            echo "Merging this pull request cuts the release:"
+            echo "\`tag-release.yml\` pushes \`v$VERSION\`, which runs the full"
+            echo "CI gate and publishes the three binaries to Releases."
+            echo
+            echo "This branch is regenerated from \`main\` on every push, so"
+            echo "edits made here are discarded. Correct the release notes in"
+            echo "\`main\`'s \`## Unreleased\` section instead."
+            echo
+            echo "Bump: \`$BUMP\`. Re-run \`release-pr.yml\` with a different"
+            echo "\`release_type\` to change it."
+          } > "$body_file"
+          number=$(gh pr list --repo "$REPO" --head "$BRANCH" --state open \
+            --json number --jq '.[0].number // empty')
+          if [ -n "$number" ]; then
+            gh pr edit "$number" --repo "$REPO" \
+              --title "$title" --body-file "$body_file"
+          else
+            gh pr create --repo "$REPO" --base main --head "$BRANCH" \
+              --title "$title" --body-file "$body_file"
+          fi

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,81 @@
+name: Tag release
+
+# Cuts the release once the release pull request lands. Fires on every push to
+# main and does nothing unless pyproject.toml's version matches the top
+# changelog heading and no tag for it exists yet — which is only true of the
+# commit that merged release-pr.yml's branch.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tag-release
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      HAS_APP: ${{ secrets.RELEASE_PR_APP_ID != '' }}
+    steps:
+      # The tag is pushed with the App token on purpose. A tag pushed with
+      # GITHUB_TOKEN starts no workflow, so ci.yml's v* release job would never
+      # run and the release would never publish. continue-on-error keeps a
+      # missing App from breaking main; the fallback still pushes the tag, it
+      # just won't trigger the release, which is then a one-click re-run.
+      - name: Mint a GitHub App token
+        id: app-token
+        if: ${{ env.HAS_APP == 'true' }}
+        continue-on-error: true
+        # v3.2.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        with:
+          app-id: ${{ secrets.RELEASE_PR_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PR_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          # Full history so the existing tags are present to check against.
+          # Credentials are kept on purpose: this job pushes the release tag.
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token || github.token }}
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        # v5.6.0
+        with:
+          python-version: "3.14"
+
+      - name: Check whether this push cut a release
+        id: check
+        run: |
+          version=$(python scripts/versioning.py project-version \
+            | sed -n 's/^version=//p')
+          top=$(grep -m1 -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md \
+            | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          echo "project=$version changelog=$top"
+          if [ "$version" != "$top" ]; then
+            echo "Project and changelog disagree; not a release commit."
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if git rev-parse -q --verify "refs/tags/v$version" >/dev/null; then
+            echo "Tag v$version already exists; nothing to cut."
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "release=true" >> "$GITHUB_OUTPUT"
+          echo "tag=v$version" >> "$GITHUB_OUTPUT"
+
+      - name: Push the release tag
+        if: ${{ steps.check.outputs.release == 'true' }}
+        env:
+          TAG: ${{ steps.check.outputs.tag }}
+        run: |
+          git tag "$TAG"
+          git push origin "$TAG"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ pytest tests/test_config.py::test_cfg_save_merges_existing_keys   # single test
 ruff check .                    # lint
 black --check .                 # formatting
 mypy                            # type check (src/hoi4cm + tests)
-pylint src/hoi4cm tests         # lint (light gate on top of ruff/black)
+pylint src/hoi4cm tests scripts # lint (light gate on top of ruff/black)
 pre-commit run --all-files      # run all hooks once
 pre-commit install              # run hooks on every commit
 
@@ -36,13 +36,14 @@ CI runs ruff, black, mypy, pylint and pytest, all on 3.14 (the project's floor).
 
 - **`hoi4_content_maker.py`** — the launch point and (still) most of the app: `App(tk.Tk)`, its Tk-shell methods and one-line delegates into extracted modules, and the deferred sidebar form. Entry point at the bottom calls `show_splash(_launch)`.
 - **`src/hoi4cm/`** — the extracted package, organized by domain: `core/` (logger, config, paths, undo, i18n, concurrency, safe file/xml helpers), `models/` (`Focus`, `FocusDocument`, `EditorWorkspace`), `focus_tree/` (parse/build/export, codec, operations, drawio, loc), `ui/` (canvas, splash, menubar, toolbar, settings dialog, gfx browser, image pipeline), `wizards/` (the five authoring wizards + shared helpers), `mod/` (mod context, GFX catalog, scan/workspace caches), `script/` (effects + syntax), `editor/` (project save/load), `data/` (effect/modifier tables). New modules land in the owning subpackage, not a catch-all.
+- **`scripts/`** — release tooling the workflows call: `versioning.py` (version arithmetic for both channels, and the table of every file that states the version) and `release_pr.py` (promotes `## Unreleased`). Linted and type-checked like packaged code, and tested under `tests/`. Not shipped in the executable — `build/` is the PyInstaller side.
 - **`docs/dev/`**: developer docs, architecture, migration status, performance, testing, wizards. Start at `docs/dev/README.md`. They carry a maintenance rule: any PR that changes architecture, hot paths, or migration status updates the matching doc in the same PR.
 
 The monolith inserts `src/` onto `sys.path` at startup and imports canonical names straight from the `hoi4cm.core` facade (`from hoi4cm.core import (...)`), which re-exports the public names of every subpackage (data, focus_tree, models, ui, ...). There's no underscore-aliasing layer left. When you extract a new module, add the public name to the owning subpackage's `__all__`, and to `core/__init__.py`'s import list and `__all__` if the monolith or a wizard needs it via the facade. Details in `docs/dev/architecture.md`.
 
 ## Conventions
 
-- **Lint scope:** Ruff (`E,F,W,I,UP,B`) and Black (line-length 88) cover all Python except `build/`; mypy and pylint cover `src/hoi4cm/` and `tests/` only. Packaged code must pass all four; the monolith must pass Ruff and Black. Config lives in `pyproject.toml` (`[tool.ruff]`, `[tool.black]`, `[tool.mypy]`, `[tool.pylint]`); `.pre-commit-config.yaml` wires them into pre-commit. Pylint's `disable` list is deliberate: it drops checks Ruff/Black already cover and false positives on Tk/dataclass/mixin patterns, so it stays a light gate.
+- **Lint scope:** Ruff (`E,F,W,I,UP,B`) and Black (line-length 88) cover all Python except `build/`; mypy and pylint cover `src/hoi4cm/`, `tests/` and `scripts/` only. Packaged code must pass all four; the monolith must pass Ruff and Black. Config lives in `pyproject.toml` (`[tool.ruff]`, `[tool.black]`, `[tool.mypy]`, `[tool.pylint]`); `.pre-commit-config.yaml` wires them into pre-commit. Pylint's `disable` list is deliberate: it drops checks Ruff/Black already cover and false positives on Tk/dataclass/mixin patterns, so it stays a light gate.
 - **Logging, not print.** `get_logger("name")` for a `HOI4CM.<name>` child. User-facing errors go through `add_error()` so they reach the in-app error log.
 - **Tolerant file reads.** Mod files have mixed encodings — read them via `read_file`, never bare `open(...).read()`.
 - **Preserve user data on round-trips.** Parse→export of an existing file must not drop fields. Test round-trips when touching the parser or exporters.
@@ -51,4 +52,14 @@ The monolith inserts `src/` onto `sys.path` at startup and imports canonical nam
 
 ## Releases
 
-`ci.yml` is the only workflow. Every push and PR runs lint, test, then the Win/macOS/Linux build matrix. Pushing a tag matching `v*` runs that same gate and adds the `release` job, which publishes a Release with the three binaries and a `SHA256SUMS.txt` attached; the version is the tag name (`github.ref_name`). Executables are never committed. Build deps are hash-pinned in `build/requirements.txt`, regenerated with `uv pip compile --generate-hashes --universal --extra build pyproject.toml -o build/requirements.txt`.
+**Never bump the version and never add a version heading to `CHANGELOG.md` by hand.** On a branch, add your bullets under `## Unreleased`; the release pull request does the rest. `pyproject.toml`'s `version` is the single source of truth, and `scripts/release_pr.py` writes it, `src/hoi4cm/__init__.py`, `build/version_info.txt` and the README badge together — a test asserts all four agree, so moving one alone fails CI.
+
+Publishing runs on two channels, neither of them from a developer's machine.
+
+**Pre-release.** Every push to `main` publishes a GitHub prerelease with the three binaries and a `SHA256SUMS.txt` (`.github/workflows/pre-release.yml`). Stable takes the even minors and pre-release the odd minor directly above, with the Actions run number as the patch: with stable at `0.4.1`, pre-releases are `0.5.<run>` (`prerelease_identity` in `scripts/versioning.py`). Only the Git tag carries the `-pre.<attempt>` suffix.
+
+**Release.** `.github/workflows/release-pr.yml` regenerates `release/version-bump` from `origin/main` on every push, where `scripts/release_pr.py` promotes `## Unreleased` to `## [x.y.z] — <date>` and moves the version sources. That branch is force-pushed, so edits made on it are discarded — fix release notes in `main`'s `## Unreleased`. Merging it makes `.github/workflows/tag-release.yml` push `v<x.y.z>`, which triggers `ci.yml`'s `release` job for the build and publish. Releases stay on even minors, so a minor bump goes `0.4.x` → `0.6.0`; `ci.yml` rejects a tag on the odd pre-release line and skips any `-pre.` tag. Run `release-pr.yml` by hand with `release_type` to make it a minor or major.
+
+Both the release PR and the release tag are pushed with a GitHub App token (`melon-release-bot`, secrets `RELEASE_PR_APP_ID` / `RELEASE_PR_APP_PRIVATE_KEY`), because a pull request or tag created with `GITHUB_TOKEN` triggers no workflow. Each mint step is guarded and `continue-on-error`, falling back to `github.token` — the PR still opens and the tag still pushes, they just won't trigger CI on themselves.
+
+`ci.yml` still runs lint, test, then the Win/macOS/Linux build matrix on every push and PR. Executables are never committed. Build deps are hash-pinned in `build/requirements.txt`, regenerated with `uv pip compile --generate-hashes --universal --extra build pyproject.toml -o build/requirements.txt`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # HOI4 Content Maker — Changelog
 
+Add entries for unreleased work under `## Unreleased`. The release pull request
+promotes that section to a dated version heading — don't add version headings or bump
+the version by hand. See `AGENTS.md`.
+
+---
+
+## Unreleased
+
+### Automated pre-release and release publishing
+
+**[ENHANCEMENT] Two publishing channels, neither run from a developer's machine**
+
+- Every push to `main` now publishes a GitHub prerelease with the Windows, macOS and
+  Linux binaries and a `SHA256SUMS.txt` (`.github/workflows/pre-release.yml`), so a fix
+  is installable without waiting for the next tag. It has its own concurrency group
+  with `cancel-in-progress: true` — a superseded pre-release build is worth cancelling,
+  unlike a release.
+- Versions follow VS Code's channel convention: stable takes the even minors and
+  pre-release the odd minor directly above, with the Actions run number as the patch,
+  so stable `0.4.1` gives pre-releases `0.5.<run>`. Only the Git tag carries the
+  `-pre.<attempt>` suffix. A pre-release build fails loudly rather than publishing into
+  the stable line if the project ever sits on an odd minor.
+- Releases are now cut by merging a pull request instead of pushing a tag by hand.
+  `release-pr.yml` regenerates `release/version-bump` from `origin/main` on every push,
+  where `scripts/release_pr.py` promotes the changelog's `## Unreleased` section to a
+  dated version heading and moves every version source to match. Merging it makes
+  `tag-release.yml` push `v<version>`, which runs the full CI gate and publishes.
+  A minor release skips the odd pre-release line, so `0.4.x` goes to `0.6.0`.
+- `pyproject.toml` is now the single source of truth for the version, seeded to the
+  last shipped tag (`0.4.1`). It had drifted to `0.1.0` while `src/hoi4cm/__init__.py`
+  said `0.1.0`, `build/version_info.txt` said `2.0.0.0` and the README badge said
+  `2.0` — four values, none of them the shipped one. All four are written together
+  now, and a test asserts they agree, so the Windows `.exe` finally reports a truthful
+  version.
+- `ci.yml`'s release job skips any tag carrying `-pre.` and rejects a tag on an odd
+  minor, so a pre-release can never go out as a full release.
+
 ---
 
 ## Application Modernization — Python Floor Raised to 3.14

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![Python](https://img.shields.io/badge/Python-3.14%2B-blue?logo=python)
 ![Platform](https://img.shields.io/badge/Platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey)
 [![License: CC BY-ND 4.0](https://img.shields.io/badge/License-CC_BY--ND_4.0-blue)](LICENSE)
-![Version](https://img.shields.io/badge/Version-2.0-gold)
+![Version](https://img.shields.io/badge/Version-0.4.1-gold)
 
 ---
 
@@ -84,6 +84,17 @@ Just download and run — no Python installation required.
 > are attached to the [Releases](../../releases) page along with a `SHA256SUMS.txt` you
 > can check them against.
 
+### Pre-release builds
+
+Every push to `main` is published as a GitHub prerelease
+(`.github/workflows/pre-release.yml`) carrying the same three binaries and a
+`SHA256SUMS.txt`. Pick one from the [Releases](../../releases) page if you want a fix
+before the next tagged release — they are marked *Pre-release* there.
+
+Pre-releases take the odd minor above the current stable version, so `0.5.x` is the
+pre-release line for stable `0.4.x` and the patch number is the CI run. They are test
+builds and may break; use a tagged release if you want something stable.
+
 ### Option 2: Run from source
 
 ```bash
@@ -116,7 +127,11 @@ code except the build scripts.
 
 CI runs the same checks on every pull request, then builds the three executables
 (`.github/workflows/ci.yml`). A `v*` tag runs that whole gate and publishes the binaries
-to Releases, so a release can't skip the tests.
+to Releases, so a release can't skip the tests. Every push to `main` additionally
+publishes a prerelease of the same binaries.
+
+Releases are cut by merging the release pull request that `release-pr.yml` keeps open,
+not by bumping the version by hand — see `AGENTS.md`.
 
 ---
 

--- a/build/version_info.txt
+++ b/build/version_info.txt
@@ -5,8 +5,8 @@
 #
 VSVersionInfo(
   ffi=FixedFileInfo(
-    filevers=(2, 0, 0, 0),
-    prodvers=(2, 0, 0, 0),
+    filevers=(0, 4, 1, 0),
+    prodvers=(0, 4, 1, 0),
     mask=0x3f,
     flags=0x0,
     OS=0x40004,
@@ -22,12 +22,12 @@ VSVersionInfo(
           [
             StringStruct(u'CompanyName',      u'Blazer'),
             StringStruct(u'FileDescription',  u'HOI4 Content Maker — Mod Tooling for Hearts of Iron IV'),
-            StringStruct(u'FileVersion',      u'2.0.0.0'),
+            StringStruct(u'FileVersion',      u'0.4.1.0'),
             StringStruct(u'InternalName',     u'HOI4ContentMaker'),
             StringStruct(u'LegalCopyright',   u'Copyright (c) 2025 Blazer. All Rights Reserved.'),
             StringStruct(u'OriginalFilename', u'HOI4ContentMaker.exe'),
             StringStruct(u'ProductName',      u'HOI4 Content Maker'),
-            StringStruct(u'ProductVersion',   u'2.0.0.0'),
+            StringStruct(u'ProductVersion',   u'0.4.1.0'),
           ]
         )
       ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,10 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hoi4cm"
-version = "0.1.0"
+# Moved by scripts/release_pr.py when the release pull request is prepared, and
+# the source of truth every other version source is written from. Do not bump
+# by hand — add bullets under CHANGELOG.md's `## Unreleased` instead.
+version = "0.4.1"
 description = "Content Maker for Hearts of Iron 4 — Millennium Dawn Team"
 requires-python = ">=3.14"
 # Runs on the stdlib + tkinter alone. Third-party deps are optional extras below.
@@ -29,7 +32,7 @@ packages = ["src/hoi4cm"]
 # The repo root is on the path so tests can import the monolith; CI runs bare
 # `pytest`, which (unlike `python -m pytest`) does not add the cwd itself.
 [tool.pytest.ini_options]
-pythonpath = ["src", "."]
+pythonpath = ["src", ".", "scripts"]
 testpaths = ["tests"]
 
 # `pytest --cov` measures the whole package. CI runs it twice: once over
@@ -68,8 +71,8 @@ select = ["E", "F", "W", "I", "UP", "B"]
 # puts src/ on the search path so tests can import hoi4cm.
 [tool.mypy]
 python_version = "3.14"
-mypy_path = ["src"]
-files = ["src/hoi4cm", "tests"]
+mypy_path = ["src", "scripts"]
+files = ["src/hoi4cm", "tests", "scripts"]
 native_parser = true
 # The monolith and build scripts stay out until refactored. The native
 # parser (above) handles PEP 758's unparenthesized `except A, B:` on 3.14,

--- a/scripts/release_pr.py
+++ b/scripts/release_pr.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+
+# Prepares the release commit the release pull request carries: promote the
+# changelog's `## Unreleased` section to a version heading and move every
+# version source in the repo to match.
+#
+# Everything that shapes text is a pure function so the tests need no
+# repository; main() is the only part that touches disk.
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import sys
+from pathlib import Path
+
+from versioning import (
+    BUMPS,
+    REPO_ROOT,
+    next_stable_version,
+    read_version,
+    write_version_sources,
+)
+
+UNRELEASED = "## Unreleased"
+
+# Sections are level two, individual changes level three, so only a `## `
+# heading ends the Unreleased section.
+SECTION_PREFIX = "## "
+
+
+def unreleased_section(changelog: str) -> list[str]:
+    lines = changelog.split("\n")
+    start = next(
+        (
+            index
+            for index, line in enumerate(lines)
+            if line.strip().lower() == UNRELEASED.lower()
+        ),
+        -1,
+    )
+    if start == -1:
+        return []
+    rest = lines[start + 1 :]
+    end = next(
+        (index for index, line in enumerate(rest) if line.startswith(SECTION_PREFIX)),
+        len(rest),
+    )
+    return rest[:end]
+
+
+def has_release_content(changelog: str) -> bool:
+    # The trailing space matters: this changelog separates its sections with
+    # `---` rules, which would otherwise read as bullets and make every empty
+    # Unreleased section look releasable.
+    return any(
+        line.lstrip().startswith(("- ", "* ")) for line in unreleased_section(changelog)
+    )
+
+
+def promote_unreleased(changelog: str, version: str, today: dt.date) -> str:
+    """Leave an empty `## Unreleased` behind and open a dated version section."""
+    heading = f"## [{version}] — {today.isoformat()}"
+    lines = changelog.split("\n")
+    for index, line in enumerate(lines):
+        if line.strip().lower() == UNRELEASED.lower():
+            # `---` between level-two sections is this file's own style.
+            lines[index : index + 1] = [UNRELEASED, "", "---", "", heading]
+            return "\n".join(lines)
+    raise RuntimeError(f"CHANGELOG.md has no {UNRELEASED!r} heading to promote")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Promote the changelog's Unreleased section to a release."
+    )
+    parser.add_argument("--bump", choices=BUMPS, default="patch")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="report the version without writing any file",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=REPO_ROOT,
+        help="repository to read and rewrite (default: this checkout)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    repo_root = Path(args.repo_root)
+    changelog_path = repo_root / "CHANGELOG.md"
+    changelog = changelog_path.read_text(encoding="utf-8")
+
+    if not has_release_content(changelog):
+        # The push that merges the release pull request itself lands an empty
+        # Unreleased section, so this is the workflow's own no-op guard rather
+        # than an error.
+        print(
+            f"No bullets under {UNRELEASED!r} in {changelog_path}; nothing to release.",
+            file=sys.stderr,
+        )
+        print("release=false")
+        return 0
+
+    current = read_version((repo_root / "pyproject.toml").read_text(encoding="utf-8"))
+    version = next_stable_version(current, args.bump)
+
+    if args.dry_run:
+        print(f"dry run: would release {current} -> {version}", file=sys.stderr)
+    else:
+        changelog_path.write_text(
+            promote_unreleased(changelog, version, dt.date.today()), encoding="utf-8"
+        )
+        written = write_version_sources(repo_root, version)
+        print(
+            f"promoted {UNRELEASED} to {version} and moved {', '.join(written)}",
+            file=sys.stderr,
+        )
+    print("release=true")
+    print(f"version={version}")
+    print(f"bump={args.bump}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (RuntimeError, OSError) as error:
+        sys.stderr.write(f"::error::{error}\n")
+        raise SystemExit(1) from error

--- a/scripts/versioning.py
+++ b/scripts/versioning.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+
+# Version arithmetic for the two publishing channels, and the rewrites that keep
+# every version source in the repo saying the same thing.
+#
+# The channels follow VS Code's convention: stable takes the even minors and
+# pre-release the odd minor directly above, with the Actions run number as the
+# patch. So stable 0.4.1 gives pre-releases 0.5.<run>, and a minor release skips
+# the odd line to land on 0.6.0. The version itself stays numeric; only the Git
+# tag carries the -pre.<attempt> suffix.
+#
+# `pyproject.toml` is the single source of truth. Everything here is a pure
+# function over strings so the tests need no repository; main() is the only part
+# that touches disk.
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from collections.abc import Callable, Mapping
+from pathlib import Path
+
+BUMPS = ("patch", "minor", "major")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# `^\s*version` will not match `python_version` or `target-version`, so the
+# first hit is `[project]`'s own version and no other key can be caught.
+PYPROJECT_VERSION_RE = re.compile(r'^(\s*version\s*=\s*")([^"]*)(")', re.MULTILINE)
+DUNDER_VERSION_RE = re.compile(r'^(__version__\s*=\s*")([^"]*)(")', re.MULTILINE)
+BADGE_VERSION_RE = re.compile(r"(img\.shields\.io/badge/Version-)([^-]*)(-)")
+FILEVERS_RE = re.compile(r"^(\s*(?:filevers|prodvers)=\()([^)]*)(\))", re.MULTILINE)
+VERSION_STRUCT_RE = re.compile(
+    r"(StringStruct\(u'(?:File|Product)Version',\s*u')([^']*)(')"
+)
+
+
+def parse_version(text: str) -> tuple[int, int, int]:
+    parts = text.strip().split(".")
+    if len(parts) != 3:
+        raise ValueError(f"not an x.y.z version: {text!r}")
+    major, minor, patch = (int(part) for part in parts)
+    return major, minor, patch
+
+
+def next_stable_version(current: str, bump: str) -> str:
+    """The version a release of `bump` size moves to, staying on the even minors."""
+    try:
+        major, minor, patch = parse_version(current.split("-", maxsplit=1)[0])
+    except ValueError as error:
+        raise RuntimeError(f"cannot bump {current!r}: not an x.y.z version") from error
+    if minor % 2 != 0:
+        raise RuntimeError(
+            f"cannot bump {current!r}: {major}.{minor} is a pre-release line, "
+            "and releases only ever sit on an even minor"
+        )
+    if bump == "patch":
+        return f"{major}.{minor}.{patch + 1}"
+    if bump == "minor":
+        # Skip the odd line the pre-releases of this stable version sit on.
+        return f"{major}.{minor + 2}.0"
+    if bump == "major":
+        return f"{major + 1}.0.0"
+    raise RuntimeError(f"unknown bump {bump!r}; expected one of {', '.join(BUMPS)}")
+
+
+def prerelease_identity(env: Mapping[str, str], base: str) -> dict[str, str]:
+    """The version and tag the pre-release channel publishes for this run."""
+    try:
+        run_number = int(env.get("GITHUB_RUN_NUMBER", "").strip())
+        run_attempt = int(env.get("GITHUB_RUN_ATTEMPT", "1").strip())
+        major, minor, patch = parse_version(base.split("-", maxsplit=1)[0])
+    except ValueError as error:
+        raise RuntimeError("pre-release version inputs must be integers") from error
+    if run_number < 1 or run_attempt < 1:
+        raise RuntimeError("pre-release run number and attempt must be positive")
+    if minor % 2 != 0:
+        raise RuntimeError(
+            f"pre-release requires an even stable minor, but the project is at "
+            f"{major}.{minor}.{patch}; releases must not land on the odd "
+            "pre-release line"
+        )
+    version = f"{major}.{minor + 1}.{run_number}"
+    return {"version": version, "tag": f"v{version}-pre.{run_attempt}"}
+
+
+def check_release_tag(tag: str) -> str:
+    """Return the version a stable release tag carries, or explain why it can't."""
+    text = tag.strip().removeprefix("v").removeprefix(".")
+    if "-" in text:
+        raise RuntimeError(
+            f"{tag!r} carries a suffix, so it belongs to the pre-release channel "
+            "and must not be published as a release"
+        )
+    try:
+        major, minor, patch = parse_version(text)
+    except ValueError as error:
+        raise RuntimeError(f"{tag!r} is not a vX.Y.Z release tag") from error
+    if minor % 2 != 0:
+        raise RuntimeError(
+            f"{tag!r} is on the odd pre-release line; releases only ever sit on "
+            "an even minor"
+        )
+    return f"{major}.{minor}.{patch}"
+
+
+def read_version(pyproject_text: str) -> str:
+    match = PYPROJECT_VERSION_RE.search(pyproject_text)
+    if match is None:
+        raise RuntimeError("pyproject.toml has no version to read")
+    return match.group(2)
+
+
+def _replace_first(pattern: re.Pattern[str], text: str, value: str, what: str) -> str:
+    replaced, count = pattern.subn(
+        lambda m: f"{m.group(1)}{value}{m.group(3)}", text, 1
+    )
+    if count == 0:
+        raise RuntimeError(f"found no {what} to move to {value}")
+    return replaced
+
+
+def set_pyproject_version(text: str, version: str) -> str:
+    return _replace_first(PYPROJECT_VERSION_RE, text, version, "pyproject.toml version")
+
+
+def set_dunder_version(text: str, version: str) -> str:
+    return _replace_first(DUNDER_VERSION_RE, text, version, "__version__")
+
+
+def set_badge_version(text: str, version: str) -> str:
+    return _replace_first(BADGE_VERSION_RE, text, version, "README version badge")
+
+
+def set_windows_version(text: str, version: str) -> str:
+    """Move both tuples and both strings in the Windows VERSIONINFO resource."""
+    major, minor, patch = parse_version(version)
+    tuple_text = f"{major}, {minor}, {patch}, 0"
+    replaced, tuples = FILEVERS_RE.subn(
+        lambda m: f"{m.group(1)}{tuple_text}{m.group(3)}", text
+    )
+    replaced, structs = VERSION_STRUCT_RE.subn(
+        lambda m: f"{m.group(1)}{major}.{minor}.{patch}.0{m.group(3)}", replaced
+    )
+    if tuples != 2 or structs != 2:
+        raise RuntimeError(
+            "version_info.txt should carry two version tuples and two version "
+            f"strings, found {tuples} and {structs}"
+        )
+    return replaced
+
+
+# Every file that states the version, and the rewrite that moves it. Keeping
+# them in one table is what stops a new source drifting away unnoticed again.
+VERSION_SOURCES: tuple[tuple[str, Callable[[str, str], str]], ...] = (
+    ("pyproject.toml", set_pyproject_version),
+    ("src/hoi4cm/__init__.py", set_dunder_version),
+    ("build/version_info.txt", set_windows_version),
+    ("README.md", set_badge_version),
+)
+
+
+def write_version_sources(repo_root: Path, version: str) -> list[str]:
+    """Move every version source to `version`, returning the paths written."""
+    written = []
+    for relative, setter in VERSION_SOURCES:
+        path = repo_root / relative
+        text = path.read_text(encoding="utf-8")
+        moved = setter(text, version)
+        if moved != text:
+            path.write_text(moved, encoding="utf-8")
+        written.append(relative)
+    return written
+
+
+def project_version(repo_root: Path = REPO_ROOT) -> str:
+    return read_version((repo_root / "pyproject.toml").read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = sys.argv[1:] if argv is None else argv
+    command = args[0] if args else ""
+    if command == "prerelease-identity":
+        identity = prerelease_identity(os.environ, project_version())
+        print(f"version={identity['version']}")
+        print(f"tag={identity['tag']}")
+    elif command == "project-version":
+        print(f"version={project_version()}")
+    elif command == "next-version":
+        bump = args[1] if len(args) > 1 else "patch"
+        print(f"version={next_stable_version(project_version(), bump)}")
+    elif command == "check-release-tag":
+        if len(args) < 2:
+            raise RuntimeError("check-release-tag needs a tag")
+        print(f"version={check_release_tag(args[1])}")
+    else:
+        raise RuntimeError(
+            "expected one of prerelease-identity, project-version, next-version, "
+            "check-release-tag"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (RuntimeError, OSError) as error:
+        sys.stderr.write(f"::error::{error}\n")
+        raise SystemExit(1) from error

--- a/src/hoi4cm/__init__.py
+++ b/src/hoi4cm/__init__.py
@@ -2,6 +2,6 @@
 
 from .core.logger import get_logger
 
-__version__ = "0.1.0"
+__version__ = "0.4.1"
 
 __all__ = ["get_logger", "__version__"]

--- a/tests/test_release_pr.py
+++ b/tests/test_release_pr.py
@@ -1,0 +1,148 @@
+"""Promoting the changelog's Unreleased section into a release commit."""
+
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+
+import pytest
+from release_pr import (
+    has_release_content,
+    main,
+    promote_unreleased,
+    unreleased_section,
+)
+from test_versioning import BADGE, PYPROJECT, VERSION_INFO
+
+CHANGELOG = """# HOI4 Content Maker — Changelog
+
+---
+
+## Unreleased
+
+### Something landed (issue #1)
+
+**[ENHANCEMENT] It does the thing**
+
+- A bullet.
+
+---
+
+## Application Modernization — Python Floor Raised to 3.14
+
+- An older note.
+"""
+
+EMPTY_CHANGELOG = """# HOI4 Content Maker — Changelog
+
+---
+
+## Unreleased
+
+---
+
+## [0.4.1] — 2026-09-02
+
+- Already shipped.
+"""
+
+
+def seed(root: Path, changelog: str) -> None:
+    (root / "src" / "hoi4cm").mkdir(parents=True)
+    (root / "build").mkdir()
+    (root / "CHANGELOG.md").write_text(changelog, encoding="utf-8")
+    (root / "pyproject.toml").write_text(PYPROJECT, encoding="utf-8")
+    (root / "src" / "hoi4cm" / "__init__.py").write_text(
+        '__version__ = "0.4.1"\n', encoding="utf-8"
+    )
+    (root / "build" / "version_info.txt").write_text(VERSION_INFO, encoding="utf-8")
+    (root / "README.md").write_text(BADGE, encoding="utf-8")
+
+
+def test_unreleased_section_stops_at_the_next_section() -> None:
+    section = unreleased_section(CHANGELOG)
+    assert "- A bullet." in section
+    assert "- An older note." not in section
+    # A level-three heading belongs to the section; a level-two one ends it.
+    assert "### Something landed (issue #1)" in section
+
+
+def test_unreleased_section_is_empty_without_the_heading() -> None:
+    assert unreleased_section("# Title\n\n## [0.4.1] — 2026-09-02\n") == []
+
+
+def test_has_release_content() -> None:
+    assert has_release_content(CHANGELOG) is True
+    assert has_release_content(EMPTY_CHANGELOG) is False
+
+
+def test_promote_unreleased_dates_the_new_section_and_keeps_unreleased() -> None:
+    promoted = promote_unreleased(CHANGELOG, "0.4.2", dt.date(2026, 9, 8))
+    assert "## Unreleased\n\n---\n\n## [0.4.2] — 2026-09-08\n" in promoted
+    # The bullets stay where they were, now under the version heading.
+    assert promoted.index("## [0.4.2]") < promoted.index("- A bullet.")
+    assert "## Application Modernization" in promoted
+
+
+def test_promote_unreleased_reports_a_changelog_without_the_heading() -> None:
+    with pytest.raises(RuntimeError, match="no '## Unreleased' heading"):
+        promote_unreleased(
+            "# Title\n\n## [0.4.1] — 2026-09-02\n", "0.4.2", dt.date.today()
+        )
+
+
+def test_main_promotes_and_moves_every_version_source(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    seed(tmp_path, CHANGELOG)
+
+    assert main(["--repo-root", str(tmp_path)]) == 0
+
+    out = capsys.readouterr().out
+    assert "release=true" in out
+    assert "version=0.4.2" in out
+    assert "bump=patch" in out
+    assert "## [0.4.2] — " in (tmp_path / "CHANGELOG.md").read_text(encoding="utf-8")
+    assert 'version = "0.4.2"' in (tmp_path / "pyproject.toml").read_text(
+        encoding="utf-8"
+    )
+    assert "Version-0.4.2-gold" in (tmp_path / "README.md").read_text(encoding="utf-8")
+
+
+def test_main_skips_the_odd_pre_release_line_on_a_minor_bump(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    seed(tmp_path, CHANGELOG)
+
+    assert main(["--repo-root", str(tmp_path), "--bump", "minor"]) == 0
+
+    assert "version=0.6.0" in capsys.readouterr().out
+
+
+def test_main_reports_nothing_to_release_without_bullets(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # The merge of the release pull request lands an empty Unreleased section,
+    # so this is a no-op rather than a failure.
+    seed(tmp_path, EMPTY_CHANGELOG)
+
+    assert main(["--repo-root", str(tmp_path)]) == 0
+
+    captured = capsys.readouterr()
+    assert "release=false" in captured.out
+    assert "version=" not in captured.out
+    assert (tmp_path / "CHANGELOG.md").read_text(encoding="utf-8") == EMPTY_CHANGELOG
+
+
+def test_main_dry_run_writes_nothing(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    seed(tmp_path, CHANGELOG)
+
+    assert main(["--repo-root", str(tmp_path), "--dry-run"]) == 0
+
+    assert "version=0.4.2" in capsys.readouterr().out
+    assert (tmp_path / "CHANGELOG.md").read_text(encoding="utf-8") == CHANGELOG
+    assert 'version = "0.4.1"' in (tmp_path / "pyproject.toml").read_text(
+        encoding="utf-8"
+    )

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -1,0 +1,232 @@
+"""Version arithmetic for the release and pre-release channels."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from versioning import (
+    VERSION_SOURCES,
+    check_release_tag,
+    next_stable_version,
+    parse_version,
+    prerelease_identity,
+    read_version,
+    set_badge_version,
+    set_dunder_version,
+    set_pyproject_version,
+    set_windows_version,
+    write_version_sources,
+)
+
+PYPROJECT = """[project]
+name = "hoi4cm"
+version = "0.4.1"
+requires-python = ">=3.14"
+
+[tool.mypy]
+python_version = "3.14"
+
+[tool.black]
+target-version = ["py314"]
+"""
+
+VERSION_INFO = """VSVersionInfo(
+  ffi=FixedFileInfo(
+    filevers=(2, 0, 0, 0),
+    prodvers=(2, 0, 0, 0),
+    mask=0x3f,
+  ),
+  kids=[
+    StringStruct(u'FileVersion',      u'2.0.0.0'),
+    StringStruct(u'ProductVersion',   u'2.0.0.0'),
+  ]
+)
+"""
+
+BADGE = "![Version](https://img.shields.io/badge/Version-2.0-gold)\n"
+
+
+def test_parse_version_rejects_anything_but_three_parts() -> None:
+    assert parse_version("0.4.1") == (0, 4, 1)
+    with pytest.raises(ValueError):
+        parse_version("0.4")
+
+
+# --- the pre-release channel -------------------------------------------------
+
+
+def test_prerelease_takes_the_odd_minor_above_stable() -> None:
+    env = {"GITHUB_RUN_NUMBER": "42", "GITHUB_RUN_ATTEMPT": "3"}
+    assert prerelease_identity(env, "0.4.1") == {
+        "version": "0.5.42",
+        "tag": "v0.5.42-pre.3",
+    }
+
+
+def test_prerelease_defaults_the_run_attempt_to_one() -> None:
+    assert prerelease_identity({"GITHUB_RUN_NUMBER": "7"}, "1.0.2") == {
+        "version": "1.1.7",
+        "tag": "v1.1.7-pre.1",
+    }
+
+
+def test_prerelease_uses_only_the_numeric_part_of_a_suffixed_base() -> None:
+    assert prerelease_identity({"GITHUB_RUN_NUMBER": "7"}, "1.0.2-beta.2") == {
+        "version": "1.1.7",
+        "tag": "v1.1.7-pre.1",
+    }
+
+
+def test_prerelease_refuses_an_odd_stable_minor() -> None:
+    # 0.5.x is the pre-release line for stable 0.4.x, so a project sitting there
+    # means a release landed on the wrong line and must not be built on.
+    with pytest.raises(RuntimeError, match="even stable minor"):
+        prerelease_identity({"GITHUB_RUN_NUMBER": "1"}, "0.5.0")
+
+
+@pytest.mark.parametrize(
+    "env",
+    [
+        {},
+        {"GITHUB_RUN_NUMBER": ""},
+        {"GITHUB_RUN_NUMBER": "not-a-number"},
+        {"GITHUB_RUN_NUMBER": "0"},
+        {"GITHUB_RUN_NUMBER": "-1"},
+        {"GITHUB_RUN_NUMBER": "1", "GITHUB_RUN_ATTEMPT": "0"},
+        {"GITHUB_RUN_NUMBER": "1", "GITHUB_RUN_ATTEMPT": "nope"},
+    ],
+)
+def test_prerelease_refuses_an_invalid_run_identity(env: dict[str, str]) -> None:
+    with pytest.raises(RuntimeError, match="pre-release"):
+        prerelease_identity(env, "0.4.1")
+
+
+# --- the release line --------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("current", "bump", "expected"),
+    [
+        ("0.4.1", "patch", "0.4.2"),
+        ("0.4.9", "patch", "0.4.10"),
+        # A minor bump skips the odd line the pre-releases sit on.
+        ("0.4.1", "minor", "0.6.0"),
+        ("0.4.1", "major", "1.0.0"),
+    ],
+)
+def test_next_stable_version(current: str, bump: str, expected: str) -> None:
+    assert next_stable_version(current, bump) == expected
+
+
+def test_next_stable_version_refuses_to_bump_off_the_pre_release_line() -> None:
+    with pytest.raises(RuntimeError, match="pre-release line"):
+        next_stable_version("0.5.42", "patch")
+
+
+def test_next_stable_version_rejects_an_unknown_bump() -> None:
+    with pytest.raises(RuntimeError, match="unknown bump"):
+        next_stable_version("0.4.1", "sideways")
+
+
+@pytest.mark.parametrize("tag", ["v0.4.2", "0.4.2", "v.0.4.2"])
+def test_check_release_tag_accepts_a_stable_tag(tag: str) -> None:
+    # `v.0.4.0` and `v.0.3.0` are real tags in this repo, so the stray dot is
+    # tolerated rather than treated as a broken release.
+    assert check_release_tag(tag) == "0.4.2"
+
+
+def test_check_release_tag_rejects_the_pre_release_line() -> None:
+    with pytest.raises(RuntimeError, match="odd pre-release line"):
+        check_release_tag("v0.5.0")
+
+
+def test_check_release_tag_rejects_a_suffixed_tag() -> None:
+    with pytest.raises(RuntimeError, match="pre-release channel"):
+        check_release_tag("v0.5.42-pre.1")
+
+
+def test_check_release_tag_rejects_a_non_version_tag() -> None:
+    with pytest.raises(RuntimeError, match="not a vX.Y.Z release tag"):
+        check_release_tag("nightly")
+
+
+# --- moving every version source --------------------------------------------
+
+
+def test_read_version_ignores_other_version_keys() -> None:
+    assert read_version(PYPROJECT) == "0.4.1"
+
+
+def test_read_version_reports_a_pyproject_without_one() -> None:
+    with pytest.raises(RuntimeError, match="no version"):
+        read_version('[project]\nname = "hoi4cm"\n')
+
+
+def test_set_pyproject_version_leaves_the_other_version_keys_alone() -> None:
+    moved = set_pyproject_version(PYPROJECT, "0.4.2")
+    assert 'version = "0.4.2"' in moved
+    assert 'python_version = "3.14"' in moved
+    assert 'target-version = ["py314"]' in moved
+
+
+def test_set_dunder_version() -> None:
+    assert (
+        set_dunder_version('__version__ = "0.1.0"\n', "0.4.2")
+        == '__version__ = "0.4.2"\n'
+    )
+
+
+def test_set_badge_version() -> None:
+    assert "Version-0.4.2-gold" in set_badge_version(BADGE, "0.4.2")
+
+
+def test_set_windows_version_moves_both_tuples_and_both_strings() -> None:
+    moved = set_windows_version(VERSION_INFO, "0.4.2")
+    assert moved.count("(0, 4, 2, 0)") == 2
+    assert moved.count("u'0.4.2.0'") == 2
+    assert "2.0.0.0" not in moved
+
+
+def test_set_windows_version_reports_a_resource_it_cannot_move() -> None:
+    with pytest.raises(RuntimeError, match="two version tuples"):
+        set_windows_version("VSVersionInfo()\n", "0.4.2")
+
+
+def test_write_version_sources_moves_every_source_together(tmp_path: Path) -> None:
+    (tmp_path / "src" / "hoi4cm").mkdir(parents=True)
+    (tmp_path / "build").mkdir()
+    (tmp_path / "pyproject.toml").write_text(PYPROJECT, encoding="utf-8")
+    (tmp_path / "src" / "hoi4cm" / "__init__.py").write_text(
+        '__version__ = "0.1.0"\n', encoding="utf-8"
+    )
+    (tmp_path / "build" / "version_info.txt").write_text(VERSION_INFO, encoding="utf-8")
+    (tmp_path / "README.md").write_text(BADGE, encoding="utf-8")
+
+    written = write_version_sources(tmp_path, "0.4.2")
+
+    assert written == [relative for relative, _ in VERSION_SOURCES]
+    assert read_version((tmp_path / "pyproject.toml").read_text(encoding="utf-8")) == (
+        "0.4.2"
+    )
+    assert '__version__ = "0.4.2"' in (
+        tmp_path / "src" / "hoi4cm" / "__init__.py"
+    ).read_text(encoding="utf-8")
+    assert "(0, 4, 2, 0)" in (tmp_path / "build" / "version_info.txt").read_text(
+        encoding="utf-8"
+    )
+    assert "Version-0.4.2-gold" in (tmp_path / "README.md").read_text(encoding="utf-8")
+
+
+def test_the_repo_itself_agrees_across_every_version_source() -> None:
+    # The whole point of the table is that these four never drift apart again.
+    root = Path(__file__).resolve().parent.parent
+    version = read_version((root / "pyproject.toml").read_text(encoding="utf-8"))
+    assert f'__version__ = "{version}"' in (
+        root / "src" / "hoi4cm" / "__init__.py"
+    ).read_text(encoding="utf-8")
+    major, minor, patch = parse_version(version)
+    assert f"({major}, {minor}, {patch}, 0)" in (
+        root / "build" / "version_info.txt"
+    ).read_text(encoding="utf-8")
+    assert f"Version-{version}-gold" in (root / "README.md").read_text(encoding="utf-8")


### PR DESCRIPTION
Publishing now runs on two channels, neither of them from a developer's machine.
Ported from cwtools-vscode's #696, adapted to this repo's Python/PyInstaller shape.

## Pre-release

`pre-release.yml` — every push to `main` (plus `workflow_dispatch`) builds the three
binaries and publishes them as a GitHub prerelease with a `SHA256SUMS.txt`. Its own
concurrency group with `cancel-in-progress: true`, because a superseded pre-release
build is worth cancelling, unlike a release.

Versions follow VS Code's convention: stable on the even minors, pre-release on the
odd minor directly above, with the Actions run number as the patch. Stable `0.4.1`
gives `0.5.<run>`. The version stays numeric; only the Git tag carries
`-pre.<attempt>`. A build **fails loudly** if the project ever sits on an odd minor
rather than publishing a pre-release into the stable line.

## Release

Releases are now cut by merging a PR instead of pushing a tag by hand.

- `release-pr.yml` regenerates `release/version-bump` from `origin/main` on every
  push. `scripts/release_pr.py` promotes the changelog's `## Unreleased` section to
  `## [x.y.z] — <date>` and moves every version source to match. The branch is
  force-pushed, so edits on it are discarded — fixes go in `main`'s `## Unreleased`.
- Merging it makes `tag-release.yml` push `v<x.y.z>`, which runs the full CI gate and
  publishes through `ci.yml`'s existing release job.
- A minor release skips the odd pre-release line: `0.4.x` → `0.6.0`.
- `ci.yml`'s release job now skips any `-pre.` tag and rejects a tag on an odd minor,
  so a pre-release can never go out as a full release.

## One version, everywhere

`pyproject.toml` becomes the single source of truth, seeded to the last shipped tag
(`0.4.1`). It had drifted to `0.1.0` while `src/hoi4cm/__init__.py` said `0.1.0`,
`build/version_info.txt` said `2.0.0.0` and the README badge said `2.0` — four values,
none of them the shipped one. All four are written together now and a test asserts
they agree, so the Windows `.exe` finally reports a truthful version.

## The release bot

The release PR and the release tag are pushed with the `melon-release-bot` App token,
because a PR or tag created with `GITHUB_TOKEN` triggers no workflow — the same reason
cwtools uses its bot in exactly one place. The pre-release job stays on
`github.token` on purpose, so its tag can't re-enter `ci.yml`'s `v*` path.

Each mint step is guarded on the secret and `continue-on-error`, with every consumer
reading `${{ steps.app-token.outputs.token || github.token }}`, so a missing or
misconfigured App degrades instead of breaking `main`.

> [!IMPORTANT]
> Two things to check before the first release PR: `RELEASE_PR_APP_ID` was saved three
> minutes *before* `melon-release-bot` existed, so it likely still holds
> `cwtools-release-bot`'s id — re-save it as `4875624`. And confirm the installation
> covers this repo, since it is scoped to selected repositories.

## Changelog convention

Contributors now add bullets under `## Unreleased`; the release PR promotes them.
Existing theme-organised sections stay as history, so the file is mixed. Documented in
`AGENTS.md`, whose `## Releases` section previously opened "`ci.yml` is the only
workflow".

## Verification

No publish, tag or PR was triggered from the branch.

- 42 new tests in `tests/test_versioning.py` and `tests/test_release_pr.py`, all
  passing: the odd-minor refusal, invalid run identities, the minor bump skipping the
  odd line, tag validation, changelog promotion, and the no-op on an empty section.
- `ruff`, `black`, `mypy` and `pylint src/hoi4cm tests scripts` all clean.
- All four workflows **parsed and asserted**, not eyeballed: triggers, concurrency
  groups, `contents: read` at top level with `write` only where needed, the `needs`
  graph, the App-token fallbacks, and every `uses:` being a 40-char SHA with a version
  comment.
- End-to-end dry run of `release_pr.py` against a copy of the real repo: `0.4.1` →
  `0.4.2`, the real `CHANGELOG.md` promoted correctly, all four version sources moved,
  and a second run correctly reporting `release=false`.
- `tag-release.yml`'s version-detection grep verified to match only on the promoted
  commit and find nothing on a normal one.

The full suite can't run locally — this machine has Python 3.13 and the project's floor
is 3.14 (PEP 758 syntax). Pristine `origin/main` produces the identical 96 collection
errors, so this is environmental, not a regression.
