### PR TITLE
Point the pre-release publish job at the repository

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -108,6 +108,10 @@ jobs:
       - name: Publish the GitHub prerelease
         env:
           GH_TOKEN: ${{ github.token }}
+          # This job checks nothing out — it only needs the built artifacts — so
+          # gh has no Git remote to infer the repository from. Without GH_REPO it
+          # dies on `fatal: not a git repository` before reaching the API.
+          GH_REPO: ${{ github.repository }}
           TAG: ${{ needs.version.outputs.tag }}
           VERSION: ${{ needs.version.outputs.version }}
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ the version by hand. See `AGENTS.md`.
 
 ## Unreleased
 
+### Pre-release publishing
+
+**[BUGFIX] The pre-release job can find the repository again**
+
+- `pre-release.yml`'s `publish` job downloads the built binaries and never checks the
+  repository out, so `gh release create` had no Git remote to infer the target
+  repository from and failed with `fatal: not a git repository` before it reached the
+  API. It now passes `GH_REPO`, so every push to `main` publishes its prerelease
+  instead of leaving a failed run on the commit.
+
 ---
 
 ## [0.4.2] — 2026-09-08


### PR DESCRIPTION
Both runs of `Pre-release` since it was added have failed in `publish` ([run 34265183453](https://github.com/MillenniumDawn/focus-tree-creation-tool/actions/runs/34265183453), [run 34265625474](https://github.com/MillenniumDawn/focus-tree-creation-tool/actions/runs/34265625474)). `version` and the three `build` jobs pass, the artifacts download and checksum fine, then the last step dies:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
Process completed with exit code 1
```

`publish` has no `actions/checkout` — it only needs the downloaded binaries — so the workspace is not a Git repo and `gh release create` cannot infer the target repository from a remote. It aborts before touching the API. `ci.yml`'s `release` job runs the same command without trouble only because it happens to check out first.

Rather than add a checkout the job does not otherwise need, the step now sets `GH_REPO: ${{ github.repository }}`. Nothing else about the command changes: `--target "$GITHUB_SHA"` and `--notes-file -` are API-side and need no working tree.

`scripts/versioning.py` was already producing the right identity (`version=0.5.2`, `tag=v0.5.2-pre.1`), so no version logic is touched. `0.4.2` shipped with this bug, hence the `## Unreleased` entry.

Verified post-merge by the next push to `main`: `publish` should go green and `v0.5.<run>-pre.1` should appear in `gh release list` with the three binaries and `SHA256SUMS.txt`.
